### PR TITLE
explicitly check if media_count is really missing from zim metadata

### DIFF
--- a/backend/maint-scripts/populate_cms_database.py
+++ b/backend/maint-scripts/populate_cms_database.py
@@ -384,9 +384,13 @@ def process_zim_file(
         logger.exception(f"encountered exception while reading {zim_file} metadata")
         return
 
-    missing_keys = get_missing_keys(
-        zim_info, "metadata", "id", "article_count", "media_count", "size"
-    )
+    missing_keys = get_missing_keys(zim_info, "metadata", "id", "article_count", "size")
+    # Check if media_count is in the zim_info. The get_missing_keys fn considers
+    # falsy values as absent but a media_count of 0 is acceptable.
+    if zim_info.get("media_count") is None:
+        logger.warning(f"{zim_file} is missing media_count information.")
+        return
+
     if missing_keys:
         logger.warning(
             f"{zim_file} is missing mandatory keys: {','.join(missing_keys)}"


### PR DESCRIPTION
## Changes
- while considering missing keys in present, restrict check to only check if key is in dictionary instead of considering the truthiness of it's value

This fixes #172 