### PR TITLE
Async tests with client-server DB

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,19 +6,17 @@ ENV ALLOWED_ORIGINS http://localhost
 ENV DATABASE_URL sqlite:///local.db
 
 # internal
-ENV APP_MODULE "backend.main:app"
+ENV APP_MODULE "backend.entrypoint:app"
 
-# launched by upstream /start.sh
+# add out prestart script launched by upstream's /start.sh and remove upstrean entry
 COPY prestart.sh /app/prestart.sh
-RUN chmod +x /app/prestart.sh
-
-# reove from upstream image
-RUN rm -f /app/main.py
+RUN chmod +x /app/prestart.sh && rm -f /app/main.py
 
 WORKDIR /tmp
 RUN pip install --no-cache-dir --upgrade pip setuptools toml invoke
 COPY pyproject.toml README.md setup.cfg setup.py tasks.py /tmp/
 RUN invoke install-deps --package runtime
+
 COPY src/ /tmp/src
 RUN python setup.py install && mv /tmp/src /src
 WORKDIR /src

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,7 @@ test = [
     "pytest-asyncio >=0.17.0,<1.0",
     "pytest-cov >=2.12.0,<4.0.0",
     "coverage >=6.0.2,<7.0",
+    "httpx >=0.22.0,<0.23"
 ]
 dev = [
     "black >=21.9b0,<22",

--- a/backend/src/backend/entrypoint.py
+++ b/backend/src/backend/entrypoint.py
@@ -1,0 +1,3 @@
+from backend.main import create_app  # pragma: no cover
+
+app = create_app()  # pragma: no cover

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -206,9 +206,3 @@ class TitleMetadata(ormar.Model, MetadataMixin):
         constraints = [ormar.UniqueColumns("name", "title")]
 
     title: Title = ormar.ForeignKey(Title, related_name="metadata")
-
-
-def setup():
-    """Create Database tables if missing"""
-    engine = sqlalchemy.create_engine(str(BaseMeta.database.url))
-    BaseMeta.metadata.create_all(engine)

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -116,7 +116,7 @@ def upload_coverage(c):
 def serve(c, args=""):
     """run devel HTTP server locally. Use --args to specify additional uvicorn args"""
     with c.cd("src"):
-        c.run(f"python -m uvicorn backend.main:app --reload {args}", pty=True)
+        c.run(f"python -m uvicorn backend.entrypoint:app --reload {args}", pty=True)
 
 
 @task

--- a/backend/tests/test_books_endpoint.py
+++ b/backend/tests/test_books_endpoint.py
@@ -17,7 +17,7 @@ from backend.models import (
 
 @pytest.mark.asyncio
 async def test_add_book(client, book_dict, clear_book_dict):
-    response = client.post("/v1/books/add", json=book_dict)
+    response = await client.post("/v1/books/add", json=book_dict)
     assert response.status_code == 201
     assert response.headers.get("Content-Type") == "application/json"
 
@@ -36,7 +36,7 @@ async def test_add_book(client, book_dict, clear_book_dict):
 
 @pytest.mark.asyncio
 async def test_add_metadata(client, book_dict, clear_book_dict):
-    response = client.post("/v1/books/add", json=book_dict)
+    response = await client.post("/v1/books/add", json=book_dict)
     assert response.status_code == 201
     assert response.headers.get("Content-Type") == "application/json"
 
@@ -59,7 +59,7 @@ async def test_add_metadata(client, book_dict, clear_book_dict):
 
 @pytest.mark.asyncio
 async def test_add_book_tags(client, book_dict, clear_book_dict):
-    response = client.post("/v1/books/add", json=book_dict)
+    response = await client.post("/v1/books/add", json=book_dict)
     assert response.status_code == 201
     assert response.headers.get("Content-Type") == "application/json"
 
@@ -76,7 +76,7 @@ async def test_add_book_tags(client, book_dict, clear_book_dict):
 
 @pytest.mark.asyncio
 async def test_save_languages(client, book_dict, clear_book_dict):
-    response = client.post("/v1/books/add", json=book_dict)
+    response = await client.post("/v1/books/add", json=book_dict)
     assert response.status_code == 201
     assert response.headers.get("Content-Type") == "application/json"
 
@@ -100,7 +100,7 @@ async def test_save_languages(client, book_dict, clear_book_dict):
 
 @pytest.mark.asyncio
 async def test_add_title(client, book_dict, clear_book_dict):
-    response = client.post("/v1/books/add", json=book_dict)
+    response = await client.post("/v1/books/add", json=book_dict)
     assert response.status_code == 201
     assert response.headers.get("Content-Type") == "application/json"
 
@@ -115,7 +115,7 @@ async def test_add_title(client, book_dict, clear_book_dict):
 
 @pytest.mark.asyncio
 async def test_add_languages(client, book_dict, clear_book_dict):
-    response = client.post("/v1/books/add", json=book_dict)
+    response = await client.post("/v1/books/add", json=book_dict)
     assert response.status_code == 201
     assert response.headers.get("Content-Type") == "application/json"
 
@@ -135,7 +135,7 @@ async def test_add_languages(client, book_dict, clear_book_dict):
 
 @pytest.mark.asyncio
 async def test_add_title_tags(client, book_dict, clear_book_dict):
-    response = client.post("/v1/books/add", json=book_dict)
+    response = await client.post("/v1/books/add", json=book_dict)
     assert response.status_code == 201
     assert response.headers.get("Content-Type") == "application/json"
 
@@ -152,7 +152,7 @@ async def test_add_title_tags(client, book_dict, clear_book_dict):
 
 @pytest.mark.asyncio
 async def test_add_title_metadata(client, book_dict, clear_book_dict):
-    response = client.post("/v1/books/add", json=book_dict)
+    response = await client.post("/v1/books/add", json=book_dict)
     assert response.status_code == 201
     assert response.headers.get("Content-Type") == "application/json"
 
@@ -186,7 +186,7 @@ async def test_add_title_metadata(client, book_dict, clear_book_dict):
 async def test_raise_httpexception_for_incorrect_title(client, book_dict):
     # updating book_dict with incorrect language code
     book_dict["metadata"]["Name"] = "wikipedia_zz_all"
-    response = client.post("/v1/books/add", json=book_dict)
+    response = await client.post("/v1/books/add", json=book_dict)
     assert response.status_code == 400
     assert response.headers.get("Content-Type") == "application/json"
 
@@ -199,7 +199,7 @@ async def test_raise_httpexception_for_incorrect_title(client, book_dict):
 
 @pytest.mark.asyncio
 async def test_get_book_info(client, book_with_metadata, book_dict):
-    response = client.get(f"/v1/books/{book_dict['id']}")
+    response = await client.get(f"/v1/books/{book_dict['id']}")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
 
@@ -208,7 +208,7 @@ async def test_get_book_info(client, book_with_metadata, book_dict):
 
 @pytest.mark.asyncio
 async def test_get_book_missing(client):
-    response = client.get("/v1/books/missing")
+    response = await client.get("/v1/books/missing")
     assert response.status_code == 404
     assert response.headers.get("Content-Type") == "application/json"
 

--- a/backend/tests/test_root_endpoint.py
+++ b/backend/tests/test_root_endpoint.py
@@ -8,10 +8,10 @@ def test_metadata():
     assert backend.__description__
 
 
-def test_root(client):
-    response = client.get("/", allow_redirects=False)
+async def test_root(client):
+    response = await client.get("/", follow_redirects=False)
     assert response.status_code == 308
-    response = client.get("/", allow_redirects=True)
-    assert response.url.endswith(PREFIX + "/")
+    response = await client.get("/", follow_redirects=True)
+    assert str(response.url).endswith(PREFIX + "/")
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == "Hello World"

--- a/backend/tests/test_titles_endpoint.py
+++ b/backend/tests/test_titles_endpoint.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_get_list_of_titles_single_title(client, title):
-    response = client.get("/v1/titles/")
+    response = await client.get("/v1/titles")
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {
@@ -18,7 +18,7 @@ async def test_get_list_of_titles_single_title(client, title):
 
 @pytest.mark.asyncio
 async def test_get_title_with_data(client, title_with_data, book_dict):
-    response = client.get(f"/v1/titles/{title_with_data.ident}")
+    response = await client.get(f"/v1/titles/{title_with_data.ident}")
     assert response.status_code == 200
 
     tags = []
@@ -37,7 +37,7 @@ async def test_get_title_with_data(client, title_with_data, book_dict):
 
 @pytest.mark.asyncio
 async def test_get_title_with_no_data(client, title):
-    response = client.get(f"/v1/titles/{title.ident}")
+    response = await client.get(f"/v1/titles/{title.ident}")
     assert response.status_code == 200
     assert response.json() == {
         "ident": title.ident,
@@ -50,7 +50,7 @@ async def test_get_title_with_no_data(client, title):
 
 @pytest.mark.asyncio
 async def test_get_book_missing(client):
-    response = client.get("/v1/titles/missing")
+    response = await client.get("/v1/titles/missing")
     assert response.status_code == 404
     assert response.headers.get("Content-Type") == "application/json"
 


### PR DESCRIPTION
Now using AsyncClient from httpx for tests as FastAPI's client doesn't support async tests

Moved FastAPI instantiation to a function so we can control when it is created and thus prevent event_loop disparities in tests for instance.

Fixes #52 