### PR TITLE
decode oauth2 client generated tokens

### DIFF
--- a/backend/src/cms_backend/api/context.py
+++ b/backend/src/cms_backend/api/context.py
@@ -24,13 +24,18 @@ class Context:
     oauth_session_login_require_2fa = parse_bool(
         os.getenv("OAUTH_SESSION_LOGIN_REQUIRE_2FA", default="true")
     )
+    oauth_client_id = os.getenv(
+        "OAUTH_CLIENT_ID", default="310c5189-ce06-463c-9c55-46e822b5d642"
+    )
     create_new_oauth_account = parse_bool(
         os.getenv("CREATE_NEW_OAUTH_ACCOUNT", default="true")
     )
-    # List of authentication modes. Allowed values are "local", "oauth-session"
+    # List of authentication modes. Allowed values are
+    # - local
+    # - oauth
     auth_modes: list[str] = os.getenv(
         "AUTH_MODES",
-        default="oauth-session",
+        default="oauth",
     ).split(",")
 
     # Local Authentication JWT settings

--- a/backend/src/cms_backend/api/routes/dependencies.py
+++ b/backend/src/cms_backend/api/routes/dependencies.py
@@ -58,7 +58,7 @@ def get_current_user_or_none_with_session(
         if claims is None:
             return None
         user = get_user_by_id_or_none(session, user_id=claims.sub)
-        # If this is a kiwix token (wilkl  have a name), we create a new user account
+        # If this claim has a "name" property, we create a new user account
         if user is None and Context.create_new_oauth_account:
             if not claims.name:
                 raise UnauthorizedError("Token is missing 'profile' scope")


### PR DESCRIPTION
## Rationale
This PR adds a new token decoder for decoding oauth client generated tokens using client_id and client_secret. Such tokens will come from the zimfarm in order to create notifications on the CSM

## Changes
- add client_id env variable to ensure token client_id matches configured one
- add decoder to chain of decoders
