### PR TITLE
add healthcheck for catalog generation

### DIFF
--- a/healthcheck/src/healthcheck/context.py
+++ b/healthcheck/src/healthcheck/context.py
@@ -32,3 +32,6 @@ class Context:
     cms_username = get_mandatory_env("CMS_USERNAME")
     cms_password = get_mandatory_env("CMS_PASSWORD")
     cms_database_url = get_mandatory_env("CMS_DATABASE_URL")
+    catalog_generation_timeout = parse_timespan(
+        os.getenv("CATALOG_GENERATION_TIMEOUT", default="10s")
+    )

--- a/healthcheck/src/healthcheck/router.py
+++ b/healthcheck/src/healthcheck/router.py
@@ -9,6 +9,7 @@ from fastapi.templating import Jinja2Templates
 
 from healthcheck.status.auth import authenticate
 from healthcheck.status.books import check_books_need_deletion, check_books_need_move
+from healthcheck.status.collections import check_catalog_generation
 from healthcheck.status.database import (
     check_database_connection,
 )
@@ -49,6 +50,7 @@ async def healthcheck(request: Request) -> HTMLResponse:
         zimfarm_notifications_check,
         file_needs_move_check,
         file_needs_deletion_check,
+        catalog_generation_check,
     ) = await gather(
         authenticate(),
         check_database_connection(),
@@ -56,6 +58,7 @@ async def healthcheck(request: Request) -> HTMLResponse:
         check_zimfarm_notifications_processed(),
         check_books_need_move(),
         check_books_need_deletion(),
+        check_catalog_generation(),
     )
 
     global_status = all(
@@ -66,6 +69,7 @@ async def healthcheck(request: Request) -> HTMLResponse:
             zimfarm_notifications_check.success,
             file_needs_move_check.success,
             file_needs_deletion_check.success,
+            catalog_generation_check.success,
         ]
     )
 
@@ -80,6 +84,7 @@ async def healthcheck(request: Request) -> HTMLResponse:
             "zimfarm_notifications": zimfarm_notifications_check,
             "file_needs_move": file_needs_move_check,
             "file_needs_deletion": file_needs_deletion_check,
+            "catalog_generation": catalog_generation_check,
         },
         status_code=HTTPStatus.OK if global_status else HTTPStatus.SERVICE_UNAVAILABLE,
     )

--- a/healthcheck/src/healthcheck/status/collections.py
+++ b/healthcheck/src/healthcheck/status/collections.py
@@ -1,0 +1,88 @@
+import asyncio
+from collections.abc import Coroutine
+from http import HTTPStatus
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import aiohttp
+from pydantic import BaseModel
+
+from healthcheck.context import Context
+from healthcheck.status import Result
+from healthcheck.status import status_logger as logger
+from healthcheck.status.requests import query_api
+
+
+class CollectionLightSchema(BaseModel):
+    """Collection for reading a collection with all the paths in it."""
+
+    id: UUID
+    name: str
+    paths: list[Path]
+
+
+class CollectionCatalogStatus(CollectionLightSchema):
+    status: HTTPStatus
+
+
+class CatalogStatus(BaseModel):
+    collections: list[CollectionCatalogStatus]
+
+
+async def check_collection_catalog_generation(
+    session: aiohttp.ClientSession, collection: CollectionLightSchema
+) -> CollectionCatalogStatus:
+    async with session.get(
+        f"{Context.cms_api_url}/{collection.id}/catalog.xml",
+        timeout=aiohttp.ClientTimeout(total=Context.catalog_generation_timeout),
+    ) as resp:
+        return CollectionCatalogStatus(
+            status=HTTPStatus(resp.status),
+            id=collection.id,
+            name=collection.name,
+            paths=collection.paths,
+        )
+
+
+async def check_catalog_generation() -> Result[CatalogStatus]:
+    """Check that generation of catalogs for all collections takes reasonable time."""
+    response = await query_api(
+        f"{Context.cms_api_url}/collections",
+        method="GET",
+        check_name="catalog-generation-status",
+    )
+
+    if not response.success:
+        return Result(
+            success=response.success,
+            status_code=response.status_code,
+            data=None,
+        )
+
+    collections = [
+        CollectionLightSchema.model_validate(item)
+        for item in response.json.get("items", [])
+    ]
+    async with aiohttp.ClientSession() as session:
+        tasks: list[Coroutine[Any, Any, CollectionCatalogStatus]] = []
+        for collection in collections:
+            tasks.append(check_collection_catalog_generation(session, collection))
+
+        catalog_statuses = await asyncio.gather(*tasks)
+        failures = [
+            catalog_status
+            for catalog_status in catalog_statuses
+            if catalog_status.status != HTTPStatus.OK
+        ]
+        if failures:
+            logger.error(
+                f"Failed to generate catalogs for the following collections: "
+                f"{','.join([failure.name for failure in failures])}"
+            )
+
+        return Result(
+            success=bool(failures),
+            status_code=HTTPStatus.OK if len(failures) > 0 else HTTPStatus.NOT_FOUND,
+            data=CatalogStatus(collections=catalog_statuses),
+        )

--- a/healthcheck/src/healthcheck/templates/healthcheck.html
+++ b/healthcheck/src/healthcheck/templates/healthcheck.html
@@ -138,6 +138,15 @@
             </td>
           </tr>
           <tr>
+            <th>Catalog Generation</th>
+            <td>Generation of catalogs for all collections</td>
+            <td
+              class="text-right {{ catalog_generation.success|status_class }}"
+            >
+              {{ catalog_generation.success|status_text }}
+            </td>
+          </tr>
+          <tr>
             <th>File Needs Move</th>
             <td>
               No files need operation, except those scheduled for deletion


### PR DESCRIPTION
## Rationale
This PR adds a healthcheck for the generation of catalogs for all collections. The check retrieves all collections and makes requests to generate their catalogs asynchronously

## Changes
- add check for generation of catalogs for all collections
- output result in html

This closes #158 