### PR TITLE
create title with collection name and path

### DIFF
--- a/backend/src/cms_backend/api/routes/collection.py
+++ b/backend/src/cms_backend/api/routes/collection.py
@@ -3,20 +3,50 @@ from typing import Annotated
 from uuid import UUID
 from xml.etree import ElementTree as ET
 
-from fastapi import APIRouter, Depends, Path
+from fastapi import APIRouter, Depends, Path, Query
 from fastapi.responses import Response
 from sqlalchemy.orm import Session as OrmSession
 
+from cms_backend.api.routes.fields import LimitFieldMax200, SkipField
+from cms_backend.api.routes.models import ListResponse, calculate_pagination_metadata
 from cms_backend.db import gen_dbsession
 from cms_backend.db.collection import (
     get_collection,
     get_collection_by_name_or_none,
     get_latest_books_for_collection,
 )
+from cms_backend.db.collection import get_collections as db_get_collections
 from cms_backend.db.exceptions import RecordDoesNotExistError
 from cms_backend.db.models import Book
+from cms_backend.schemas import BaseModel
+from cms_backend.schemas.orms import CollectionLightSchema
 
 router = APIRouter(prefix="/collections", tags=["collections"])
+
+
+class CollectionsGetSchema(BaseModel):
+    skip: SkipField = 0
+    limit: LimitFieldMax200 = 20
+
+
+@router.get("")
+async def get_collections(
+    params: Annotated[CollectionsGetSchema, Query()],
+    session: Annotated[OrmSession, Depends(gen_dbsession)],
+) -> ListResponse[CollectionLightSchema]:
+    """Get a list of collections"""
+
+    results = db_get_collections(session, skip=params.skip, limit=params.limit)
+
+    return ListResponse[CollectionLightSchema](
+        meta=calculate_pagination_metadata(
+            nb_records=results.nb_records,
+            skip=params.skip,
+            limit=params.limit,
+            page_size=len(results.records),
+        ),
+        items=results.records,
+    )
 
 
 def _build_library_xml(books: list[Book]) -> str:

--- a/backend/src/cms_backend/schemas/orms.py
+++ b/backend/src/cms_backend/schemas/orms.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Generic, TypeVar
 from uuid import UUID
 
+from cms_backend.api.routes.fields import NotEmptyString
 from cms_backend.schemas import BaseModel
 
 T = TypeVar("T")
@@ -19,13 +21,16 @@ class TitleLightSchema(BaseModel):
 
     id: UUID
     name: str
-    maturity: str
+    maturity: str | None
 
 
-class TitleCollectionSchema(BaseModel):
-    collection_id: UUID
-    collection_name: str
+class BaseTitleCollectionSchema(BaseModel):
+    collection_name: NotEmptyString
     path: str
+
+
+class TitleCollectionSchema(BaseTitleCollectionSchema):
+    collection_id: UUID
 
 
 class TitleFullSchema(TitleLightSchema):
@@ -36,6 +41,14 @@ class TitleFullSchema(TitleLightSchema):
     events: list[str]
     books: list["BookLightSchema"]
     collections: list["TitleCollectionSchema"]
+
+
+class CollectionLightSchema(BaseModel):
+    """Collection for reading a collection with all the paths in it."""
+
+    id: UUID
+    name: str
+    paths: list[Path]
 
 
 class ZimfarmNotificationLightSchema(BaseModel):

--- a/backend/tests/api/routes/test_collections.py
+++ b/backend/tests/api/routes/test_collections.py
@@ -1,0 +1,83 @@
+from collections.abc import Callable
+from http import HTTPStatus
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session as OrmSession
+
+from cms_backend.db.models import Collection, Title
+
+
+def test_get_collections_empty(client: TestClient):
+    """Test get collections endpoint with no collection"""
+
+    response = client.get("/v1/collections")
+    assert response.status_code == HTTPStatus.OK
+    response_doc = response.json()
+    assert "meta" in response_doc
+    assert response_doc["meta"]["count"] == 0
+    assert response_doc["meta"]["skip"] == 0
+    assert response_doc["meta"]["limit"] == 20
+    assert response_doc["meta"]["page_size"] == 0
+    assert "items" in response_doc
+    assert response_doc["items"] == []
+
+
+@pytest.mark.parametrize(
+    "skip,limit,expected_count",
+    [
+        pytest.param(0, 3, 3, id="first-page"),
+        pytest.param(3, 3, 3, id="second-page"),
+        pytest.param(6, 3, 2, id="third-page-partial"),
+        pytest.param(8, 3, 0, id="page-num-too-high-no-results"),
+        pytest.param(0, 1, 1, id="first-page-with-low-limit"),
+        pytest.param(0, 20, 8, id="first-page-with-high-limit"),
+    ],
+)
+def test_get_collections_pagination(
+    client: TestClient,
+    dbsession: OrmSession,
+    create_collection: Callable[..., Collection],
+    create_title: Callable[..., Title],
+    skip: int,
+    limit: int,
+    expected_count: int,
+):
+    """Test that get_collections works correctly with skip and limit"""
+
+    title1 = create_title(name="wikipedia_en_all")
+    title2 = create_title(name="ted_en_all")
+    title3 = create_title(name="gutenberg_en_all")
+
+    # Create 8 collections with varying numbers of titles/paths
+    for i in range(8):
+        if i % 3 == 0:
+            # Every third collection has multiple titles
+            create_collection(
+                title_ids_with_paths=[
+                    (title1.id, f"/path/to/collection{i}/wikipedia"),
+                    (title2.id, f"/path/to/collection{i}/ted"),
+                ]
+            )
+        elif i % 3 == 1:
+            # Some collections have a single title
+            create_collection(
+                title_ids_with_paths=[
+                    (title3.id, f"/path/to/collection{i}/gutenberg"),
+                ]
+            )
+        else:
+            # Some collections have no titles
+            create_collection()
+
+    dbsession.flush()
+
+    response = client.get(f"/v1/collections?skip={skip}&limit={limit}")
+    assert response.status_code == HTTPStatus.OK
+    response_doc = response.json()
+    assert "meta" in response_doc
+    assert response_doc["meta"]["count"] == 8
+    assert response_doc["meta"]["skip"] == skip
+    assert response_doc["meta"]["limit"] <= limit
+    assert response_doc["meta"]["page_size"] == expected_count
+    assert "items" in response_doc

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -287,6 +287,36 @@ def collection(
 
 
 @pytest.fixture
+def create_collection_title(
+    dbsession: OrmSession,
+    create_title: Callable[..., Title],
+    create_collection: Callable[..., Collection],
+) -> Callable[..., CollectionTitle]:
+    def _create_collection_title(
+        title: Title | None = None,
+        collection: Collection | None = None,
+        path: str | Path = "/test/path",
+    ) -> CollectionTitle:
+        if title is None:
+            title = create_title()
+
+        if collection is None:
+            collection = create_collection()
+
+        collection_title = CollectionTitle(
+            path=Path(path) if isinstance(path, str) else path
+        )
+        collection_title.title_id = title.id
+        collection_title.collection_id = collection.id
+
+        dbsession.add(collection_title)
+        dbsession.flush()
+        return collection_title
+
+    return _create_collection_title
+
+
+@pytest.fixture
 def create_user(
     dbsession: OrmSession,
     faker: Faker,

--- a/backend/tests/db/test_collections.py
+++ b/backend/tests/db/test_collections.py
@@ -1,0 +1,96 @@
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy.orm import Session as OrmSession
+
+from cms_backend.db.collection import (
+    get_collection_by_name,
+    get_collection_by_name_or_none,
+    get_collections,
+)
+from cms_backend.db.exceptions import RecordDoesNotExistError
+from cms_backend.db.models import Collection, Title
+
+
+def test_get_collection_by_name_or_none_not_found(
+    dbsession: OrmSession,
+):
+    """Returns None if the book does not exist"""
+    result = get_collection_by_name_or_none(dbsession, collection_name="test")
+    assert result is None
+
+
+def test_get_collection_by_name_not_found(
+    dbsession: OrmSession,
+):
+    with pytest.raises(RecordDoesNotExistError):
+        get_collection_by_name(dbsession, collection_name="test")
+
+
+def test_get_collection_by_name(
+    dbsession: OrmSession,
+    create_collection: Callable[..., Collection],
+):
+    """Returns the collection by name"""
+    collection = create_collection()
+    result = get_collection_by_name_or_none(dbsession, collection_name=collection.name)
+    assert result is not None
+    assert result.name == collection.name
+
+
+@pytest.mark.parametrize(
+    "skip,limit,expected_count",
+    [
+        pytest.param(0, 3, 3, id="first-page"),
+        pytest.param(3, 3, 3, id="second-page"),
+        pytest.param(6, 3, 2, id="third-page-partial"),
+        pytest.param(8, 3, 0, id="page-num-too-high-no-results"),
+        pytest.param(0, 1, 1, id="first-page-with-low-limit"),
+        pytest.param(0, 20, 8, id="first-page-with-high-limit"),
+    ],
+)
+def test_get_collections_pagination(
+    dbsession: OrmSession,
+    create_collection: Callable[..., Collection],
+    create_title: Callable[..., Title],
+    skip: int,
+    limit: int,
+    expected_count: int,
+):
+    """Test that get_collections works correctly with skip and limit"""
+
+    title1 = create_title(name="wikipedia_en_all")
+    title2 = create_title(name="ted_en_all")
+    title3 = create_title(name="gutenberg_en_all")
+
+    # Create 8 collections with varying numbers of titles/paths
+    for i in range(8):
+        if i % 3 == 0:
+            # Every third collection has multiple titles
+            create_collection(
+                title_ids_with_paths=[
+                    (title1.id, f"/path/to/collection{i}/wikipedia"),
+                    (title2.id, f"/path/to/collection{i}/ted"),
+                ]
+            )
+        elif i % 3 == 1:
+            # Some collections have a single title
+            create_collection(
+                title_ids_with_paths=[
+                    (title3.id, f"/path/to/collection{i}/gutenberg"),
+                ]
+            )
+        else:
+            # Some collections have no titles
+            create_collection()
+
+    dbsession.flush()
+
+    results = get_collections(
+        dbsession,
+        skip=skip,
+        limit=limit,
+    )
+    assert results.nb_records == 8
+    assert len(results.records) <= limit
+    assert len(results.records) == expected_count

--- a/frontend/src/components/CreateTitleDialog.vue
+++ b/frontend/src/components/CreateTitleDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="isOpen" max-width="600px" persistent>
+  <v-dialog v-model="isOpen" max-width="800px" persistent>
     <v-card>
       <v-card-title class="text-h5 pa-4 bg-primary">
         <span class="text-white">Create New Title</span>
@@ -16,14 +16,81 @@
             class="mb-2"
           />
 
-          <v-text-field
+          <v-select
             v-model="formData.maturity"
-            label="Title Maturity"
+            label="Maturity"
+            :items="maturityOptions"
             :rules="[rules.required]"
             variant="outlined"
             density="comfortable"
             class="mb-2"
           />
+
+          <v-divider class="my-4" />
+
+          <div class="d-flex align-center justify-space-between mb-3">
+            <h3 class="text-subtitle-1">Collection Paths</h3>
+            <v-btn
+              color="primary"
+              variant="text"
+              size="small"
+              prepend-icon="mdi-plus"
+              @click="addCollectionTitle"
+              :disabled="loadingCollections || !canAddMoreCollections"
+            >
+              Add Collection
+            </v-btn>
+          </div>
+
+          <v-alert
+            v-if="formData.collection_titles.length === 0"
+            type="info"
+            density="compact"
+            class="mb-4"
+          >
+            No collections added.
+          </v-alert>
+
+          <div
+            v-for="(collectionTitle, index) in formData.collection_titles"
+            :key="index"
+            class="mb-4 pa-3 border rounded"
+          >
+            <div class="d-flex align-center mb-2">
+              <span class="text-subtitle-2 flex-grow-1">Collection #{{ index + 1 }}</span>
+              <v-btn
+                icon="mdi-delete"
+                size="x-small"
+                variant="text"
+                color="error"
+                @click="removeCollectionTitle(index)"
+              />
+            </div>
+
+            <v-select
+              v-model="collectionTitle.collection_name"
+              label="Collection"
+              :items="getAvailableCollections(index)"
+              :rules="[rules.required]"
+              variant="outlined"
+              density="comfortable"
+              class="mb-2"
+              :loading="loadingCollections"
+              @update:model-value="handleCollectionChange(index)"
+            />
+
+            <v-select
+              v-model="collectionTitle.path"
+              label="Path"
+              :items="getAvailablePaths(collectionTitle.collection_name)"
+              :rules="[rules.required]"
+              variant="outlined"
+              density="comfortable"
+              :disabled="!collectionTitle.collection_name"
+              :hint="!collectionTitle.collection_name ? 'Please select a collection first' : ''"
+              persistent-hint
+            />
+          </div>
         </v-form>
 
         <v-alert v-if="error" type="error" class="mt-4" density="compact">
@@ -49,9 +116,10 @@
 </template>
 
 <script setup lang="ts">
+import { useCollectionsStore } from '@/stores/collections'
 import { useTitleStore } from '@/stores/title'
-import type { TitleCreate } from '@/types/title'
-import { computed, ref } from 'vue'
+import type { BaseTitleCollection, TitleCreate } from '@/types/title'
+import { computed, onMounted, ref, watch } from 'vue'
 
 interface Props {
   modelValue: boolean
@@ -65,15 +133,20 @@ const emit = defineEmits<{
 }>()
 
 const titleStore = useTitleStore()
+const collectionsStore = useCollectionsStore()
 
 const formRef = ref()
 const formValid = ref(false)
 const loading = ref(false)
+const loadingCollections = ref(false)
 const error = ref('')
+
+const maturityOptions = ['dev', 'robust']
 
 const formData = ref<TitleCreate>({
   name: '',
   maturity: 'dev',
+  collection_titles: [],
 })
 
 const isOpen = computed({
@@ -81,8 +154,87 @@ const isOpen = computed({
   set: (value) => emit('update:modelValue', value),
 })
 
+const collectionNames = computed(() => {
+  return collectionsStore.collections.map((collection) => collection.name)
+})
+
+const getAvailableCollections = (currentIndex: number) => {
+  // Get collections that are already used by other collection titles
+  const usedCollections = new Set<string>()
+  formData.value.collection_titles.forEach((ct, index) => {
+    if (index !== currentIndex && ct.collection_name) {
+      usedCollections.add(ct.collection_name)
+    }
+  })
+
+  return collectionNames.value.filter((name) => !usedCollections.has(name))
+}
+
+const canAddMoreCollections = computed(() => {
+  // Check if there are any collections that haven't been used yet
+  const usedCollections = new Set<string>()
+  formData.value.collection_titles.forEach((ct) => {
+    if (ct.collection_name) {
+      usedCollections.add(ct.collection_name)
+    }
+  })
+
+  return collectionNames.value.length > usedCollections.size
+})
+
+const getAvailablePaths = (collectionName: string) => {
+  if (!collectionName) return []
+
+  const selectedCollection = collectionsStore.collections.find(
+    (collection) => collection.name === collectionName,
+  )
+
+  return selectedCollection?.paths || []
+}
+
 const rules = {
   required: (value: string) => !!value || 'This field is required',
+}
+
+watch(isOpen, async (newValue) => {
+  if (newValue && collectionNames.value.length === 0) {
+    await fetchCollections()
+  }
+})
+
+async function fetchCollections() {
+  loadingCollections.value = true
+  try {
+    await collectionsStore.fetchCollections()
+  } catch (err) {
+    console.error('Failed to fetch collections', err)
+  } finally {
+    loadingCollections.value = false
+  }
+}
+
+function addCollectionTitle() {
+  const newCollectionTitle: BaseTitleCollection = {
+    collection_name: '',
+    path: '',
+  }
+  const newIndex = formData.value.collection_titles.length
+  formData.value.collection_titles.push(newCollectionTitle)
+
+  // Auto-select collection if only one is available
+  const availableCollections = getAvailableCollections(newIndex)
+  if (availableCollections.length === 1) {
+    newCollectionTitle.collection_name = availableCollections[0]
+  }
+}
+
+function removeCollectionTitle(index: number) {
+  formData.value.collection_titles.splice(index, 1)
+}
+
+function handleCollectionChange(index: number) {
+  // Reset path when collection changes
+  formData.value.collection_titles[index].path = ''
 }
 
 async function handleSubmit() {
@@ -113,8 +265,19 @@ function resetForm() {
   formData.value = {
     name: '',
     maturity: 'dev',
+    collection_titles: [],
   }
   error.value = ''
   formRef.value?.resetValidation()
 }
+
+onMounted(async () => {
+  await fetchCollections()
+})
 </script>
+
+<style scoped>
+.border {
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+}
+</style>

--- a/frontend/src/stores/book.ts
+++ b/frontend/src/stores/book.ts
@@ -1,19 +1,16 @@
-import constants from '@/constants'
 import { useAuthStore } from '@/stores/auth'
 import type { ListResponse, Paginator } from '@/types/base'
 import type { Book, BookLight } from '@/types/book'
 import type { ErrorResponse } from '@/types/errors'
 import { translateErrors } from '@/utils/errors'
 import { defineStore } from 'pinia'
-import { inject, ref } from 'vue'
-import type { VueCookies } from 'vue-cookies'
+import { ref } from 'vue'
 
 export const useBookStore = defineStore('book', () => {
-  const $cookies = inject<VueCookies>('$cookies')
   const book = ref<Book | null>(null)
   const errors = ref<string[]>([])
   const books = ref<BookLight[]>([])
-  const defaultLimit = ref<number>(Number($cookies?.get('books-table-limit') || 20))
+  const defaultLimit = ref<number>(Number(localStorage.getItem('books-table-limit') || 20))
   const paginator = ref<Paginator>({
     page: 1,
     page_size: defaultLimit.value,
@@ -80,7 +77,7 @@ export const useBookStore = defineStore('book', () => {
   }
 
   const savePaginatorLimit = (limit: number) => {
-    $cookies?.set('books-table-limit', limit, constants.COOKIE_LIFETIME_EXPIRY)
+    localStorage.setItem('books-table-limit', limit.toString())
   }
 
   return {

--- a/frontend/src/stores/collections.ts
+++ b/frontend/src/stores/collections.ts
@@ -1,0 +1,53 @@
+import { useAuthStore } from '@/stores/auth'
+import type { ListResponse, Paginator } from '@/types/base'
+import type { CollectionLight } from '@/types/collections'
+import type { ErrorResponse } from '@/types/errors'
+import { translateErrors } from '@/utils/errors'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useCollectionsStore = defineStore('collection', () => {
+  const errors = ref<string[]>([])
+  const collections = ref<CollectionLight[]>([])
+  const defaultLimit = ref<number>(Number(localStorage.getItem('collections-table-limit') || 20))
+  const paginator = ref<Paginator>({
+    page: 1,
+    page_size: defaultLimit.value,
+    skip: 0,
+    limit: defaultLimit.value,
+    count: 0,
+  })
+  const authStore = useAuthStore()
+
+  const fetchCollections = async (limit: number = 20, skip: number = 0) => {
+    const service = await authStore.getApiService('collections')
+    try {
+      const response = await service.get<null, ListResponse<CollectionLight>>('', {
+        params: { skip, limit },
+      })
+      collections.value = response.items
+      paginator.value = response.meta
+      errors.value = []
+      return collections.value
+    } catch (_error) {
+      console.error('Failed to fetch collections', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
+  const savePaginatorLimit = (limit: number) => {
+    localStorage.setItem('colle-table-limit', limit.toString())
+  }
+
+  return {
+    // State
+    defaultLimit,
+    collections,
+    paginator,
+    errors,
+    // Actions
+    fetchCollections,
+    savePaginatorLimit,
+  }
+})

--- a/frontend/src/stores/zimfarmNotification.ts
+++ b/frontend/src/stores/zimfarmNotification.ts
@@ -1,19 +1,18 @@
-import constants from '@/constants'
 import { useAuthStore } from '@/stores/auth'
 import type { ListResponse, Paginator } from '@/types/base'
 import type { ErrorResponse } from '@/types/errors'
 import type { ZimfarmNotification, ZimfarmNotificationLight } from '@/types/zimfarmNotification'
 import { translateErrors } from '@/utils/errors'
 import { defineStore } from 'pinia'
-import { inject, ref } from 'vue'
-import type { VueCookies } from 'vue-cookies'
+import { ref } from 'vue'
 
 export const useZimfarmNotificationStore = defineStore('zimfarm-notification', () => {
-  const $cookies = inject<VueCookies>('$cookies')
   const zimfarmNotification = ref<ZimfarmNotification | null>(null)
   const errors = ref<string[]>([])
   const zimfarmNotifications = ref<ZimfarmNotificationLight[]>([])
-  const defaultLimit = ref<number>(Number($cookies?.get('zimfarm-notifications-table-limit') || 20))
+  const defaultLimit = ref<number>(
+    Number(localStorage.getItem('zimfarm-notifications-table-limit') || 20),
+  )
   const paginator = ref<Paginator>({
     page: 1,
     page_size: defaultLimit.value,
@@ -91,7 +90,7 @@ export const useZimfarmNotificationStore = defineStore('zimfarm-notification', (
   }
 
   const savePaginatorLimit = (limit: number) => {
-    $cookies?.set('zimfarm-notifications-table-limit', limit, constants.COOKIE_LIFETIME_EXPIRY)
+    localStorage.setItem('zimfarm-notifications-table-limit', limit.toString())
   }
 
   return {

--- a/frontend/src/types/collections.ts
+++ b/frontend/src/types/collections.ts
@@ -1,0 +1,5 @@
+export interface CollectionLight {
+  id: string
+  name: string
+  paths: string[]
+}

--- a/frontend/src/types/title.ts
+++ b/frontend/src/types/title.ts
@@ -6,10 +6,13 @@ export interface WarehousePathInfo {
   warehouse_name: string
 }
 
-export interface TitleCollection {
-  collection_id: string
+export interface BaseTitleCollection {
   collection_name: string
   path: string
+}
+
+export interface TitleCollection extends BaseTitleCollection {
+  collection_id: string
 }
 
 export interface Title {
@@ -30,4 +33,5 @@ export interface TitleLight {
 export interface TitleCreate {
   name: string
   maturity: string
+  collection_titles: BaseTitleCollection[]
 }


### PR DESCRIPTION
## Rationale
This PR enhances the API/UI to create titles with a collection name and path
<img width="904" height="700" alt="Screenshot_20260206_104332" src="https://github.com/user-attachments/assets/1aa57a94-d816-41a9-a78e-946485993e89" />
<img width="908" height="682" alt="Screenshot_20260206_104322" src="https://github.com/user-attachments/assets/1927d554-bc7c-4ee5-8f0a-7289b5c31229" />


## Changes
- add endpoint to retrieve a list of collections
- enhance model schema to create title so that values are `NotEmptyString`s
- add methods to retrieve the collection by name
- remove occurences of using cookies to store user-preferences
- add store for collections

This closes #139 