### PR TITLE
Added support for missing Book

### DIFF
--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -34,3 +34,7 @@ class TitleSendSchema(BaseModel):
     tags: List[str]
     metadata: Dict[str, Any]
     books: List[BooksListSendSchema]
+
+
+class Message(BaseModel):
+    message: str

--- a/backend/tests/test_books_endpoint.py
+++ b/backend/tests/test_books_endpoint.py
@@ -205,3 +205,12 @@ async def test_get_book_info(book_with_metadata, book_dict):
     assert response.headers.get("Content-Type") == "application/json"
 
     assert response.json() == book_dict
+
+
+@pytest.mark.asyncio
+async def test_get_book_missing():
+    response = client.get("/v1/books/missing")
+    assert response.status_code == 404
+    assert response.headers.get("Content-Type") == "application/json"
+
+    assert response.json() == {"message": "Title with ID “missing” not found"}


### PR DESCRIPTION
`/books/xxx` was not handling incorrect ID requests gracefully.
An unfound book now properly returns a 404 response