### PR TITLE
consider empty flavour as None while creating book

### DIFF
--- a/backend/maint-scripts/populate_cms_database.py
+++ b/backend/maint-scripts/populate_cms_database.py
@@ -306,7 +306,7 @@ def _create_book_from_zim(
         zimcheck_result={},
         name=zim_metadata["Name"],
         date=zim_metadata["Date"],
-        flavour=zim_metadata.get("Flavour"),
+        flavour=zim_metadata.get("Flavour") or None,
         zimfarm_notification=None,
     )
     book.events.append(

--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -33,7 +33,7 @@ def create_book(
     # Extract metadata fields (optional fields may not be present)
     name = zim_metadata.get("Name")
     date = zim_metadata.get("Date")
-    flavour = zim_metadata.get("Flavour")
+    flavour = zim_metadata.get("Flavour") or None
 
     book = Book(
         id=book_id,


### PR DESCRIPTION
## Rationale
This PR considers `Flavour`s which are empty strings as `None` before storing them to the DB.

This closes #182 