### PR TITLE
create initial user

### DIFF
--- a/backend/src/cms_backend/api/main.py
+++ b/backend/src/cms_backend/api/main.py
@@ -26,6 +26,8 @@ from cms_backend.db.exceptions import (
     RecordDoesNotExistError,
 )
 from cms_backend.utils.database import (
+    check_if_schema_is_up_to_date,
+    create_initial_user,
     upgrade_db_schema,
 )
 
@@ -34,6 +36,8 @@ from cms_backend.utils.database import (
 async def lifespan(_: FastAPI):
     if Context.alembic_upgrade_head_on_start:
         upgrade_db_schema()
+    check_if_schema_is_up_to_date()
+    create_initial_user()
     yield
 
 

--- a/backend/src/cms_backend/utils/database.py
+++ b/backend/src/cms_backend/utils/database.py
@@ -1,11 +1,14 @@
+import os
 import subprocess
 
 from alembic import config, script
 from alembic.runtime import migration
+from werkzeug.security import generate_password_hash
 
 from cms_backend import logger
 from cms_backend.context import Context
 from cms_backend.db import Session
+from cms_backend.db.user import create_user, get_user_by_username_or_none
 
 
 def check_if_schema_is_up_to_date():
@@ -30,3 +33,21 @@ def upgrade_db_schema():
     """Checks if Alembic schema has been applied to the DB"""
     logger.info(f"Upgrading database schema with config in {Context.base_dir}")
     subprocess.check_output(args=["alembic", "upgrade", "head"], cwd=Context.base_dir)
+
+
+def create_initial_user():
+    with Session.begin() as session:
+        username = os.getenv("INIT_USERNAME", default="admin")
+        password = os.getenv("INIT_PASSWORD", default="admin_pass")
+
+        user = get_user_by_username_or_none(session, username=username)
+        if user is None:
+            logger.info(f"creating initial user `{username}`")
+            create_user(
+                session=session,
+                username=username,
+                password_hash=generate_password_hash(password),
+                role="editor",
+            )
+        else:
+            logger.info(f"user {username} already exists")

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       CREATE_NEW_OAUTH_ACCOUNT: true
       AUTH_MODES: local
       JWT_SECRET: DH8kSxcflUVfNRdkEiJJCn2dOOKI3qfw
+      INIT_USERNAME: admin
+      INIT_PASSWORD: admin_pass
     command:
       - uvicorn
       - cms_backend.api.main:app


### PR DESCRIPTION
## Rationale

This PR adds functionality to create initial user account on application start. initial user details are set as env vars: `INIT_USERNAME` and `INIT_PASSWORD`