### PR TITLE
fix catalog generation and populate zims using id from info

### DIFF
--- a/backend/src/cms_backend/api/routes/collection.py
+++ b/backend/src/cms_backend/api/routes/collection.py
@@ -1,3 +1,4 @@
+import math
 from http import HTTPStatus
 from typing import Annotated
 from uuid import UUID
@@ -11,15 +12,17 @@ from cms_backend.api.routes.fields import LimitFieldMax200, SkipField
 from cms_backend.api.routes.models import ListResponse, calculate_pagination_metadata
 from cms_backend.db import gen_dbsession
 from cms_backend.db.collection import (
+    CollectionBook,
     get_collection,
     get_collection_by_name_or_none,
     get_latest_books_for_collection,
 )
 from cms_backend.db.collection import get_collections as db_get_collections
 from cms_backend.db.exceptions import RecordDoesNotExistError
-from cms_backend.db.models import Book
 from cms_backend.schemas import BaseModel
 from cms_backend.schemas.orms import CollectionLightSchema
+from cms_backend.utils.filename import construct_download_url
+from cms_backend.utils.zim import convert_tags
 
 router = APIRouter(prefix="/collections", tags=["collections"])
 
@@ -49,12 +52,13 @@ async def get_collections(
     )
 
 
-def _build_library_xml(books: list[Book]) -> str:
+def _build_library_xml(entries: list[CollectionBook]) -> str:
     """Build XML library catalog from books."""
     library_elem = ET.Element("library")
     library_elem.set("version", "20110515")
 
-    for book in books:
+    for entry in entries:
+        book, download_base_url, path, filename = entry
         if not book.zim_metadata:
             continue
 
@@ -62,7 +66,9 @@ def _build_library_xml(books: list[Book]) -> str:
 
         # Required attributes
         book_elem.set("id", str(book.id))
-        book_elem.set("size", str(book.size))
+        book_elem.set(
+            "size", str(math.ceil(book.size / 1024) if book.size > 0 else book.size)
+        )
         book_elem.set("mediaCount", str(book.media_count))
         book_elem.set("articleCount", str(book.article_count))
 
@@ -79,20 +85,18 @@ def _build_library_xml(books: list[Book]) -> str:
         # Optional tags - combine with underscores if present
         tags = zim_meta.get("Tags", "")
         if tags:
-            book_elem.set("tags", tags)
+            book_elem.set("tags", ";".join(convert_tags(tags)))
 
-        # Favicon and faviconMimeType - these are typically extracted from the ZIM
-        # but for now we'll use empty strings as the data structure doesn't contain them
         favicon = zim_meta.get("Illustration_48x48@1", "")
         if favicon:
             book_elem.set("favicon", favicon)
             book_elem.set("faviconMimeType", "image/png")
 
-        # URL - would need to be constructed from warehouse config
-        # For now, leaving empty as warehouse config mapping is not implemented
-        url = zim_meta.get("URL", "")
-        if url:
-            book_elem.set("url", url)
+        if download_base_url:
+            download_url = construct_download_url(download_base_url, path, filename)
+            book_elem.set("url", f"{download_url}.meta4")
+
+    ET.indent(library_elem, space="  ", level=0)
 
     return ET.tostring(library_elem, encoding="unicode")
 
@@ -123,8 +127,8 @@ async def get_library_catalog_xml(
             media_type="application/xml",
         )
 
-    books = get_latest_books_for_collection(session, collection.id)
-    xml_content = _build_library_xml(books)
+    entries = get_latest_books_for_collection(session, collection.id)
+    xml_content = _build_library_xml(entries)
 
     return Response(
         content=xml_content,

--- a/backend/src/cms_backend/utils/filename.py
+++ b/backend/src/cms_backend/utils/filename.py
@@ -1,6 +1,7 @@
 """Utilities for computing and managing book target filenames."""
 
 import re
+from pathlib import Path
 from uuid import UUID
 
 from sqlalchemy import select
@@ -175,3 +176,12 @@ def get_period_and_suffix_from_filename(filename: str) -> tuple[str, str]:
         raise ValueError("Unable to retrieve period from filename")
     groupdict = match.groupdict()
     return (groupdict["period"], groupdict["suffix"])
+
+
+def construct_download_url(base_url: str, subpath: Path, filename: str) -> str:
+    """Construct the download URL of a ZIM file based on it's subpath and filename."""
+    if subpath == Path(""):  # root folder
+        download_url = f"{base_url}/zim/{filename}"
+    else:
+        download_url = f"{base_url}/zim/{subpath}/{filename}"
+    return download_url

--- a/backend/src/cms_backend/utils/zim.py
+++ b/backend/src/cms_backend/utils/zim.py
@@ -1,20 +1,59 @@
 from typing import Any
 
 
+def get_missing_keys(payload: dict[str, Any], *keys: str) -> list[str]:
+    """Get the list of missing keys from payload."""
+    return [key for key in sorted(keys) if key not in payload or not payload.get(key)]
+
+
 def get_missing_metadata_keys(zim_metadata: dict[str, Any]) -> list[str]:
     """Get the the list of missing metadata keys from a zim."""
-    return [
-        key
-        for key in sorted(
-            [
-                "Name",
-                "Title",
-                "Creator",
-                "Publisher",
-                "Date",
-                "Description",
-                "Language",
-            ]
-        )
-        if key not in zim_metadata or not zim_metadata.get(key)
-    ]
+    return get_missing_keys(
+        zim_metadata,
+        "Name",
+        "Title",
+        "Creator",
+        "Publisher",
+        "Date",
+        "Description",
+        "Language",
+    )
+
+
+def convert_tags(tags_str: str) -> list[str]:
+    """List of tags expanded with libkiwix's additional hints for pic/vid/det/index
+
+    Copied from https://github.com/openzim/python-scraperlib/blob/99047776f5998ef4244a78afb5499e2c23890c70/src/zimscraperlib/zim/_libkiwix.py#L92
+    """
+    tags = tags_str.split(";")
+    tags_list: list[str] = []
+    pic_seen = vid_seen = det_seen = index_seen = False
+    for tag in tags:
+        # not upstream
+        if not tag:
+            continue
+        pic_seen |= tag == "nopic" or tag.startswith("_pictures:")
+        vid_seen |= tag == "novid" or tag.startswith("_videos:")
+        det_seen |= tag == "nodet" or tag.startswith("_details:")
+        index_seen |= tag.startswith("_ftindex")
+
+        if tag == "nopic":
+            tags_list.append("_pictures:no")
+        elif tag == "novid":
+            tags_list.append("_videos:no")
+        elif tag == "nodet":
+            tags_list.append("_details:no")
+        elif tag == "_ftindex":
+            tags_list.append("_ftindex:yes")
+        else:
+            tags_list.append(tag)
+
+    if not index_seen:
+        tags_list.append("_ftindex:no")
+    if not pic_seen:
+        tags_list.append("_pictures:yes")
+    if not vid_seen:
+        tags_list.append("_videos:yes")
+    if not det_seen:
+        tags_list.append("_details:yes")
+    return tags_list

--- a/backend/tests/utils/test_zim.py
+++ b/backend/tests/utils/test_zim.py
@@ -1,0 +1,51 @@
+import pytest
+
+from cms_backend.utils.zim import convert_tags, get_missing_keys
+
+
+@pytest.mark.parametrize(
+    ["keys", "expected_missing_keys"],
+    [
+        (["apples", "bananas"], ["apples"]),
+        (["bananas", "oranges"], []),
+    ],
+)
+def test_get_missing_keys(keys: list[str], expected_missing_keys: list[str]):
+    payload: dict[str, int] = {
+        "bananas": 1,
+        "oranges": 2,
+    }
+    assert get_missing_keys(payload, *keys) == expected_missing_keys
+
+
+def test_libkiwix_convert_tags():
+    assert convert_tags("") == [
+        "_ftindex:no",
+        "_pictures:yes",
+        "_videos:yes",
+        "_details:yes",
+    ]
+    assert convert_tags("nopic") == [
+        "_pictures:no",
+        "_ftindex:no",
+        "_videos:yes",
+        "_details:yes",
+    ]
+    assert convert_tags("novid") == [
+        "_videos:no",
+        "_ftindex:no",
+        "_pictures:yes",
+        "_details:yes",
+    ]
+    assert convert_tags("nodet") == [
+        "_details:no",
+        "_ftindex:no",
+        "_pictures:yes",
+        "_videos:yes",
+    ]
+    assert convert_tags("_ftindex") == [
+        "_ftindex:yes",
+        "_pictures:yes",
+        "_videos:yes",
+        "_details:yes",
+    ]


### PR DESCRIPTION
## Changes
- add helper function to retrieve missing keys from any dictionary and use to validate missing info keys and missing metdata keys from zim info
- convert tags using scraperlib logic
- divide sizes by 1024
- indent catalog xml output

This fixes #166 