### PR TITLE
Add query filtering parameters for `/titles`

### DIFF
--- a/backend/src/backend/constants.py
+++ b/backend/src/backend/constants.py
@@ -1,10 +1,13 @@
 import os
+import pathlib
 from dataclasses import dataclass
+
+src_dir = pathlib.Path(__file__).parent.resolve()
 
 
 @dataclass
 class BackendConf:
-    database_url: str = os.getenv("DATABASE_URL", "sqlite:///dev.db")
+    database_url: str = os.getenv("DATABASE_URL", f"sqlite:////{src_dir}/dev.db")
     allowed_origins = os.getenv(
         "ALLOWED_ORIGINS",
         "http://localhost|http://localhost:8000|http://localhost:8080",  # dev fallback

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -24,7 +24,7 @@ async def shutdown() -> None:
         await database.disconnect()
 
 
-def create_app():
+def create_app() -> FastAPI:
     app = FastAPI(
         title=__title__,
         description=__description__,

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -206,3 +206,51 @@ class TitleMetadata(ormar.Model, MetadataMixin):
         constraints = [ormar.UniqueColumns("name", "title")]
 
     title: Title = ormar.ForeignKey(Title, related_name="metadata")
+
+async def get_matched_m2m_combination(on: str, items: List[str]) -> List[str]:
+    """Ids of requested model matching a combination of values on many2many column
+
+    params:
+        on: a {model}-{collection} string to indiquate which model and m2m colums
+        are being queried.
+        model is either `title` or `book`; collection is either `language` or `tag`
+
+        items: list of pk from the m2m target that must all be present to match
+
+    Sample uses:
+        get list of titles ident for which the m2m has eng and french language:
+            on="title-language", items=["eng", "fra"]
+        get list of books uuids for which the m2m has "wiki", "new" and "kid" tags:
+            on="book-tag", items=["wiki", "new", "kid"]"""
+    model_name, collection_name = on.lower().split("-", 1)
+    if model_name not in ("title", "book") or collection_name not in (
+        "language",
+        "tags",
+    ):
+        raise ValueError("Invalid m2m combination request")
+    if model_name == "title":
+        model = Title
+        id_field = "ident"
+        lookup_field = "title"
+    elif on == "book":
+        model = Book
+        id_field = "uuid"
+        lookup_field = "book"
+    coll_lookup_field = collection_name
+    # fine as long as there's no customed-table-name for the through model
+    through_tablename = f"{model.Meta.tablename}_{collection_name}s"
+
+    # expanding bound params alternative (https://stackoverflow.com/a/25168069/631925)
+    params = {f"item{idx}": item for idx, item in enumerate(items)}
+    where = f"{coll_lookup_field} in (:" + ", :".join(params.keys()) + ")"
+    stmt = (
+        f"SELECT {model.Meta.tablename}.{id_field} "
+        f"FROM {model.Meta.tablename}, "
+        f"(SELECT DISTINCT {lookup_field}, COUNT({coll_lookup_field}) as nbi "
+        f"FROM {through_tablename} WHERE {where} "
+        f"GROUP BY {lookup_field}) tmp "
+        f"WHERE {model.Meta.tablename}.{id_field} = tmp.{lookup_field} "
+        f"AND tmp.nbi = :nbitems;"
+    )
+    params["nbitems"] = len(items)
+    return [row[0] for row in await database.fetch_all(stmt, params)]

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -207,6 +207,7 @@ class TitleMetadata(ormar.Model, MetadataMixin):
 
     title: Title = ormar.ForeignKey(Title, related_name="metadata")
 
+
 async def get_matched_m2m_combination(on: str, items: List[str]) -> List[str]:
     """Ids of requested model matching a combination of values on many2many column
 
@@ -232,10 +233,10 @@ async def get_matched_m2m_combination(on: str, items: List[str]) -> List[str]:
         model = Title
         id_field = "ident"
         lookup_field = "title"
-    elif on == "book":
-        model = Book
-        id_field = "uuid"
-        lookup_field = "book"
+    # elif on == "book":
+    #     model = Book
+    #     id_field = "uuid"
+    #     lookup_field = "book"
     coll_lookup_field = collection_name
     # fine as long as there's no customed-table-name for the through model
     through_tablename = f"{model.Meta.tablename}_{collection_name}s"

--- a/backend/src/backend/routes/books.py
+++ b/backend/src/backend/routes/books.py
@@ -102,18 +102,18 @@ async def create_book(book_payload: BookAddSchema):
 
 @database.transaction()
 @router.get(
-    "/{id}",
+    "/{book_id}",
     responses={
         404: {"model": Message, "description": "Requested Book not found"},
         200: {"model": BookAddSchema, "description": "The requested Book"},
     },
 )
-async def get_book(id: str):
+async def get_book(book_id: str):
     try:
-        book = await Book.objects.select_all().get(id=id)
+        book = await Book.objects.select_all().get(id=book_id)
     except NoMatch:
         return JSONResponse(
-            status_code=404, content={"message": f"Book with ID “{id}” not found"}
+            status_code=404, content={"message": f"Book with ID “{book_id}” not found"}
         )
 
     return {

--- a/backend/src/backend/routes/titles.py
+++ b/backend/src/backend/routes/titles.py
@@ -1,17 +1,24 @@
 import base64
+import http
+from typing import Dict, List, Optional, Union
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from fastapi_pagination import Page, Params, paginate
 from ormar.exceptions import NoMatch
+from sqlalchemy import select
 
 from backend.models import (
     KIND_ILLUSTRATION,
+    KIND_TEXT,
     Title,
     database,
     get_matched_m2m_combination,
+    matching_metadata,
+    reduce_qs,
+    star_to_like,
 )
-from backend.schemas import Message, TitleSendSchema, TitlesListSendSchema
+from backend.schemas import Message, TitleSendSchema, TitlesListSendSchemasHolder
 
 router = APIRouter(
     prefix="/titles",
@@ -21,98 +28,185 @@ router = APIRouter(
 
 @database.transaction()
 @router.get(
-    "", status_code=200, tags=["titles"], response_model=Page[TitlesListSendSchema]
+    "",
+    status_code=200,
+    tags=["titles"],
+    responses={
+        200: {
+            "model": Page[Union[TitlesListSendSchemasHolder.all()]],
+            "description": "Titles list",
+        },
+    },
 )
 async def list_titles(
     params: Params = Depends(),
-    lang: str = None,
-    with_languages: bool = False,
-    with_tags: bool = False,
-    with_metadata: str = None,
+    ident: str = Query(
+        None,
+        title="Ident lookup query",
+        description="Ident to match results against. "
+        "Can include `*` which matches anything (multi chars).",
+    ),
+    lang: str = Query(
+        None,
+        title="Language matching query",
+        description="ISO-639-3 language codes to filter Titles by. "
+        "Multiple-language queries must use either `|` for union of language matches "
+        "or `,` for intersection.",
+        min_length=3,
+        regex=r"[a-z,\,|]{3,}",
+    ),
+    tag: str = Query(
+        None,
+        title="Tag matching query",
+        description="Tags to filter Titles by."
+        "Multiple-tag queries must use either `|` for union of tag matches "
+        "or `,` for intersection.",
+    ),
+    metadata: Optional[List[str]] = Query(
+        None,
+        title="Metadata query",
+        description="List of single `{name}:{value}` metadata query. "
+        "All metadata queries are combined (intersection). "
+        "Value can include `*` which matches anything (multi chars).",
+    ),
+    with_languages: bool = Query(
+        False,
+        alias="with-languages",
+        title="Include Languages in response.",
+        description="Whether to include the `languages` list for each returned Title.",
+    ),
+    with_tags: bool = Query(
+        False,
+        alias="with-tags",
+        title="Include Tags in response.",
+        description="Whether to include the `tags` list for each returned Title.",
+    ),
+    with_metadata: Optional[List[str]] = Query(
+        None,
+        alias="with-metadata",
+        title="Included Metadata in response.",
+        description="Which (if any – default is none) Metadata to include "
+        "in the `metadata` dict for each returned Title (not included if none). "
+        "Single-value of `all` or `true` includes them all. Single-value of `all-text` "
+        "includes all text metadata (excludes binaries and illustrations)",
+    ),
 ):
-    """WARNING: When the flags are set to false (by default), the API still sends
-    those fields in response. The value of those keys are either empty of None.
-    """
+    qs = Title.objects.prefetch_related(["languages", "tags", "metadata"])
+
+    # filter on ident lookup. Usage of `*` is expected
+    if ident:
+        stmt = select(Title.Meta.table.c.ident).where(
+            Title.Meta.table.c.ident.like(star_to_like(ident))
+        )
+        qs = qs.filter(ident__in=[row[0] for row in await database.fetch_all(stmt)])
+
+    # filter on language code of Titles
+    # intersection (comma separated) or union (pipe separated)
     if lang:
-        if "|" in lang:
-            # union of languages
-            return paginate(
-                (
-                    await Title.objects.select_related("languages")
-                    .filter(languages__code__in=lang.split("|"))
-                    .fields("ident")
-                    .all()
-                ),
-                params,
+        # invalid combination of operators
+        if "," in lang and "|" in lang:
+            raise HTTPException(
+                status_code=http.HTTPStatus.BAD_REQUEST,
+                detail="`lang` parameter cannot mix intersection and union. "
+                "Use either `,` or `|`.",
             )
-        elif "," in lang:
-            # intersection of languages
-            idents = await get_matched_m2m_combination(
-                items=lang.split(","), on="title-language"
+        # intersection of languages
+        if "," in lang:
+            qs = qs.filter(
+                ident__in=await get_matched_m2m_combination(
+                    items=lang.split(","),
+                    on="title-language",
+                    combination="intersection",
+                )
             )
-            # we could directly paginate the idents from line above but in other use
-            # cases we'd probably cast and filter on it
-            return paginate(
-                (
-                    await Title.objects.select_related("languages")
-                    .filter(ident__in=idents)
-                    .fields("ident")
-                    .all()
-                ),
-                params,
+        # Applies to both single values of union of | seperated values
+        else:
+            qs = qs.filter(
+                ident__in=await get_matched_m2m_combination(
+                    items=lang.split("|"), on="title-language", combination="union"
+                )
             )
 
-        # when single language code is given, example "/titles?lang=eng"
-        return paginate(
-            (
-                await Title.objects.select_related("languages")
-                .filter(languages__code=lang)
-                .fields("ident")
-                .all()
-            ),
-            params,
+    # filter on tag
+    if tag:
+        # invalid combination of operators
+        if "," in tag and "|" in tag:
+            raise HTTPException(
+                status_code=http.HTTPStatus.BAD_REQUEST,
+                detail="`tag` parameter cannot mix intersection and union. "
+                "Use either `,` or `|`.",
+            )
+        # intersection of tags
+        if "," in tag:
+            qs = qs.filter(
+                ident__in=await get_matched_m2m_combination(
+                    items=tag.split(","),
+                    on="title-titletag",
+                    combination="intersection",
+                )
+            )
+        # Applies to both single values of union of | seperated values
+        else:
+            qs = qs.filter(
+                ident__in=await get_matched_m2m_combination(
+                    items=tag.split("|"), on="title-titletag", combination="union"
+                )
+            )
+
+    # filter on metadata
+    if metadata:
+        idents = await reduce_qs(qs) or None
+        for name, value in [line.split(":", 1) for line in metadata]:
+            idents = await matching_metadata(
+                on="title",
+                name=name,
+                value=star_to_like(value),
+                using=idents,
+            )
+        qs = qs.filter(ident__in=idents)
+
+    def dress_page(page):
+        """transform items from Title model to appropriate schema based on request"""
+
+        def text_only_filter(item):
+            return item.kind == KIND_TEXT
+
+        def passed_metadata_filter(item):
+            return item.name.lower() in [meta.strip().lower() for meta in with_metadata]
+
+        def prepare_item(item) -> Dict[str, any]:
+            """request-matching payload from the loaded Title"""
+            payload = {key: getattr(item, key) for key in model.__fields__.keys()}
+            if "languages" in payload:
+                payload["languages"] = [lang.code for lang in payload["languages"]]
+            if "tags" in payload:
+                payload["tags"] = [tag_.name for tag_ in payload["tags"]]
+            if "metadata" in payload:
+                if with_metadata[-1] == "all" or with_metadata[-1] == "true":
+                    md_filter = all
+                elif with_metadata[0] == "all-text":
+                    md_filter = text_only_filter
+                else:
+                    md_filter = passed_metadata_filter
+                payload["metadata"] = {
+                    md.name: md.value
+                    if md.kind == KIND_TEXT
+                    else base64.standard_b64encode(md.bin_value)
+                    for md in filter(md_filter, payload["metadata"])
+                }
+            return payload
+
+        model = TitlesListSendSchemasHolder.get_for(
+            with_languages=with_languages,
+            with_tags=with_tags,
+            with_metadata=with_metadata,
         )
+        for index, item in enumerate(page.items):
+            page.items[index] = model(**prepare_item(item))
 
-    if with_languages and with_tags:
-        return paginate(
-            await Title.objects.select_related(["languages", "tags"]).all(),
-            params,
-        )
+        return page
 
-    if with_languages:
-        return paginate(
-            await Title.objects.select_related("languages").all(),
-            params,
-        )
-
-    if with_tags:
-        return paginate(
-            await Title.objects.select_related("tags").all(),
-            params,
-        )
-
-    if with_metadata:
-        metadata_keys = with_metadata.split(",")
-
-        titles = await Title.objects.select_related("metadata").fields("metadata").all()
-        response = [
-            {
-                "ident": title.ident,
-                "metadata": {
-                    metadata.name: metadata.value
-                    for metadata in title.metadata
-                    if metadata.name in metadata_keys
-                },
-            }
-            for title in titles
-        ]
-
-        return paginate(
-            response,
-            params,
-        )
-
-    return paginate(await Title.objects.fields(["ident"]).all(), params)
+    return dress_page(paginate(await qs.all(), params))
 
 
 @database.transaction()

--- a/backend/src/backend/routes/titles.py
+++ b/backend/src/backend/routes/titles.py
@@ -23,7 +23,11 @@ router = APIRouter(
 @router.get(
     "", status_code=200, tags=["titles"], response_model=Page[TitlesListSendSchema]
 )
-async def list_titles(params: Params = Depends(), lang: str = None):
+async def list_titles(
+    params: Params = Depends(),
+    lang: str = None,
+    with_languages: bool = False,
+):
     if lang:
         if "|" in lang:
             # union of languages
@@ -63,7 +67,13 @@ async def list_titles(params: Params = Depends(), lang: str = None):
             ),
             params,
         )
-    return paginate(await Title.objects.fields("ident").all(), params)
+    if with_languages:
+        return paginate(
+            await Title.objects.select_all().fields(["languages"]).all(),
+            params,
+        )
+
+    return paginate(await Title.objects.fields(["ident"]).all(), params)
 
 
 @database.transaction()

--- a/backend/src/backend/routes/titles.py
+++ b/backend/src/backend/routes/titles.py
@@ -68,15 +68,22 @@ async def list_titles(
             ),
             params,
         )
+
+    if with_languages and with_tags:
+        return paginate(
+            await Title.objects.select_all().all(),
+            params,
+        )
+
     if with_languages:
         return paginate(
-            await Title.objects.select_related("languages").fields(["languages"]).all(),
+            await Title.objects.select_related("languages").all(),
             params,
         )
 
     if with_tags:
         return paginate(
-            await Title.objects.select_related("tags").fields(["tags"]).all(),
+            await Title.objects.select_related("tags").all(),
             params,
         )
 

--- a/backend/src/backend/routes/titles.py
+++ b/backend/src/backend/routes/titles.py
@@ -28,6 +28,7 @@ async def list_titles(
     lang: str = None,
     with_languages: bool = False,
     with_tags: bool = False,
+    with_metadata: str = None,
 ):
     if lang:
         if "|" in lang:
@@ -84,6 +85,27 @@ async def list_titles(
     if with_tags:
         return paginate(
             await Title.objects.select_related("tags").all(),
+            params,
+        )
+
+    if with_metadata:
+        metadata_keys = with_metadata.split(",")
+
+        titles = await Title.objects.select_related("metadata").fields("metadata").all()
+        response = [
+            {
+                "ident": title.ident,
+                "metadata": {
+                    metadata.name: metadata.value
+                    for metadata in title.metadata
+                    if metadata.name in metadata_keys
+                },
+            }
+            for title in titles
+        ]
+
+        return paginate(
+            response,
             params,
         )
 

--- a/backend/src/backend/routes/titles.py
+++ b/backend/src/backend/routes/titles.py
@@ -30,6 +30,9 @@ async def list_titles(
     with_tags: bool = False,
     with_metadata: str = None,
 ):
+    """WARNING: When the flags are set to false (by default), the API still sends
+    those fields in response. The value of those keys are either empty of None.
+    """
     if lang:
         if "|" in lang:
             # union of languages
@@ -59,7 +62,7 @@ async def list_titles(
                 params,
             )
 
-        # when single language code is given
+        # when single language code is given, example "/titles?lang=eng"
         return paginate(
             (
                 await Title.objects.select_related("languages")
@@ -72,7 +75,7 @@ async def list_titles(
 
     if with_languages and with_tags:
         return paginate(
-            await Title.objects.select_all().all(),
+            await Title.objects.select_related(["languages", "tags"]).all(),
             params,
         )
 

--- a/backend/src/backend/routes/titles.py
+++ b/backend/src/backend/routes/titles.py
@@ -18,8 +18,12 @@ router = APIRouter(
 @router.get(
     "", status_code=200, tags=["titles"], response_model=Page[TitlesListSendSchema]
 )
-async def list_titles(params: Params = Depends()):
-    titles = await Title.objects.fields("ident").all()
+async def list_titles(params: Params = Depends(), lang: str = None):
+    titles = (
+        await Title.objects.select_related("languages")
+        .filter(languages__code=lang)
+        .all()
+    )
     return paginate(titles, params)
 
 

--- a/backend/src/backend/routes/titles.py
+++ b/backend/src/backend/routes/titles.py
@@ -27,6 +27,7 @@ async def list_titles(
     params: Params = Depends(),
     lang: str = None,
     with_languages: bool = False,
+    with_tags: bool = False,
 ):
     if lang:
         if "|" in lang:
@@ -69,7 +70,13 @@ async def list_titles(
         )
     if with_languages:
         return paginate(
-            await Title.objects.select_all().fields(["languages"]).all(),
+            await Title.objects.select_related("languages").fields(["languages"]).all(),
+            params,
+        )
+
+    if with_tags:
+        return paginate(
+            await Title.objects.select_related("tags").fields(["tags"]).all(),
             params,
         )
 

--- a/backend/src/backend/routes/titles.py
+++ b/backend/src/backend/routes/titles.py
@@ -19,12 +19,19 @@ router = APIRouter(
     "", status_code=200, tags=["titles"], response_model=Page[TitlesListSendSchema]
 )
 async def list_titles(params: Params = Depends(), lang: str = None):
-    titles = (
-        await Title.objects.select_related("languages")
-        .filter(languages__code=lang)
-        .all()
-    )
-    return paginate(titles, params)
+    if lang:
+
+        return paginate(
+            (
+                await Title.objects.select_related("languages")
+                .filter(languages__code=lang)
+                .fields("ident")
+                .all()
+            ),
+            params,
+        )
+    else:
+        return paginate(await Title.objects.fields("ident").all(), params)
 
 
 @database.transaction()

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -1,9 +1,10 @@
 import datetime
+import itertools
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import pydantic
-from pydantic import BaseModel
+from pydantic import BaseModel, create_model
 
 
 class TagGetSchema(BaseModel):
@@ -35,9 +36,96 @@ class BooksListSendSchema(BaseModel):
 
 class TitlesListSendSchema(BaseModel):
     ident: str
-    languages: Optional[List[LanguageGetSchema]] = None
-    tags: Optional[List[TagGetSchema]] = None
-    metadata: Optional[Dict[str, Any]] = None
+
+
+class TitlesListSendSchemasHolder:
+    """Dynamic Titles List Schemas Holder"""
+
+    schemas = set()
+
+    @classmethod
+    def all(cls):
+        return tuple(getattr(cls, name) for name in cls.schemas)
+
+    @classmethod
+    def add(cls, schema):
+        setattr(cls, schema.__name__, schema)
+        cls.schemas.add(schema.__name__)
+
+    @classmethod
+    def _name_for(
+        cls,
+        with_languages: bool = False,
+        with_tags: bool = False,
+        with_metadata: Union[List[str], bool] = False,
+    ):
+        if not with_languages and not with_tags and not with_metadata:
+            return "TitlesListSendSchema"
+        name = "BooksListSend"
+        if with_languages:
+            name += "Languages"
+        if with_tags:
+            name += "Tags"
+        if with_metadata:
+            name += "Metadata"
+        name += "Schema"
+        return name
+
+    @classmethod
+    def build_for(
+        cls,
+        with_languages: bool = False,
+        with_tags: bool = False,
+        with_metadata: Union[str, bool] = False,
+    ):
+        name = cls._name_for(
+            with_languages=with_languages,
+            with_tags=with_tags,
+            with_metadata=with_metadata,
+        )
+        kwargs = {}
+        if with_languages:
+            kwargs["languages"] = (Optional[List[str]], ...)
+        if with_tags:
+            kwargs["tags"] = (Optional[List[str]], ...)
+        if with_metadata:
+            kwargs["metadata"] = (Optional[Dict[str, Any]], ...)
+        return create_model(
+            name,
+            __base__=TitlesListSendSchema,
+            __module__=TitlesListSendSchema.__module__,
+            **kwargs,
+        )
+
+    @classmethod
+    def init(cls):
+        combinations = itertools.product((True, False), repeat=3)
+        for kwargs in map(
+            lambda r: {
+                "with_languages": r[0],
+                "with_tags": r[1],
+                "with_metadata": r[2],
+            },
+            combinations,
+        ):
+            cls.add(cls.build_for(**kwargs))
+
+    @classmethod
+    def get_for(
+        cls,
+        with_languages: bool = False,
+        with_tags: bool = False,
+        with_metadata: Union[List[str], bool] = False,
+    ):
+
+        return getattr(
+            cls,
+            cls._name_for(
+                with_languages=with_languages,
+                with_tags=with_tags,
+                with_metadata=with_metadata,
+            ),
+        )
 
 
 class TitleSendSchema(BaseModel):
@@ -51,3 +139,6 @@ class TitleSendSchema(BaseModel):
 
 class Message(BaseModel):
     message: str
+
+
+TitlesListSendSchemasHolder.init()

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -1,6 +1,6 @@
 import datetime
 import uuid
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pydantic
 from pydantic import BaseModel
@@ -35,8 +35,9 @@ class BooksListSendSchema(BaseModel):
 
 class TitlesListSendSchema(BaseModel):
     ident: str
-    languages: List[LanguageGetSchema] = []
-    tags: List[TagGetSchema] = []
+    languages: Optional[List[LanguageGetSchema]] = None
+    tags: Optional[List[TagGetSchema]] = None
+    metadata: Optional[Dict[str, Any]] = None
 
 
 class TitleSendSchema(BaseModel):

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -1,9 +1,13 @@
 import datetime
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import pydantic
 from pydantic import BaseModel
+
+
+class TagGetSchema(BaseModel):
+    name: str
 
 
 class LanguageGetSchema(BaseModel):
@@ -31,7 +35,8 @@ class BooksListSendSchema(BaseModel):
 
 class TitlesListSendSchema(BaseModel):
     ident: str
-    languages: Optional[List[LanguageGetSchema]]
+    languages: List[LanguageGetSchema] = []
+    tags: List[TagGetSchema] = []
 
 
 class TitleSendSchema(BaseModel):

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -1,9 +1,15 @@
 import datetime
 import uuid
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pydantic
 from pydantic import BaseModel
+
+
+class LanguageGetSchema(BaseModel):
+    code: str
+    name: str
+    native: str
 
 
 class BookAddSchema(BaseModel):
@@ -25,6 +31,7 @@ class BooksListSendSchema(BaseModel):
 
 class TitlesListSendSchema(BaseModel):
     ident: str
+    languages: Optional[List[LanguageGetSchema]]
 
 
 class TitleSendSchema(BaseModel):

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -150,6 +150,19 @@ def db_gen(c):
 
 
 @task
+def db_init_no_migration(c):
+    """[dev] create database schema from models, without migration. expects empty DB"""
+    with c.cd("src"):
+        c.run(
+            "python -c 'import sqlalchemy\n"
+            "from backend.models import BaseMeta;\n"
+            "engine = sqlalchemy.create_engine(str(BaseMeta.database.url))\n"
+            "BaseMeta.metadata.drop_all(engine)\n"
+            "BaseMeta.metadata.create_all(engine)\n'"
+        )
+
+
+@task
 def load_demo_fixture(c):
     with c.cd("src"):
         c.run(f"{sys.executable} ./demo/data.py", env={"PYTHONPATH": "."})

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -65,7 +65,7 @@ def test(c, args="", path=""):
                 env={
                     "DATABASE_URL": custom_db_url
                     if custom_db_url
-                    else f"sqlite:///{db_path.resolve()}"
+                    else f"sqlite:////{db_path.resolve()}"
                 },
             )
         finally:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,7 +3,6 @@ import base64
 import uuid
 
 import pytest
-import pytest_asyncio
 import sqlalchemy
 from httpx import AsyncClient
 
@@ -43,25 +42,25 @@ async def test_database():
     BaseMeta.metadata.drop_all(engine)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 async def client(app):
     async with AsyncClient(app=app, base_url="http://test") as client:
         yield client
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def clear_titles():
     yield
     await Title.objects.delete(each=True)
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def clear_title_tags():
     yield
     await TitleTag.objects.delete(each=True)
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def clear_book_dict(book_dict):
     """removes metadata, tags, languages, title and book created from the book_dict"""
     yield
@@ -90,21 +89,21 @@ async def clear_book_dict(book_dict):
     ).delete()
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def language_eng():
     lang = await Language.objects.create(code="eng", name="English", native="English")
     yield lang
     await lang.delete()
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def language_fra():
     lang = await Language.objects.create(code="fra", name="French", native="Français")
     yield lang
     await lang.delete()
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def language_lug():
     lang = await Language.objects.create(
         code="lug", name="Ganda (Uganda)", native="Luganda (Yuganda)"
@@ -113,7 +112,7 @@ async def language_lug():
     await lang.delete()
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def language_ara():
     lang = await Language.objects.create(
         code="ara", name="Arabic (Egypt)", native="العربية (مصر)"
@@ -172,7 +171,7 @@ def book_dict(base64_png):
     }
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def book(book_dict):
     book = await Book.objects.create(
         id=book_dict["id"],
@@ -191,13 +190,13 @@ async def book(book_dict):
     await book.delete()
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def book_with_language(book, language_eng):
     await book.languages.add(language_eng)
     yield book
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def book_with_metadata(book, book_dict):
     for metadata_name, value in book_dict["metadata"].items():
         if metadata_name.startswith("Illustration_"):
@@ -225,7 +224,7 @@ def title_dict():
     }
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def title(title_dict):
     title = await Title.objects.create(
         ident=title_dict["ident"],
@@ -237,20 +236,20 @@ async def title(title_dict):
     await title.delete()
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def title_with_language(title, language_eng):
     await title.languages.add(language_eng)
     yield title
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def title_tag():
     tag = await TitleTag.objects.create(name="wikipedia")
     yield tag
     await tag.delete()
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture(scope="function")
 async def title_with_data(
     title,
     language_eng,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -374,3 +374,25 @@ async def title_fra(title_fra_dict, language_fra):
     await title.tags.clear()
     await title.metadata.clear(keep_reversed=False)
     await title.delete()
+
+
+@pytest.fixture(scope="function")
+def title_fra_eng_dict():
+    return {
+        "ident": "wikipedia_fr-eng_nopic",
+    }
+
+
+@pytest.fixture(scope="function")
+@pytest.mark.asyncio
+async def title_fra_eng(title_fra_eng_dict, language_fra, language_eng):
+    title = await Title.objects.create(
+        ident=title_fra_eng_dict["ident"],
+    )
+    await title.languages.add(language_fra)
+    await title.languages.add(language_eng)
+    yield title
+    await title.languages.clear(keep_reversed=False)
+    await title.tags.clear()
+    await title.metadata.clear(keep_reversed=False)
+    await title.delete()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -332,3 +332,45 @@ def base64_png():
         "r1NGFnFPRAqa3QMMfmxAQrcJCLb1kdULbGJvxlrjvONBwDnQ0en9tR6GM31gslK145z1YtW"
         "Hs91N/RKEgP/x2Pc+lY9VeYqBDz1rqiJ41SxVy6nuOyUqeJIMRAAAAA=="
     )
+
+
+@pytest.fixture(scope="function")
+def title_ara_dict():
+    return {
+        "ident": "wikipedia_ar_all",
+    }
+
+
+@pytest.fixture(scope="function")
+@pytest.mark.asyncio
+async def title_ara(title_ara_dict, language_ara):
+    title = await Title.objects.create(
+        ident=title_ara_dict["ident"],
+    )
+    await title.languages.add(language_ara)
+    yield title
+    await title.languages.clear(keep_reversed=False)
+    await title.tags.clear()
+    await title.metadata.clear(keep_reversed=False)
+    await title.delete()
+
+
+@pytest.fixture(scope="function")
+def title_fra_dict():
+    return {
+        "ident": "wikipedia_fr_all",
+    }
+
+
+@pytest.fixture(scope="function")
+@pytest.mark.asyncio
+async def title_fra(title_fra_dict, language_fra):
+    title = await Title.objects.create(
+        ident=title_fra_dict["ident"],
+    )
+    await title.languages.add(language_fra)
+    yield title
+    await title.languages.clear(keep_reversed=False)
+    await title.tags.clear()
+    await title.metadata.clear(keep_reversed=False)
+    await title.delete()

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -13,6 +13,7 @@ from backend.models import (
     Title,
     TitleMetadata,
     TitleTag,
+    get_matched_m2m_combination,
 )
 
 
@@ -180,3 +181,18 @@ async def test_title_illustrations(title, base64_png):
     # `.illustrations` is dumb and just checks for begining of Name
     assert await title.illustrations.count() == 2
     assert illus.size is None
+
+
+@pytest.mark.asyncio
+async def test_get_matched_m2m_combination(title_fra_eng):
+    assert (
+        len(
+            await get_matched_m2m_combination(items=["eng", "fra"], on="title-language")
+        )
+        == 1
+    )
+
+    with pytest.raises(ValueError, match="Invalid"):
+        await get_matched_m2m_combination(items=["eng", "fra"], on="title-erp")
+    with pytest.raises(ValueError, match="Invalid"):
+        await get_matched_m2m_combination(items=["eng", "fra"], on="erp-language")

--- a/backend/tests/test_titles_endpoint.py
+++ b/backend/tests/test_titles_endpoint.py
@@ -4,7 +4,7 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_get_list_of_titles_single_title(client, title):
+async def test_get_list_of_titles_single_title(client, title, title_ara, title_fra):
     response = await client.get("/v1/titles")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
@@ -22,11 +22,12 @@ async def test_get_list_of_titles_single_title(client, title):
 
 @pytest.mark.asyncio
 async def test_get_list_of_titles_with_languages(
+    client,
     title_with_language,
     title_fra,
     title_ara,
 ):
-    response = client.get("/v1/titles?with_languages=true")
+    response = await client.get("/v1/titles?with_languages=true")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
@@ -104,9 +105,9 @@ async def test_get_book_missing(client):
 
 
 async def test_filter_titles_by_language_get_eng(
-    title_dict, title_with_language, title_fra
+    client, title_dict, title_with_language, title_fra
 ):
-    response = client.get("/v1/titles?lang=eng")
+    response = await client.get("/v1/titles?lang=eng")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
@@ -126,9 +127,9 @@ async def test_filter_titles_by_language_get_eng(
 
 @pytest.mark.asyncio
 async def test_filter_titles_by_language_get_fra(
-    title_fra_dict, title_with_language, title_fra
+    client, title_fra_dict, title_with_language, title_fra
 ):
-    response = client.get("/v1/titles?lang=fra")
+    response = await client.get("/v1/titles?lang=fra")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
@@ -148,12 +149,12 @@ async def test_filter_titles_by_language_get_fra(
 
 @pytest.mark.asyncio
 async def test_filter_titles_by_language_get_fra_or_eng(
-    title_with_language, title_fra, title_ara, title_fra_dict, title_dict
+    client, title_with_language, title_fra, title_ara, title_fra_dict, title_dict
 ):
     """we're creating three Titles with different languages: eng, fra, ara
     But we're only fetching titles whi have languages either 'eng' OR 'fra'
     """
-    response = client.get("/v1/titles?lang=fra|eng")
+    response = await client.get("/v1/titles?lang=fra|eng")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
@@ -183,11 +184,11 @@ async def test_filter_titles_by_language_get_fra_or_eng(
 
 @pytest.mark.asyncio
 async def test_filter_titles_by_language_get_fra_and_eng(
-    title_fra_eng_dict, title_fra_eng, title_with_language, title_fra, title_ara
+    client, title_fra_eng_dict, title_fra_eng, title_with_language, title_fra, title_ara
 ):
     """Testing the AND operation on languages. Only fetch Titles that have both
     English and French in its languages"""
-    response = client.get("/v1/titles?lang=fra,eng")
+    response = await client.get("/v1/titles?lang=fra,eng")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
@@ -209,8 +210,8 @@ async def test_filter_titles_by_language_get_fra_and_eng(
 
 
 @pytest.mark.asyncio
-async def test_get_list_of_titles_with_tags_without_languages(title_with_data):
-    response = client.get("/v1/titles?with_tags=true")
+async def test_get_list_of_titles_with_tags_without_languages(client, title_with_data):
+    response = await client.get("/v1/titles?with_tags=true")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
@@ -229,8 +230,8 @@ async def test_get_list_of_titles_with_tags_without_languages(title_with_data):
 
 
 @pytest.mark.asyncio
-async def test_get_list_of_titles_with_languages_and_tags(title_with_data):
-    response = client.get("/v1/titles?with_languages=true&with_tags=true")
+async def test_get_list_of_titles_with_languages_and_tags(client, title_with_data):
+    response = await client.get("/v1/titles?with_languages=true&with_tags=true")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
@@ -261,8 +262,10 @@ async def test_get_list_of_titles_with_languages_and_tags(title_with_data):
 
 
 @pytest.mark.asyncio
-async def test_get_title_with_specific_metadata(title_with_data, title_dict, book_dict):
-    response = client.get("/v1/titles?with_metadata=Title,Publisher")
+async def test_get_title_with_specific_metadata(
+    client, title_with_data, title_dict, book_dict
+):
+    response = await client.get("/v1/titles?with_metadata=Title,Publisher")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {

--- a/backend/tests/test_titles_endpoint.py
+++ b/backend/tests/test_titles_endpoint.py
@@ -10,9 +10,9 @@ async def test_get_list_of_titles_single_title(client, title):
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
         "items": [
-            {"ident": title_ara.ident, "languages": [], "tags": []},
-            {"ident": title.ident, "languages": [], "tags": []},
-            {"ident": title_fra.ident, "languages": [], "tags": []},
+            {"ident": title_ara.ident},
+            {"ident": title.ident},
+            {"ident": title_fra.ident},
         ],
         "total": 3,
         "page": 1,
@@ -40,17 +40,17 @@ async def test_get_list_of_titles_with_languages(
                         "native": "العربية (مصر)",
                     },
                 ],
-                "tags": [],
+                # "tags": [],
             },
             {
                 "ident": title_with_language.ident,
                 "languages": [{"code": "eng", "name": "English", "native": "English"}],
-                "tags": [],
+                # "tags": [],
             },
             {
                 "ident": title_fra.ident,
                 "languages": [{"code": "fra", "name": "French", "native": "Français"}],
-                "tags": [],
+                # "tags": [],
             },
         ],
         "total": 3,
@@ -110,8 +110,8 @@ async def test_filter_titles_by_language_get_eng(
         "items": [
             {
                 "ident": title_dict["ident"],
-                "languages": [{"code": "eng", "name": "English", "native": "English"}],
-                "tags": [],
+                # "languages": [],
+                # "tags": [],
             }
         ],
         "total": 1,
@@ -131,8 +131,8 @@ async def test_filter_titles_by_language_get_fra(
         "items": [
             {
                 "ident": title_fra_dict["ident"],
-                "languages": [{"code": "fra", "name": "French", "native": "Français"}],
-                "tags": [],
+                # "languages": [],
+                # "tags": [],
             }
         ],
         "total": 1,
@@ -155,13 +155,17 @@ async def test_filter_titles_by_language_get_fra_or_eng(
         "items": [
             {
                 "ident": title_dict["ident"],
-                "languages": [{"code": "eng", "name": "English", "native": "English"}],
-                "tags": [],
+                # "languages": [
+                #     {"code": "eng", "name": "English", "native": "English"},
+                # ],
+                # "tags": [],
             },
             {
                 "ident": title_fra_dict["ident"],
-                "languages": [{"code": "fra", "name": "French", "native": "Français"}],
-                "tags": [],
+                # "languages": [
+                #     {"code": "fra", "name": "French", "native": "Français"},
+                # ],
+                # "tags": [],
             },
         ],
         "total": 2,
@@ -183,11 +187,11 @@ async def test_filter_titles_by_language_get_fra_and_eng(
         "items": [
             {
                 "ident": title_fra_eng_dict["ident"],
-                "languages": [
-                    {"code": "eng", "name": "English", "native": "English"},
-                    {"code": "fra", "name": "French", "native": "Français"},
-                ],
-                "tags": [],
+                # "languages": [
+                #     {"code": "eng", "name": "English", "native": "English"},
+                #     {"code": "fra", "name": "French", "native": "Français"},
+                # ],
+                # "tags": [],
             }
         ],
         "total": 1,
@@ -205,7 +209,7 @@ async def test_get_list_of_titles_with_tags_without_languages(title_with_data):
         "items": [
             {
                 "ident": title_with_data.ident,
-                "languages": [],
+                # "languages": [],
                 "tags": [{"name": "_category:wikipedia"}, {"name": "wikipedia"}],
             },
         ],
@@ -238,6 +242,27 @@ async def test_get_list_of_titles_with_languages_and_tags(title_with_data):
                     },
                 ],
                 "tags": [{"name": "_category:wikipedia"}, {"name": "wikipedia"}],
+            },
+        ],
+        "total": 1,
+        "page": 1,
+        "size": 50,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_title_with_specific_metadata(title_with_data, title_dict, book_dict):
+    response = client.get("/v1/titles?with_metadata=Title,Publisher")
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    assert response.json() == {
+        "items": [
+            {
+                "ident": title_dict["ident"],
+                "metadata": {
+                    "Title": book_dict["metadata"]["Title"],
+                    "Publisher": book_dict["metadata"]["Publisher"],
+                },
             },
         ],
         "total": 1,

--- a/backend/tests/test_titles_endpoint.py
+++ b/backend/tests/test_titles_endpoint.py
@@ -88,3 +88,41 @@ async def test_filter_titles_by_language_get_fra(
         "page": 1,
         "size": 50,
     }
+
+
+@pytest.mark.asyncio
+async def test_filter_titles_by_language_get_fra_or_eng(
+    title_with_language, title_fra, title_ara, title_fra_dict, title_dict
+):
+    """we're creating three Titles with different languages: eng, fra, ara
+    But we're only fetching titles whi have languages either 'eng' OR 'fra'
+    """
+    response = client.get("/v1/titles?lang=fra|eng")
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    assert response.json() == {
+        "items": [
+            {"ident": title_dict["ident"]},
+            {"ident": title_fra_dict["ident"]},
+        ],
+        "total": 2,
+        "page": 1,
+        "size": 50,
+    }
+
+
+@pytest.mark.asyncio
+async def test_filter_titles_by_language_get_fra_and_eng(
+    title_fra_eng_dict, title_fra_eng, title_with_language, title_fra, title_ara
+):
+    """Testing the AND operation on languages. Only fetch Titles that have both
+    English and French in its languages"""
+    response = client.get("/v1/titles?lang=fra,eng")
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    assert response.json() == {
+        "items": [{"ident": title_fra_eng_dict["ident"]}],
+        "total": 1,
+        "page": 1,
+        "size": 50,
+    }

--- a/backend/tests/test_titles_endpoint.py
+++ b/backend/tests/test_titles_endpoint.py
@@ -10,9 +10,9 @@ async def test_get_list_of_titles_single_title(client, title):
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
         "items": [
-            {"ident": title_ara.ident, "languages": []},
-            {"ident": title.ident, "languages": []},
-            {"ident": title_fra.ident, "languages": []},
+            {"ident": title_ara.ident, "languages": [], "tags": []},
+            {"ident": title.ident, "languages": [], "tags": []},
+            {"ident": title_fra.ident, "languages": [], "tags": []},
         ],
         "total": 3,
         "page": 1,
@@ -38,16 +38,19 @@ async def test_get_list_of_titles_with_languages(
                         "code": "ara",
                         "name": "Arabic (Egypt)",
                         "native": "العربية (مصر)",
-                    }
+                    },
                 ],
+                "tags": [],
             },
             {
                 "ident": title_with_language.ident,
                 "languages": [{"code": "eng", "name": "English", "native": "English"}],
+                "tags": [],
             },
             {
                 "ident": title_fra.ident,
                 "languages": [{"code": "fra", "name": "French", "native": "Français"}],
+                "tags": [],
             },
         ],
         "total": 3,
@@ -108,6 +111,7 @@ async def test_filter_titles_by_language_get_eng(
             {
                 "ident": title_dict["ident"],
                 "languages": [{"code": "eng", "name": "English", "native": "English"}],
+                "tags": [],
             }
         ],
         "total": 1,
@@ -128,6 +132,7 @@ async def test_filter_titles_by_language_get_fra(
             {
                 "ident": title_fra_dict["ident"],
                 "languages": [{"code": "fra", "name": "French", "native": "Français"}],
+                "tags": [],
             }
         ],
         "total": 1,
@@ -151,10 +156,12 @@ async def test_filter_titles_by_language_get_fra_or_eng(
             {
                 "ident": title_dict["ident"],
                 "languages": [{"code": "eng", "name": "English", "native": "English"}],
+                "tags": [],
             },
             {
                 "ident": title_fra_dict["ident"],
                 "languages": [{"code": "fra", "name": "French", "native": "Français"}],
+                "tags": [],
             },
         ],
         "total": 2,
@@ -180,7 +187,27 @@ async def test_filter_titles_by_language_get_fra_and_eng(
                     {"code": "eng", "name": "English", "native": "English"},
                     {"code": "fra", "name": "French", "native": "Français"},
                 ],
+                "tags": [],
             }
+        ],
+        "total": 1,
+        "page": 1,
+        "size": 50,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_list_of_titles_with_tags_without_languages(title_with_data):
+    response = client.get("/v1/titles?with_tags=true")
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    assert response.json() == {
+        "items": [
+            {
+                "ident": title_with_data.ident,
+                "languages": [],
+                "tags": [{"name": "_category:wikipedia"}, {"name": "wikipedia"}],
+            },
         ],
         "total": 1,
         "page": 1,

--- a/backend/tests/test_titles_endpoint.py
+++ b/backend/tests/test_titles_endpoint.py
@@ -213,3 +213,34 @@ async def test_get_list_of_titles_with_tags_without_languages(title_with_data):
         "page": 1,
         "size": 50,
     }
+
+
+@pytest.mark.asyncio
+async def test_get_list_of_titles_with_languages_and_tags(title_with_data):
+    response = client.get("/v1/titles?with_languages=true&with_tags=true")
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    assert response.json() == {
+        "items": [
+            {
+                "ident": title_with_data.ident,
+                "languages": [
+                    {
+                        "code": "ara",
+                        "name": "Arabic (Egypt)",
+                        "native": "العربية (مصر)",
+                    },
+                    {"code": "eng", "name": "English", "native": "English"},
+                    {
+                        "code": "lug",
+                        "name": "Ganda (Uganda)",
+                        "native": "Luganda (Yuganda)",
+                    },
+                ],
+                "tags": [{"name": "_category:wikipedia"}, {"name": "wikipedia"}],
+            },
+        ],
+        "total": 1,
+        "page": 1,
+        "size": 50,
+    }

--- a/backend/tests/test_titles_endpoint.py
+++ b/backend/tests/test_titles_endpoint.py
@@ -10,9 +10,45 @@ async def test_get_list_of_titles_single_title(client, title):
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
         "items": [
-            {"ident": title_ara.ident},
-            {"ident": title.ident},
-            {"ident": title_fra.ident},
+            {"ident": title_ara.ident, "languages": []},
+            {"ident": title.ident, "languages": []},
+            {"ident": title_fra.ident, "languages": []},
+        ],
+        "total": 3,
+        "page": 1,
+        "size": 50,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_list_of_titles_with_languages(
+    title_with_language,
+    title_fra,
+    title_ara,
+):
+    response = client.get("/v1/titles?with_languages=true")
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    assert response.json() == {
+        "items": [
+            {
+                "ident": title_ara.ident,
+                "languages": [
+                    {
+                        "code": "ara",
+                        "name": "Arabic (Egypt)",
+                        "native": "العربية (مصر)",
+                    }
+                ],
+            },
+            {
+                "ident": title_with_language.ident,
+                "languages": [{"code": "eng", "name": "English", "native": "English"}],
+            },
+            {
+                "ident": title_fra.ident,
+                "languages": [{"code": "fra", "name": "French", "native": "Français"}],
+            },
         ],
         "total": 3,
         "page": 1,
@@ -68,7 +104,12 @@ async def test_filter_titles_by_language_get_eng(
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
-        "items": [{"ident": title_dict["ident"]}],
+        "items": [
+            {
+                "ident": title_dict["ident"],
+                "languages": [{"code": "eng", "name": "English", "native": "English"}],
+            }
+        ],
         "total": 1,
         "page": 1,
         "size": 50,
@@ -83,7 +124,12 @@ async def test_filter_titles_by_language_get_fra(
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
-        "items": [{"ident": title_fra_dict["ident"]}],
+        "items": [
+            {
+                "ident": title_fra_dict["ident"],
+                "languages": [{"code": "fra", "name": "French", "native": "Français"}],
+            }
+        ],
         "total": 1,
         "page": 1,
         "size": 50,
@@ -102,8 +148,14 @@ async def test_filter_titles_by_language_get_fra_or_eng(
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
         "items": [
-            {"ident": title_dict["ident"]},
-            {"ident": title_fra_dict["ident"]},
+            {
+                "ident": title_dict["ident"],
+                "languages": [{"code": "eng", "name": "English", "native": "English"}],
+            },
+            {
+                "ident": title_fra_dict["ident"],
+                "languages": [{"code": "fra", "name": "French", "native": "Français"}],
+            },
         ],
         "total": 2,
         "page": 1,
@@ -121,7 +173,15 @@ async def test_filter_titles_by_language_get_fra_and_eng(
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
-        "items": [{"ident": title_fra_eng_dict["ident"]}],
+        "items": [
+            {
+                "ident": title_fra_eng_dict["ident"],
+                "languages": [
+                    {"code": "eng", "name": "English", "native": "English"},
+                    {"code": "fra", "name": "French", "native": "Français"},
+                ],
+            }
+        ],
         "total": 1,
         "page": 1,
         "size": 50,

--- a/backend/tests/test_titles_endpoint.py
+++ b/backend/tests/test_titles_endpoint.py
@@ -55,3 +55,36 @@ async def test_get_book_missing(client):
     assert response.headers.get("Content-Type") == "application/json"
 
     assert response.json() == {"message": "Title with ID “missing” not found"}
+
+
+async def test_filter_titles_by_language_get_eng(
+    title_dict, title_with_language, title_fra
+):
+    """Creating two titles: title and title_fra. We're trying to fetch all Titles
+    in Franch Language."""
+    response = client.get("/v1/titles?lang=eng")
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    assert response.json() == {
+        "items": [{"ident": title_dict["ident"]}],
+        "total": 1,
+        "page": 1,
+        "size": 50,
+    }
+
+
+@pytest.mark.asyncio
+async def test_filter_titles_by_language_get_fra(
+    title_fra_dict, title_with_language, title_fra
+):
+    """Creating two titles: title and title_fra. We're trying to fetch all Titles
+    in Franch Language."""
+    response = client.get("/v1/titles?lang=fra")
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    assert response.json() == {
+        "items": [{"ident": title_fra_dict["ident"]}],
+        "total": 1,
+        "page": 1,
+        "size": 50,
+    }

--- a/backend/tests/test_titles_endpoint.py
+++ b/backend/tests/test_titles_endpoint.py
@@ -10,9 +10,9 @@ async def test_get_list_of_titles_single_title(client, title):
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
         "items": [
-            {"ident": title_ara.ident},
-            {"ident": title.ident},
-            {"ident": title_fra.ident},
+            {"ident": title_ara.ident, "languages": [], "metadata": {}, "tags": []},
+            {"ident": title.ident, "languages": [], "metadata": {}, "tags": []},
+            {"ident": title_fra.ident, "languages": [], "metadata": {}, "tags": []},
         ],
         "total": 3,
         "page": 1,
@@ -40,17 +40,20 @@ async def test_get_list_of_titles_with_languages(
                         "native": "العربية (مصر)",
                     },
                 ],
-                # "tags": [],
+                "metadata": {},
+                "tags": [],
             },
             {
                 "ident": title_with_language.ident,
                 "languages": [{"code": "eng", "name": "English", "native": "English"}],
-                # "tags": [],
+                "metadata": {},
+                "tags": [],
             },
             {
                 "ident": title_fra.ident,
                 "languages": [{"code": "fra", "name": "French", "native": "Français"}],
-                # "tags": [],
+                "metadata": {},
+                "tags": [],
             },
         ],
         "total": 3,
@@ -110,8 +113,9 @@ async def test_filter_titles_by_language_get_eng(
         "items": [
             {
                 "ident": title_dict["ident"],
-                # "languages": [],
-                # "tags": [],
+                "languages": [{"code": "eng", "name": "English", "native": "English"}],
+                "metadata": {},
+                "tags": [],
             }
         ],
         "total": 1,
@@ -131,8 +135,9 @@ async def test_filter_titles_by_language_get_fra(
         "items": [
             {
                 "ident": title_fra_dict["ident"],
-                # "languages": [],
-                # "tags": [],
+                "languages": [{"code": "fra", "name": "French", "native": "Français"}],
+                "metadata": {},
+                "tags": [],
             }
         ],
         "total": 1,
@@ -155,17 +160,19 @@ async def test_filter_titles_by_language_get_fra_or_eng(
         "items": [
             {
                 "ident": title_dict["ident"],
-                # "languages": [
-                #     {"code": "eng", "name": "English", "native": "English"},
-                # ],
-                # "tags": [],
+                "languages": [
+                    {"code": "eng", "name": "English", "native": "English"},
+                ],
+                "metadata": {},
+                "tags": [],
             },
             {
                 "ident": title_fra_dict["ident"],
-                # "languages": [
-                #     {"code": "fra", "name": "French", "native": "Français"},
-                # ],
-                # "tags": [],
+                "languages": [
+                    {"code": "fra", "name": "French", "native": "Français"},
+                ],
+                "metadata": {},
+                "tags": [],
             },
         ],
         "total": 2,
@@ -187,11 +194,12 @@ async def test_filter_titles_by_language_get_fra_and_eng(
         "items": [
             {
                 "ident": title_fra_eng_dict["ident"],
-                # "languages": [
-                #     {"code": "eng", "name": "English", "native": "English"},
-                #     {"code": "fra", "name": "French", "native": "Français"},
-                # ],
-                # "tags": [],
+                "languages": [
+                    {"code": "eng", "name": "English", "native": "English"},
+                    {"code": "fra", "name": "French", "native": "Français"},
+                ],
+                "metadata": {},
+                "tags": [],
             }
         ],
         "total": 1,
@@ -209,7 +217,8 @@ async def test_get_list_of_titles_with_tags_without_languages(title_with_data):
         "items": [
             {
                 "ident": title_with_data.ident,
-                # "languages": [],
+                "languages": [],
+                "metadata": {},
                 "tags": [{"name": "_category:wikipedia"}, {"name": "wikipedia"}],
             },
         ],
@@ -241,6 +250,7 @@ async def test_get_list_of_titles_with_languages_and_tags(title_with_data):
                         "native": "Luganda (Yuganda)",
                     },
                 ],
+                "metadata": {},
                 "tags": [{"name": "_category:wikipedia"}, {"name": "wikipedia"}],
             },
         ],
@@ -259,10 +269,12 @@ async def test_get_title_with_specific_metadata(title_with_data, title_dict, boo
         "items": [
             {
                 "ident": title_dict["ident"],
+                "languages": None,
                 "metadata": {
-                    "Title": book_dict["metadata"]["Title"],
                     "Publisher": book_dict["metadata"]["Publisher"],
+                    "Title": book_dict["metadata"]["Title"],
                 },
+                "tags": None,
             },
         ],
         "total": 1,

--- a/backend/tests/test_titles_endpoint.py
+++ b/backend/tests/test_titles_endpoint.py
@@ -9,8 +9,12 @@ async def test_get_list_of_titles_single_title(client, title):
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
-        "items": [{"ident": title.ident}],
-        "total": 1,
+        "items": [
+            {"ident": title_ara.ident},
+            {"ident": title.ident},
+            {"ident": title_fra.ident},
+        ],
+        "total": 3,
         "page": 1,
         "size": 50,
     }
@@ -60,8 +64,6 @@ async def test_get_book_missing(client):
 async def test_filter_titles_by_language_get_eng(
     title_dict, title_with_language, title_fra
 ):
-    """Creating two titles: title and title_fra. We're trying to fetch all Titles
-    in Franch Language."""
     response = client.get("/v1/titles?lang=eng")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
@@ -77,8 +79,6 @@ async def test_filter_titles_by_language_get_eng(
 async def test_filter_titles_by_language_get_fra(
     title_fra_dict, title_with_language, title_fra
 ):
-    """Creating two titles: title and title_fra. We're trying to fetch all Titles
-    in Franch Language."""
     response = client.get("/v1/titles?lang=fra")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"


### PR DESCRIPTION
Closes #41 

This is a work-in-progress.

@rgaudin 

I have failing BUT valid tests in this PR.

We will use/need `exclude_unset` refer this https://pydantic-docs.helpmanual.io/usage/exporting_models/
 whether fields which were not explicitly set when creating the model should be excluded from the returned dictionary; default False


I am still confused how they are using it here in FastApi https://fastapi.tiangolo.com/tutorial/body-updates/#using-pydantics-exclude_unset-parameter

here's ORMar's same docs for unsetting https://collerek.github.io/ormar/models/methods/#exclude_unset

---

following is my notes on this issue

-  [x] https://github.com/openzim/cms/issues/41
	- filters
		- [ ]  `?metadata-name=wikipedia_fr_test` to filter based on a meta (`Name` here). Value can include the `*` character (ex: `wikipedia_*_maxi`, `*_nopic`, etc). `Illustration_*` are not supported obviously.
			- [ ] exact match, `?metadata-name=wikipedia_fr_test`
			- [ ] wildcard match, `?metadata-name=wikipedia_*_all`
				- look into **SELECT LIKE**
			- [ ] ignore `Illustration_*`
		- [ ] `?tag=wikipedia,kids`, `?tag=wikipedia|wikibooks`
- [ ] payload-control
	- [ ] `?with_metadata=title,scraper,illustration_48x48`: includes the requested metadata in response. `all` is a shortcut for including all metadata (including illustration). `all_text` is same but only text-ones. `illustration` is an alias for `illustration_48x48`.
	- [ ] **`?with_languages`: include languages into response**
		- the `?with_languages` just by itself is not supported, it needs some value
			- ```diff
				-?with_languages
				+?with_languages=true
		- test
		- add `False` as the default
		- use the `bool` type
		- ❌ the `fields()` is not having any effect
		- test cases
			- [x] titles with single language
			- [x] titles with multiple languages
		- ⭕ Should all the `language` response follow the above style, instead of `["eng", "fra"]`
	- [ ] `?with_tags`: include tags (all) into response.
		- test cases
			- [x] combine `with_languages` and `with_tags`

**Meeting with Renaud** at 17:30
- Q. Will we ever have Titles w/o languages?
	- No
- Q. Should we be sending language data of titles by default. Because `fields("ident")` is not able to remove languages when `select_related()` is used
	- unless `with_languages` is used, don't send "language" key in the response
- Q. Will there be test case where `?lang=fra&with_languages=false`?
	- Yes

**Notes**
- We could just not use pydantic `response_model` for parsing, and then we can customise the response. Note of the pagination working with this new custom response. Refer `/titles/{ident}` on how to do this.
- Code is becoming spaghetti when I try to get multiple query parameters to work together, a.k.a. complex request
- Maybe if we use the difference between `None` vs `[]`, use can still use Pydantic schema?