### PR TITLE
display books in inbox with filters based on location

### DIFF
--- a/backend/src/cms_backend/api/routes/models.py
+++ b/backend/src/cms_backend/api/routes/models.py
@@ -1,3 +1,4 @@
+import math
 from typing import Generic, TypeVar
 
 from pydantic import Field
@@ -12,6 +13,7 @@ class Paginator(BaseModel):
     skip: int
     limit: int
     page_size: int
+    page: int
 
 
 class ListResponse(BaseModel, Generic[T]):
@@ -26,16 +28,19 @@ def calculate_pagination_metadata(
     limit: int,
     page_size: int,
 ) -> Paginator:
+    page = math.floor(skip / limit) + 1 if limit > 0 else 1
     if nb_records == 0:
         return Paginator(
             nb_records=0,
             skip=skip,
             limit=limit,
             page_size=0,
+            page=page,
         )
     return Paginator(
         nb_records=nb_records,
         skip=skip,
         limit=limit,
         page_size=min(page_size, nb_records),
+        page=page,
     )

--- a/frontend/src/assets/data-table.css
+++ b/frontend/src/assets/data-table.css
@@ -1,0 +1,32 @@
+/* Global Vuetify Data Table Mobile Customization Styles */
+
+.v-data-table-headers--mobile {
+  display: none !important;
+}
+
+.v-table--density-compact {
+  --v-table-row-height: 24px !important;
+}
+
+.v-data-table__tr--mobile {
+  display: block !important;
+  margin: 4px 0 !important;
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+  border-radius: 5px !important;
+}
+
+.v-data-table__tr--mobile .v-data-table__td {
+  border-bottom: none !important;
+}
+
+.v-data-table__tr--mobile > td {
+  padding: 2px 8px !important;
+}
+
+.v-data-table__tr--mobile > td:first-child {
+  padding-top: 4px !important;
+}
+
+.v-data-table__tr--mobile > td:last-child {
+  padding-bottom: 4px !important;
+}

--- a/frontend/src/components/BookFilters.vue
+++ b/frontend/src/components/BookFilters.vue
@@ -13,35 +13,66 @@
             @change="emitFilters"
           />
         </v-col>
+        <v-col cols="12" sm="6" md="3">
+          <v-select
+            v-model="localFilters.location_kind"
+            label="Location"
+            :items="formattedLocationKindOptions"
+            placeholder="Select location kind"
+            variant="outlined"
+            density="compact"
+            hide-details
+            :clearable="hasActiveFilters"
+            @update:model-value="emitFilters"
+            @click:clear="handleClearFilters"
+          />
+        </v-col>
+        <v-col
+          v-if="hasActiveFilters"
+          cols="12"
+          class="d-flex flex-sm-row flex-column align-sm-center"
+        >
+          <v-btn size="small" variant="outlined" @click="handleClearFilters">
+            <v-icon size="small" class="mr-1">mdi-close-circle</v-icon>
+            clear filters
+          </v-btn>
+        </v-col>
       </v-row>
     </v-card-text>
   </v-card>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 // Props
 interface Props {
   filters: {
     id: string
+    location_kind: string
   }
+  locationKindOptions?: string[]
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  locationKindOptions: () => [],
+})
 
 // Define emits
 const emit = defineEmits<{
   filtersChanged: [
     filters: {
       id: string
+      location_kind: string
     },
   ]
+  clearFilters: []
 }>()
 
 // Local filters state
 const localFilters = ref({
   id: props.filters.id,
+  location_kind: props.filters.location_kind,
 })
 
 // Watch for prop changes and update local state
@@ -50,15 +81,31 @@ watch(
   (newFilters) => {
     localFilters.value = {
       id: newFilters.id,
+      location_kind: newFilters.location_kind,
     }
   },
-  { deep: true },
 )
+
+const formattedLocationKindOptions = computed(() => {
+  return props.locationKindOptions.map((option) => ({
+    title: option.charAt(0).toUpperCase() + option.slice(1),
+    value: option,
+  }))
+})
+
+const hasActiveFilters = computed(() => {
+  return props.filters.id.length > 0 || props.filters.location_kind.length > 0
+})
 
 // Emit filters when they change
 function emitFilters() {
   emit('filtersChanged', {
     id: localFilters.value.id,
+    location_kind: localFilters.value.location_kind,
   })
+}
+
+function handleClearFilters() {
+  emit('clearFilters')
 }
 </script>

--- a/frontend/src/components/BookTable.vue
+++ b/frontend/src/components/BookTable.vue
@@ -2,7 +2,7 @@
   <div>
     <v-card v-if="!errors.length" :class="{ loading: loading }" flat>
       <v-card-title
-        v-if="showSelection || showFilters || $slots.actions"
+        v-if="showSelection || $slots.actions"
         class="d-flex flex-column-reverse flex-sm-row align-sm-center justify-sm-end ga-2"
       >
         <slot name="actions" />
@@ -17,25 +17,18 @@
           <v-icon size="small" class="mr-1">mdi-checkbox-multiple-blank-outline</v-icon>
           clear selections
         </v-btn>
-        <v-btn
-          v-if="showFilters"
-          size="small"
-          variant="outlined"
-          :disabled="!hasActiveFilters"
-          @click="handleClearFilters"
-        >
-          <v-icon size="small" class="mr-1">mdi-close-circle</v-icon>
-          clear filters
-        </v-btn>
       </v-card-title>
 
       <v-data-table-server
         :headers="headers"
         :items="books"
         :loading="loading"
-        :items-per-page="selectedLimit"
+        :page="props.paginator.page"
+        :items-per-page="props.paginator.limit"
         :items-length="paginator.count"
         :items-per-page-options="limits"
+        :mobile="smAndDown"
+        :density="smAndDown ? 'compact' : 'comfortable'"
         class="elevation-1"
         item-value="name"
         :show-select="showSelection"
@@ -62,6 +55,16 @@
           </router-link>
         </template>
 
+        <template #[`item.location_kind`]="{ item }">
+          <v-chip
+            :color="item.location_kind === 'quarantine' ? 'warning' : 'info'"
+            size="small"
+            variant="flat"
+          >
+            {{ item.location_kind }}
+          </v-chip>
+        </template>
+
         <template #[`item.status`]="{ item }">
           <BookStatus :book="item" />
         </template>
@@ -81,7 +84,14 @@
 import BookStatus from '@/components/BookStatus.vue'
 import type { Paginator } from '@/types/base'
 import type { BookLight } from '@/types/book'
-import { computed, ref, watch } from 'vue'
+import { computed } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { useDisplay } from 'vuetify'
+
+const router = useRouter()
+const route = useRoute()
+
+const { smAndDown } = useDisplay()
 
 // Props
 interface Props {
@@ -93,6 +103,7 @@ interface Props {
   loadingText: string
   filters?: {
     id: string
+    location_kind: string
   }
   selectedBooks?: string[]
   showSelection?: boolean
@@ -100,7 +111,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  filters: () => ({ id: '' }),
+  filters: () => ({ id: '', location_kind: '' }),
   selectedBooks: () => [],
   showSelection: true,
   showFilters: true,
@@ -110,33 +121,28 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   limitChanged: [limit: number]
   loadData: [limit: number, skip: number]
-  clearFilters: []
   selectionChanged: [selectedBooks: string[]]
 }>()
 
 const limits = [10, 20, 50, 100]
-const selectedLimit = ref(props.paginator.limit)
 
 const selectedBooks = computed(() => props.selectedBooks)
 
-// Check if any filters are active
-const hasActiveFilters = computed(() => {
-  return props.filters.id.length > 0
-})
-
 function onUpdateOptions(options: { page: number; itemsPerPage: number }) {
-  // page is 1-indexed, we need to calculate the skip for the request
-  const page = options.page > 1 ? options.page - 1 : 0
-  emit('loadData', options.itemsPerPage, page * options.itemsPerPage)
-}
+  const query = { ...route.query }
 
-watch(
-  () => props.paginator,
-  (newPaginator) => {
-    selectedLimit.value = newPaginator.limit
-  },
-  { immediate: true },
-)
+  if (options.page > 1) {
+    query.page = options.page.toString()
+  } else {
+    delete query.page
+  }
+
+  router.push({ query })
+
+  if (options.itemsPerPage != props.paginator.limit) {
+    emit('limitChanged', options.itemsPerPage)
+  }
+}
 
 function handleSelectionChange(selection: string[]) {
   emit('selectionChanged', selection)
@@ -144,9 +150,5 @@ function handleSelectionChange(selection: string[]) {
 
 function clearSelections() {
   emit('selectionChanged', [])
-}
-
-function handleClearFilters() {
-  emit('clearFilters')
 }
 </script>

--- a/frontend/src/components/ZimfarmNotificationFilters.vue
+++ b/frontend/src/components/ZimfarmNotificationFilters.vue
@@ -13,13 +13,23 @@
             @change="emitFilters"
           />
         </v-col>
+        <v-col
+          v-if="hasActiveFilters"
+          cols="12"
+          class="d-flex flex-sm-row flex-column align-sm-center"
+        >
+          <v-btn size="small" variant="outlined" @click="handleClearFilters">
+            <v-icon size="small" class="mr-1">mdi-close-circle</v-icon>
+            clear filters
+          </v-btn>
+        </v-col>
       </v-row>
     </v-card-text>
   </v-card>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 // Props
 interface Props {
@@ -37,6 +47,7 @@ const emit = defineEmits<{
       id: string
     },
   ]
+  clearFilters: []
 }>()
 
 // Local filters state
@@ -55,10 +66,18 @@ watch(
   { deep: true },
 )
 
+const hasActiveFilters = computed(() => {
+  return props.filters.id.length > 0
+})
+
 // Emit filters when they change
 function emitFilters() {
   emit('filtersChanged', {
     id: localFilters.value.id,
   })
+}
+
+function handleClearFilters() {
+  emit('clearFilters')
 }
 </script>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,3 +1,5 @@
+import 'vuetify/styles'
+import '@/assets/data-table.css'
 import '@/assets/styles.css'
 import '@mdi/font/css/materialdesignicons.css' // Ensure you are using css-loader
 
@@ -6,7 +8,6 @@ import { createApp } from 'vue'
 import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
-import 'vuetify/styles'
 
 import { createPinia } from 'pinia'
 import VueMatomo from 'vue-matomo'

--- a/frontend/src/stores/book.ts
+++ b/frontend/src/stores/book.ts
@@ -13,12 +13,12 @@ export const useBookStore = defineStore('book', () => {
   const book = ref<Book | null>(null)
   const errors = ref<string[]>([])
   const books = ref<BookLight[]>([])
-  const limit = Number($cookies?.get('books-table-limit') || 20)
+  const defaultLimit = ref<number>(Number($cookies?.get('books-table-limit') || 20))
   const paginator = ref<Paginator>({
     page: 1,
-    page_size: limit,
+    page_size: defaultLimit.value,
     skip: 0,
-    limit: limit,
+    limit: defaultLimit.value,
     count: 0,
   })
   const authStore = useAuthStore()
@@ -49,6 +49,7 @@ export const useBookStore = defineStore('book', () => {
     skip: number,
     has_title: boolean | undefined = undefined,
     id: string | undefined = undefined,
+    location_kind: string | undefined = undefined,
   ) => {
     const service = await authStore.getApiService('books')
     // filter out undefined values from params
@@ -58,6 +59,7 @@ export const useBookStore = defineStore('book', () => {
         skip,
         has_title,
         id,
+        location_kind,
       }).filter(
         ([name, value]) => !!value || (!['limit', 'skip'].includes(name) && value !== undefined),
       ),
@@ -83,6 +85,7 @@ export const useBookStore = defineStore('book', () => {
 
   return {
     // State
+    defaultLimit,
     book,
     books,
     paginator,

--- a/frontend/src/stores/zimfarmNotification.ts
+++ b/frontend/src/stores/zimfarmNotification.ts
@@ -13,12 +13,12 @@ export const useZimfarmNotificationStore = defineStore('zimfarm-notification', (
   const zimfarmNotification = ref<ZimfarmNotification | null>(null)
   const errors = ref<string[]>([])
   const zimfarmNotifications = ref<ZimfarmNotificationLight[]>([])
-  const limit = Number($cookies?.get('zimfarm-notifications-table-limit') || 20)
+  const defaultLimit = ref<number>(Number($cookies?.get('zimfarm-notifications-table-limit') || 20))
   const paginator = ref<Paginator>({
     page: 1,
-    page_size: limit,
+    page_size: defaultLimit.value,
     skip: 0,
-    limit: limit,
+    limit: defaultLimit.value,
     count: 0,
   })
   const authStore = useAuthStore()
@@ -96,6 +96,7 @@ export const useZimfarmNotificationStore = defineStore('zimfarm-notification', (
 
   return {
     // State
+    defaultLimit,
     zimfarmNotification,
     zimfarmNotifications,
     paginator,

--- a/frontend/src/views/InboxView.vue
+++ b/frontend/src/views/InboxView.vue
@@ -1,19 +1,22 @@
-<!-- Pipeline View showing a list of tasks -->
+<!-- Inbox View showing a list of books and zimfarm notifications -->
 
 <template>
-  <TabsList :active-tab="activeTab" :tab-options="tabOptions" @tab-changed="handleTabChange" />
+  <TabsList :active-tab="currentTab" :tab-options="tabOptions" @tab-changed="handleTabChange" />
   <BookFilters
-    v-if="activeTab == 'books'"
+    v-if="currentTab == 'books'"
     :filters="bookFilters"
+    :location-kind-options="['quarantine', 'staging']"
     @filters-changed="handleBookFiltersChange"
+    @clear-filters="clearFilters"
   />
   <ZimfarmNotificationFilters
-    v-if="activeTab == 'zimfarm_notifications'"
+    v-if="currentTab == 'zimfarm_notifications'"
     :filters="zimfarmFilters"
     @filters-changed="handleZimfarmFiltersChange"
+    @clear-filters="clearFilters"
   />
   <BookTable
-    v-show="ready && activeTab == 'books'"
+    v-show="currentTab == 'books'"
     :headers="headers"
     :books="books"
     :paginator="paginator"
@@ -26,11 +29,10 @@
     :show-filters="true"
     @limit-changed="handleLimitChange"
     @load-data="loadData"
-    @clear-filters="clearFilters"
     @selection-changed="handleSelectionChanged"
   />
   <ZimfarmNotificationTable
-    v-show="ready && activeTab == 'zimfarm_notifications'"
+    v-show="currentTab == 'zimfarm_notifications'"
     :headers="headers"
     :zimfarm-notifications="zimfarmNotifications"
     :paginator="paginator"
@@ -40,15 +42,10 @@
     :filters="zimfarmFilters"
     :selected-zimfarm-notifications="selectedZimfarmNotifications"
     :show-selection="true"
-    :show-filters="true"
     @limit-changed="handleLimitChange"
     @load-data="loadData"
-    @clear-filters="clearFilters"
     @selection-changed="handleSelectionChanged"
   />
-  <div v-if="!ready" class="d-flex align-center justify-center" style="height: 60vh">
-    <v-progress-circular indeterminate size="70" width="7" color="primary" />
-  </div>
 </template>
 
 <script setup lang="ts">
@@ -62,15 +59,30 @@ import { useBookStore } from '@/stores/book'
 import { useZimfarmNotificationStore } from '@/stores/zimfarmNotification'
 import type { BookLight } from '@/types/book'
 import type { ZimfarmNotificationLight } from '@/types/zimfarmNotification'
+import type { Paginator } from '@/types/base'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
+
+const router = useRouter()
+const route = useRoute()
+
+const bookStore = useBookStore()
+const zimfarmNotificationStore = useZimfarmNotificationStore()
+const loadingStore = useLoadingStore()
+
+// Filter options
+const tabOptions = [
+  { value: 'books', label: 'BOOKS' },
+  { value: 'zimfarm_notifications', label: 'ZIMFARM NOTIFICATIONS' },
+]
 
 // Define headers for the table
 const headers = computed(() => {
-  switch (activeTab.value) {
+  switch (currentTab.value) {
     case 'books':
       return [
         { title: 'ID', value: 'id' },
+        { title: 'Location', value: 'location_kind' },
         { title: 'Status', value: 'status' },
       ]
     case 'zimfarm_notifications':
@@ -84,148 +96,102 @@ const headers = computed(() => {
   }
 })
 
-const paginator = computed(() => {
-  switch (activeTab.value) {
-    case 'books':
-      return bookStore.paginator
-    case 'zimfarm_notifications':
-      return zimfarmNotificationStore.paginator
-    default:
-      return bookStore.paginator
-  }
+const currentTab = computed(() => {
+  const tab = route.query.tab
+  return (Array.isArray(tab) ? tab[0] : tab) || 'books'
 })
 
-// Filter options
-const tabOptions = [
-  { value: 'books', label: 'BOOKS' },
-  { value: 'zimfarm_notifications', label: 'ZIMFARM NOTIFICATIONS' },
-]
-
-const props = withDefaults(
-  defineProps<{
-    activeTab?: string
-  }>(),
-  {
-    activeTab: new URLSearchParams(window.location.search).get('tab') || 'books',
-  },
+const defaultLimit = computed(() =>
+  currentTab.value == 'book' ? bookStore.defaultLimit : zimfarmNotificationStore.defaultLimit,
 )
 
-const ready = ref<boolean>(false)
 const books = ref<BookLight[]>([])
 const zimfarmNotifications = ref<ZimfarmNotificationLight[]>([])
+const paginator = ref<Paginator>({
+  page: Number(route.query.page) || 1,
+  page_size: defaultLimit.value,
+  skip: 0,
+  limit: defaultLimit.value,
+  count: 0,
+})
 const errors = ref<string[]>([])
-const bookFilters = ref({
-  id: '',
+
+const bookFilters = computed(() => {
+  const query = router.currentRoute.value.query
+  const derived = {
+    location_kind: '',
+    id: '',
+  }
+  if (query.id && typeof query.id === 'string') {
+    derived.id = query.id
+  }
+
+  if (query.location_kind && typeof query.location_kind === 'string') {
+    derived.location_kind = query.location_kind
+  }
+
+  return derived
 })
-const zimfarmFilters = ref({
-  id: '',
+
+const zimfarmFilters = computed(() => {
+  const query = router.currentRoute.value.query
+  const derived = {
+    id: '',
+  }
+  if (query.id && typeof query.id === 'string') {
+    derived.id = query.id
+  }
+
+  return derived
 })
+
 const intervalId = ref<number | null>(null)
 const selectedBooks = ref<string[]>([])
 const selectedZimfarmNotifications = ref<string[]>([])
 
-const router = useRouter()
-
-const bookStore = useBookStore()
-const zimfarmNotificationStore = useZimfarmNotificationStore()
-const loadingStore = useLoadingStore()
-
-const activeTab = ref(props.activeTab)
-
 const handleTabChange = (newTab: string) => {
-  activeTab.value = newTab
-
   // Navigate to the new tab route
   router.push({
     query: {
-      ...router.currentRoute.value.query,
       tab: newTab,
     },
   })
 }
 
-async function handleLimitChange(newLimit: number) {
-  switch (activeTab.value) {
-    case 'books':
-      bookStore.savePaginatorLimit(newLimit)
-      break
-    case 'zimfarm_notifications':
-      zimfarmNotificationStore.savePaginatorLimit(newLimit)
-      break
-  }
-}
-
-async function clearFilters() {
-  switch (activeTab.value) {
-    case 'books':
-      bookFilters.value = {
-        id: '',
-      }
-      break
-    case 'zimfarm_notifications':
-      zimfarmFilters.value = {
-        id: '',
-      }
-      break
-  }
-  await loadData(paginator.value.limit, 0)
-}
-
-async function handleBookFiltersChange(newFilters: typeof bookFilters.value) {
-  bookFilters.value = newFilters
-  await loadData(paginator.value.limit, 0)
-}
-
-async function handleZimfarmFiltersChange(newFilters: typeof zimfarmFilters.value) {
-  zimfarmFilters.value = newFilters
-  await loadData(paginator.value.limit, 0)
-}
-
-function handleSelectionChanged(newSelection: string[]) {
-  switch (activeTab.value) {
-    case 'books':
-      selectedBooks.value = newSelection
-      break
-    case 'zimfarm_notifications':
-      selectedZimfarmNotifications.value = newSelection
-      break
-  }
-}
-
-// Watch for filter changes and load data
-watch(activeTab, async (newTab) => {
-  if (intervalId.value) {
-    clearInterval(intervalId.value)
-  }
-  await loadData(paginator.value.limit, paginator.value.skip, newTab)
-  intervalId.value = window.setInterval(async () => {
-    await loadData(paginator.value.limit, paginator.value.skip, activeTab.value, true)
-  }, 60000)
+// Clear selections when switching tabs
+watch(currentTab, () => {
+  selectedBooks.value = []
+  selectedZimfarmNotifications.value = []
 })
 
 async function loadData(limit: number, skip: number, tab?: string, hideLoading: boolean = false) {
   if (!tab) {
-    tab = activeTab.value
+    tab = currentTab.value
   }
 
-  ready.value = false
-  books.value = []
-  zimfarmNotifications.value = []
+  if (!hideLoading) {
+    loadingStore.startLoading(
+      tab === 'books' ? 'Fetching books...' : 'Fetching zimfarm notifications...',
+    )
+    books.value = []
+    zimfarmNotifications.value = []
+  }
 
   switch (tab) {
     case 'books':
-      if (!hideLoading) {
-        loadingStore.startLoading('Fetching books...')
-      }
-      await bookStore.fetchBooks(limit, skip, false, bookFilters.value.id || undefined)
+      await bookStore.fetchBooks(
+        limit,
+        skip,
+        false,
+        bookFilters.value.id || undefined,
+        bookFilters.value.location_kind || undefined,
+      )
       books.value = bookStore.books
       errors.value = bookStore.errors
       bookStore.savePaginatorLimit(limit)
+      paginator.value = { ...bookStore.paginator }
       break
     case 'zimfarm_notifications':
-      if (!hideLoading) {
-        loadingStore.startLoading('Fetching zimfarm notifications...')
-      }
       await zimfarmNotificationStore.fetchZimfarmNotifications(
         limit,
         skip,
@@ -238,20 +204,114 @@ async function loadData(limit: number, skip: number, tab?: string, hideLoading: 
       zimfarmNotifications.value = zimfarmNotificationStore.zimfarmNotifications
       errors.value = zimfarmNotificationStore.errors
       zimfarmNotificationStore.savePaginatorLimit(limit)
+      paginator.value = { ...zimfarmNotificationStore.paginator }
       break
     default:
-      throw new Error(`Invalid filter: ${tab}`)
+      throw new Error(`Invalid tab: ${tab}`)
   }
 
-  ready.value = true
   if (loadingStore.isLoading) {
     loadingStore.stopLoading()
   }
 }
 
+async function handleLimitChange(newLimit: number) {
+  switch (currentTab.value) {
+    case 'books':
+      bookStore.savePaginatorLimit(newLimit)
+      break
+    case 'zimfarm_notifications':
+      zimfarmNotificationStore.savePaginatorLimit(newLimit)
+      break
+  }
+
+  if (paginator.value.page != 1) {
+    paginator.value = {
+      ...paginator.value,
+      limit: newLimit,
+      page: 1,
+      skip: 0,
+    }
+  } else {
+    await loadData(newLimit, 0, currentTab.value)
+  }
+}
+
+function updateUrlFilters(
+  sourceFilters: typeof bookFilters.value | typeof ZimfarmNotificationFilters.value,
+) {
+  // create query object from selected filters
+  const query: Record<string, string | string[]> = {}
+
+  // Preserve the current tab
+  if (currentTab.value) {
+    query.tab = currentTab.value
+  }
+
+  if (sourceFilters.id) {
+    query.id = sourceFilters.id
+  }
+
+  if (sourceFilters.location_kind) {
+    query.location_kind = sourceFilters.location_kind
+  }
+
+  router.push({
+    name: route.name,
+    query: Object.keys(query).length > 0 ? query : undefined,
+  })
+}
+
+async function clearFilters() {
+  switch (currentTab.value) {
+    case 'books':
+      updateUrlFilters({ id: '', location_kind: '' })
+      break
+    case 'zimfarm_notifications':
+      updateUrlFilters({ id: '' })
+      break
+  }
+}
+
+async function handleBookFiltersChange(newFilters: typeof bookFilters.value) {
+  updateUrlFilters(newFilters)
+}
+
+async function handleZimfarmFiltersChange(newFilters: typeof zimfarmFilters.value) {
+  updateUrlFilters(newFilters)
+}
+
+function handleSelectionChanged(newSelection: string[]) {
+  switch (currentTab.value) {
+    case 'books':
+      selectedBooks.value = newSelection
+      break
+    case 'zimfarm_notifications':
+      selectedZimfarmNotifications.value = newSelection
+      break
+  }
+}
+
+watch(
+  () => router.currentRoute.value.query,
+  async () => {
+    const query = router.currentRoute.value.query
+    let page = 1
+    if (query.page && typeof query.page === 'string') {
+      const parsedPage = parseInt(query.page, 10)
+      if (!isNaN(parsedPage) && parsedPage > 1) {
+        page = parsedPage
+      }
+    }
+    const newSkip = (page - 1) * paginator.value.limit
+    await loadData(paginator.value.limit, newSkip)
+  },
+  { deep: true, immediate: true },
+)
+
 onMounted(async () => {
   intervalId.value = window.setInterval(async () => {
-    await loadData(paginator.value.limit, paginator.value.skip, activeTab.value, true)
+    await loadData(paginator.value.limit, paginator.value.skip, currentTab.value, true)
   }, 60000)
 })
 


### PR DESCRIPTION
## Rationale
This PR enhances the inbox view to support filters for book locations. The combination of `has_titles` and `location_kind` filters can be used to show books which have no title and are in quarantine/staging. The PR also refactors the filters to be populated from route (openzim/zimfarm#1609) and make tables to be responsive (openzim/zimfarm#1624)

<img width="1223" height="479" alt="Screenshot_20260204_164444" src="https://github.com/user-attachments/assets/10ecd54e-352d-4a4f-b522-3b8412c59347" />

## Changes
- add filters for location in books tab of the inbox view
- return `page` from API so frontend knows the current page number of the results to persist in route (openzim/zimfarm#1609)
- make inbox tables mobile-responsive

This closes #142 