### PR TITLE
Move werkzeug as common backend dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "psycopg[binary,pool] == 3.2.11",
     "regex == 2025.10.23",
     "humanfriendly == 10.0",
+    "cryptography == 46.0.4",
+    "Werkzeug == 3.1.5",
 ]
 dynamic = ["version"]
 
@@ -31,8 +33,6 @@ dynamic = ["version"]
 api = [
     "fastapi[all] == 0.115.2",
     "PyJWT == 2.11.0",
-    "Werkzeug == 3.1.5",
-    "cryptography == 46.0.4"
 ]
 scripts = [
     "invoke == 2.2.0",


### PR DESCRIPTION
Move dependencies to "shared" backend dependencies since they are used in shared DB code `backend/src/cms_backend/utils/database.py`.