### PR TITLE
improve cms book and title views, return download/view urls

### DIFF
--- a/backend/src/cms_backend/api/routes/books.py
+++ b/backend/src/cms_backend/api/routes/books.py
@@ -62,6 +62,14 @@ def get_books(
     )
 
 
+@router.get("/zims")
+def get_zim_urls(
+    zim_ids: Annotated[list[UUID], Query()],
+    session: Annotated[OrmSession, Depends(gen_dbsession)],
+) -> ZimUrlsSchema:
+    return db_get_zim_urls(session, zim_ids)
+
+
 @router.get("/{book_id}")
 def get_book(
     book_id: Annotated[UUID, Path()],
@@ -114,11 +122,3 @@ def get_book(
         current_locations=current_locations,
         target_locations=target_locations,
     )
-
-
-@router.get("/zims")
-def get_zim_urls(
-    zim_ids: Annotated[list[UUID], Query()],
-    session: Annotated[OrmSession, Depends(gen_dbsession)],
-) -> ZimUrlsSchema:
-    return db_get_zim_urls(session, zim_ids)

--- a/backend/src/cms_backend/api/routes/titles.py
+++ b/backend/src/cms_backend/api/routes/titles.py
@@ -10,17 +10,18 @@ from cms_backend.api.routes.fields import LimitFieldMax200, NotEmptyString, Skip
 from cms_backend.api.routes.models import ListResponse, calculate_pagination_metadata
 from cms_backend.db import gen_dbsession
 from cms_backend.db.title import create_title as db_create_title
+from cms_backend.db.title import create_title_full_schema
 from cms_backend.db.title import get_title_by_id as db_get_title_by_id
+from cms_backend.db.title import get_title_by_name as db_get_title_by_name
 from cms_backend.db.title import get_titles as db_get_titles
 from cms_backend.db.title import update_title as db_update_title
 from cms_backend.schemas import BaseModel
 from cms_backend.schemas.orms import (
     BaseTitleCollectionSchema,
-    BookLightSchema,
-    TitleCollectionSchema,
     TitleFullSchema,
     TitleLightSchema,
 )
+from cms_backend.utils.datetime import is_valid_uuid
 
 router = APIRouter(prefix="/titles", tags=["titles"])
 
@@ -80,43 +81,17 @@ def get_titles(
     )
 
 
-@router.get("/{title_id}")
+@router.get("/{title_identifier}")
 def get_title(
-    title_id: UUID,
+    title_identifier: str,
     session: OrmSession = Depends(gen_dbsession),
 ) -> TitleFullSchema:
     """Get a title by ID with full details including books"""
-    title = db_get_title_by_id(session, title_id=title_id)
-
-    return TitleFullSchema(
-        id=title.id,
-        name=title.name,
-        maturity=title.maturity,
-        events=title.events,
-        books=[
-            BookLightSchema(
-                id=book.id,
-                title_id=book.title_id,
-                needs_processing=book.needs_processing,
-                has_error=book.has_error,
-                needs_file_operation=book.needs_file_operation,
-                location_kind=book.location_kind,
-                created_at=book.created_at,
-                name=book.name,
-                date=book.date,
-                flavour=book.flavour,
-            )
-            for book in title.books
-        ],
-        collections=[
-            TitleCollectionSchema(
-                collection_id=tc.collection_id,
-                collection_name=tc.collection.name,
-                path=str(tc.path),
-            )
-            for tc in title.collections
-        ],
-    )
+    if is_valid_uuid(title_identifier):
+        title = db_get_title_by_id(session, title_id=UUID(title_identifier))
+    else:
+        title = db_get_title_by_name(session, name=title_identifier)
+    return create_title_full_schema(title)
 
 
 @router.post(

--- a/backend/src/cms_backend/db/title.py
+++ b/backend/src/cms_backend/db/title.py
@@ -17,10 +17,46 @@ from cms_backend.db.exceptions import RecordAlreadyExistsError, RecordDoesNotExi
 from cms_backend.db.models import CollectionTitle, Title
 from cms_backend.schemas.orms import (
     BaseTitleCollectionSchema,
+    BookLightSchema,
     ListResult,
+    TitleCollectionSchema,
+    TitleFullSchema,
     TitleLightSchema,
 )
 from cms_backend.utils.datetime import getnow
+
+
+def create_title_full_schema(title: Title) -> TitleFullSchema:
+    """Create a schema of a tilte."""
+    return TitleFullSchema(
+        id=title.id,
+        name=title.name,
+        maturity=title.maturity,
+        events=title.events,
+        books=[
+            BookLightSchema(
+                id=book.id,
+                title_id=book.title_id,
+                needs_processing=book.needs_processing,
+                has_error=book.has_error,
+                needs_file_operation=book.needs_file_operation,
+                location_kind=book.location_kind,
+                created_at=book.created_at,
+                name=book.name,
+                date=book.date,
+                flavour=book.flavour,
+            )
+            for book in title.books
+        ],
+        collections=[
+            TitleCollectionSchema(
+                collection_id=tc.collection_id,
+                collection_name=tc.collection.name,
+                path=str(tc.path),
+            )
+            for tc in title.collections
+        ],
+    )
 
 
 def get_title_by_id(session: OrmSession, *, title_id: UUID) -> Title:
@@ -36,6 +72,13 @@ def get_title_by_name_or_none(session: OrmSession, *, name: str) -> Title | None
     """Get a title by name if possible else None"""
 
     return session.scalars(select(Title).where(Title.name == name)).one_or_none()
+
+
+def get_title_by_name(session: OrmSession, *, name: str) -> Title:
+    """Get a title or raise RecordDoesNotExistError if it doesn't exist."""
+    if (title := get_title_by_name_or_none(session, name=name)) is None:
+        raise RecordDoesNotExistError(f"Title with name '{name}' does not exist")
+    return title
 
 
 def get_titles(

--- a/backend/src/cms_backend/utils/datetime.py
+++ b/backend/src/cms_backend/utils/datetime.py
@@ -1,6 +1,16 @@
 import datetime
+from uuid import UUID
 
 
 def getnow():
     """naive UTC now"""
     return datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
+
+
+def is_valid_uuid(identifier: str) -> bool:
+    """Check if string is a valid UUID"""
+    try:
+        UUID(identifier)
+    except ValueError:
+        return False
+    return True

--- a/frontend/src/components/BookStatus.vue
+++ b/frontend/src/components/BookStatus.vue
@@ -1,32 +1,70 @@
 <template>
-  <span v-if="isErrored" class="d-flex align-center">
-    <v-icon size="small" color="error" icon="mdi-alert-circle-outline"></v-icon>
-    <span class="text-caption ml-1">Errored</span>
-  </span>
-  <span v-else-if="isProcessing" class="d-flex align-center">
-    <v-icon size="small" color="grey" icon="mdi-clock-outline"></v-icon>
-    <span class="text-caption ml-1">Processing</span>
-  </span>
-  <span v-else-if="isMovingFiles" class="d-flex align-center">
-    <v-icon size="small" color="info" icon="mdi-truck-delivery-outline"></v-icon>
-    <span class="text-caption ml-1">Moving Files</span>
-    <v-chip size="x-small" class="ml-1" :color="locationColor">
-      {{ locationLabel }}
-    </v-chip>
-  </span>
-  <span v-else-if="!hasTitle" class="d-flex align-center">
-    <v-icon size="small" color="warning" icon="mdi-alert-circle-outline"></v-icon>
-    <span class="text-caption ml-1">Pending Title</span>
-    <v-chip size="x-small" class="ml-1" :color="locationColor">
-      {{ locationLabel }}
-    </v-chip>
-  </span>
-  <span v-else class="d-flex align-center">
-    <v-icon size="small" color="success" icon="mdi-check-circle"></v-icon>
-    <span class="text-caption ml-1">Published</span>
-    <v-chip size="x-small" class="ml-1" :color="locationColor">
-      {{ locationLabel }}
-    </v-chip>
+  <v-tooltip v-if="iconOnly" location="bottom">
+    <template #activator="{ props: tooltipProps }">
+      <span v-bind="tooltipProps">
+        <v-icon
+          v-if="isErrored"
+          size="small"
+          color="error"
+          icon="mdi-alert-circle-outline"
+        ></v-icon>
+        <v-icon
+          v-else-if="isProcessing"
+          size="small"
+          color="grey"
+          icon="mdi-clock-outline"
+        ></v-icon>
+        <v-icon
+          v-else-if="isMovingFiles"
+          size="small"
+          color="info"
+          icon="mdi-truck-delivery-outline"
+        ></v-icon>
+        <v-icon
+          v-else-if="!hasTitle"
+          size="small"
+          color="warning"
+          icon="mdi-alert-circle-outline"
+        ></v-icon>
+        <v-icon v-else size="small" color="success" icon="mdi-check-circle"></v-icon>
+      </span>
+    </template>
+    <div>
+      <div class="font-weight-bold">{{ statusLabel }}</div>
+      <div class="text-caption">{{ locationLabel }}</div>
+    </div>
+  </v-tooltip>
+
+  <span v-else>
+    <span v-if="isErrored">
+      <v-icon size="small" color="error" icon="mdi-alert-circle-outline"></v-icon>
+      <span class="text-caption ml-1">Errored</span>
+    </span>
+    <span v-else-if="isProcessing">
+      <v-icon size="small" color="grey" icon="mdi-clock-outline"></v-icon>
+      <span class="text-caption ml-1">Processing</span>
+    </span>
+    <span v-else-if="isMovingFiles">
+      <v-icon size="small" color="info" icon="mdi-truck-delivery-outline"></v-icon>
+      <span class="text-caption ml-1">Moving Files</span>
+      <v-chip size="x-small" class="ml-1" :color="locationColor">
+        {{ locationLabel }}
+      </v-chip>
+    </span>
+    <span v-else-if="!hasTitle">
+      <v-icon size="small" color="warning" icon="mdi-alert-circle-outline"></v-icon>
+      <span class="text-caption ml-1">Pending Title</span>
+      <v-chip size="x-small" class="ml-1" :color="locationColor">
+        {{ locationLabel }}
+      </v-chip>
+    </span>
+    <span v-else>
+      <v-icon size="small" color="success" icon="mdi-check-circle"></v-icon>
+      <span class="text-caption ml-1">Published</span>
+      <v-chip size="x-small" class="ml-1" :color="locationColor">
+        {{ locationLabel }}
+      </v-chip>
+    </span>
   </span>
 </template>
 
@@ -34,14 +72,28 @@
 import { computed } from 'vue'
 import type { Book, BookLight } from '@/types/book'
 
-const props = defineProps<{
-  book: Book | BookLight
-}>()
+const props = withDefaults(
+  defineProps<{
+    book: Book | BookLight
+    iconOnly?: boolean
+  }>(),
+  {
+    iconOnly: false,
+  },
+)
 
 const isErrored = computed(() => props.book.has_error)
 const isProcessing = computed(() => props.book.needs_processing && !props.book.has_error)
 const isMovingFiles = computed(() => props.book.needs_file_operation && !props.book.has_error)
 const hasTitle = computed(() => props.book.title_id)
+
+const statusLabel = computed(() => {
+  if (isErrored.value) return 'Errored'
+  if (isProcessing.value) return 'Processing'
+  if (isMovingFiles.value) return 'Moving Files'
+  if (!hasTitle.value) return 'Pending Title'
+  return 'Published'
+})
 
 const locationLabel = computed(() => {
   switch (props.book.location_kind) {

--- a/frontend/src/components/BookTable.vue
+++ b/frontend/src/components/BookTable.vue
@@ -49,9 +49,7 @@
 
         <template #[`item.id`]="{ item }">
           <router-link :to="{ name: 'book-detail', params: { id: item.id } }">
-            <span class="d-flex align-center">
-              {{ item.id }}
-            </span>
+            {{ item.id }}
           </router-link>
         </template>
 

--- a/frontend/src/components/EventsList.vue
+++ b/frontend/src/components/EventsList.vue
@@ -1,0 +1,69 @@
+<template>
+  <div v-if="events.length > 0">
+    <v-btn size="small" variant="outlined" class="mb-2" @click="copyToClipboard(events.join('\n'))">
+      <v-icon size="small" class="mr-1">mdi-content-copy</v-icon>
+      Copy All
+    </v-btn>
+
+    <v-list lines="one" density="compact" class="overflow-y-auto" style="max-height: 400px">
+      <v-list-item
+        v-for="(event, index) in parsedEvents"
+        :key="index"
+        :class="index % 2 === 0 ? 'bg-grey-lighten-4' : ''"
+        class="px-3 py-1"
+      >
+        <v-list-item-title class="text-body-2 text-wrap">
+          {{ event.timestamp }}: {{ event.message }}
+        </v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </div>
+  <span v-else class="text-grey">No events</span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useNotificationStore } from '@/stores/notification'
+
+interface Props {
+  events: string[]
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  events: () => [],
+})
+
+const notificationStore = useNotificationStore()
+
+interface ParsedEvent {
+  timestamp: string
+  message: string
+}
+
+const parsedEvents = computed((): ParsedEvent[] => {
+  return props.events.map((event) => {
+    // Events are typically formatted as: "TIMESTAMP: message"
+    const colonIndex = event.indexOf(':')
+    if (colonIndex !== -1) {
+      return {
+        timestamp: event.substring(0, colonIndex).trim(),
+        message: event.substring(colonIndex + 1).trim(),
+      }
+    }
+    // If no colon found, treat entire string as message
+    return {
+      timestamp: '',
+      message: event,
+    }
+  })
+})
+
+const copyToClipboard = async (text: string) => {
+  try {
+    await navigator.clipboard.writeText('```\n' + text + '\n```\n')
+    notificationStore.showSuccess('Copied to Clipboard!')
+  } catch {
+    notificationStore.showError('Unable to copy to clipboard 😞. Please copy it manually.')
+  }
+}
+</script>

--- a/frontend/src/components/TimestampLink.vue
+++ b/frontend/src/components/TimestampLink.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-tooltip v-if="tooltip" :text="formatDt(props.timestamp)">
+    <template v-slot:activator="{ props }">
+      <router-link v-bind="props" :to="to" class="text-decoration-none">
+        {{ displayText }}
+      </router-link>
+    </template>
+  </v-tooltip>
+  <router-link v-else :to="to" class="text-decoration-none">
+    {{ displayText }}
+  </router-link>
+</template>
+
+<script setup lang="ts">
+import { formatDt, fromNow } from '@/utils/format'
+import { computed } from 'vue'
+
+// Props
+interface Props {
+  id: string
+  route: string
+  timestamp: string
+  tooltip?: boolean
+  text?: string | null
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  tooltip: true,
+  text: null,
+})
+
+// Computed properties
+const to = computed(() => {
+  return { name: props.route, params: { id: props.id } }
+})
+
+const displayText = computed(() => {
+  return props.text === null ? fromNow(props.timestamp) : props.text
+})
+</script>

--- a/frontend/src/components/TitlesTable.vue
+++ b/frontend/src/components/TitlesTable.vue
@@ -53,7 +53,7 @@
         </template>
 
         <template #[`item.name`]="{ item }">
-          <router-link :to="{ name: 'title-detail', params: { id: item.id } }">
+          <router-link :to="{ name: 'title-detail', params: { id: item.name } }">
             <span class="d-flex align-center">
               {{ item.name }}
             </span>

--- a/frontend/src/components/ZimUrlButtons.vue
+++ b/frontend/src/components/ZimUrlButtons.vue
@@ -1,0 +1,46 @@
+<template>
+  <div v-if="loading" class="d-flex align-center">
+    <v-progress-circular indeterminate size="20" width="2" />
+    <span v-if="!compact" class="ml-2 text-grey">Loading URLs...</span>
+  </div>
+  <div v-else-if="urls && urls.length > 0">
+    <v-tooltip v-for="url in urls" :key="`${url.kind}-${url.collection}`" location="bottom">
+      <template #activator="{ props: tooltipProps }">
+        <v-btn
+          v-bind="tooltipProps"
+          :href="url.url"
+          target="_blank"
+          :icon="compact"
+          :prepend-icon="compact ? undefined : url.kind === 'download' ? 'mdi-download' : 'mdi-eye'"
+          :variant="compact ? 'text' : 'outlined'"
+          :size="compact ? 'x-small' : 'small'"
+          :class="compact ? '' : 'mr-2'"
+        >
+          <v-icon v-if="compact">{{ url.kind === 'download' ? 'mdi-download' : 'mdi-eye' }}</v-icon>
+          <span v-else>{{ url.kind === 'download' ? 'Download' : 'View' }}</span>
+        </v-btn>
+      </template>
+      <span>{{ url.kind === 'download' ? 'Download' : 'View' }}</span>
+    </v-tooltip>
+  </div>
+  <span v-else class="text-grey">{{ emptyText }}</span>
+</template>
+
+<script setup lang="ts">
+import type { ZimUrl } from '@/types/book'
+
+withDefaults(
+  defineProps<{
+    urls?: ZimUrl[]
+    loading?: boolean
+    compact?: boolean
+    emptyText?: string
+  }>(),
+  {
+    urls: undefined,
+    loading: false,
+    compact: false,
+    emptyText: 'No URLs available',
+  },
+)
+</script>

--- a/frontend/src/stores/book.ts
+++ b/frontend/src/stores/book.ts
@@ -1,6 +1,6 @@
 import { useAuthStore } from '@/stores/auth'
 import type { ListResponse, Paginator } from '@/types/base'
-import type { Book, BookLight } from '@/types/book'
+import type { Book, BookLight, ZimUrls } from '@/types/book'
 import type { ErrorResponse } from '@/types/errors'
 import { translateErrors } from '@/utils/errors'
 import { defineStore } from 'pinia'
@@ -80,6 +80,20 @@ export const useBookStore = defineStore('book', () => {
     localStorage.setItem('books-table-limit', limit.toString())
   }
 
+  const fetchZimUrls = async (zim_ids: string[]) => {
+    const service = await authStore.getApiService('books')
+    try {
+      const response = await service.get<null, ZimUrls>('/zims', {
+        params: { zim_ids },
+      })
+      return response
+    } catch (_error) {
+      console.error('Failed to fetch zim URLs', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
   return {
     // State
     defaultLimit,
@@ -91,5 +105,6 @@ export const useBookStore = defineStore('book', () => {
     fetchBook,
     fetchBooks,
     savePaginatorLimit,
+    fetchZimUrls,
   }
 })

--- a/frontend/src/stores/title.ts
+++ b/frontend/src/stores/title.ts
@@ -23,27 +23,6 @@ export const useTitleStore = defineStore('title', () => {
   })
   const authStore = useAuthStore()
 
-  const fetchTitle = async (titleName: string, forceReload: boolean = false) => {
-    const service = await authStore.getApiService('titles')
-    // Check if we already have the title and don't need to force reload
-    if (!forceReload && title.value && title.value.name === titleName) {
-      return title.value
-    }
-
-    try {
-      errors.value = []
-      // Clear current title until we receive the right one
-      title.value = null
-
-      const response = await service.get<null, Title>(`/${titleName}`)
-      title.value = response
-    } catch (_error) {
-      console.error('Failed to load title', _error)
-      errors.value = translateErrors(_error as ErrorResponse)
-    }
-    return title.value
-  }
-
   const fetchTitleById = async (titleId: string, forceReload: boolean = false) => {
     const service = await authStore.getApiService('titles')
     // Check if we already have the title and don't need to force reload
@@ -127,7 +106,6 @@ export const useTitleStore = defineStore('title', () => {
     paginator,
     errors,
     // Actions
-    fetchTitle,
     fetchTitleById,
     fetchTitles,
     savePaginatorLimit,

--- a/frontend/src/types/book.ts
+++ b/frontend/src/types/book.ts
@@ -44,3 +44,13 @@ export interface BookLight {
   date?: string
   flavour?: string
 }
+
+export interface ZimUrl {
+  kind: 'view' | 'download'
+  url: string
+  collection: string
+}
+
+export interface ZimUrls {
+  urls: Record<string, ZimUrl[]>
+}

--- a/frontend/src/views/BookView.vue
+++ b/frontend/src/views/BookView.vue
@@ -9,81 +9,136 @@
     </div>
 
     <div v-if="dataLoaded && book">
-      <v-table>
-        <tbody>
-          <tr>
-            <th class="text-left" style="width: 200px">Id</th>
-            <td>
-              <code>{{ book.id }}</code>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left" style="width: 200px">Title Id</th>
-            <td>
-              <code v-if="book.title_id">{{ book.title_id }}</code>
-              <span v-else class="text-grey">None</span>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left" style="width: 200px">Status</th>
-            <td>
-              <BookStatus :book="book" />
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left" style="width: 200px">Created</th>
-            <td>
-              <v-tooltip location="bottom">
-                <template #activator="{ props }">
-                  <span v-bind="props">
-                    {{ fromNow(book.created_at) }}
-                  </span>
-                </template>
-                <span>{{ formatDt(book.created_at) }}</span>
-              </v-tooltip>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left" style="width: 200px">Name</th>
-            <td>
-              <span v-if="book.name">{{ book.name }}</span>
-              <span v-else class="text-grey">-</span>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left" style="width: 200px">Flavour</th>
-            <td>
-              <span v-if="book.flavour">{{ book.flavour }}</span>
-              <span v-else class="text-grey">-</span>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left" style="width: 200px">Date</th>
-            <td>
-              <span v-if="book.date">{{ book.date }}</span>
-              <span v-else class="text-grey">-</span>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left" style="width: 200px">Article Count</th>
-            <td>
-              {{ book.article_count.toLocaleString() }}
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left" style="width: 200px">Media Count</th>
-            <td>
-              {{ book.media_count.toLocaleString() }}
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left" style="width: 200px">Size</th>
-            <td>
-              {{ formatBytes(book.size) }}
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left pa-4 align-top">
+      <div>
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Id</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <code>{{ book.id }}</code>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Title Id</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <router-link
+              v-if="book.title_id"
+              :to="{ name: 'title-detail', params: { id: book.title_id } }"
+            >
+              {{ book.title_id }}
+            </router-link>
+            <span v-else class="text-grey">None</span>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Status</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <BookStatus :book="book" />
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Created</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <v-tooltip location="bottom">
+              <template #activator="{ props }">
+                <span v-bind="props">
+                  {{ fromNow(book.created_at) }}
+                </span>
+              </template>
+              <span>{{ formatDt(book.created_at) }}</span>
+            </v-tooltip>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Name</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <span v-if="book.name">{{ book.name }}</span>
+            <span v-else class="text-grey">-</span>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Flavour</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <span v-if="book.flavour">{{ book.flavour }}</span>
+            <span v-else class="text-grey">-</span>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Date</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <span v-if="book.date">{{ book.date }}</span>
+            <span v-else class="text-grey">-</span>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">URLs</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <ZimUrlButtons :urls="zimUrls" :loading="loadingUrls" />
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Article Count</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            {{ book.article_count.toLocaleString() }}
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Media Count</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            {{ book.media_count.toLocaleString() }}
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Size</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            {{ formatBytes(book.size) }}
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">
               ZIM Metadata
               <v-btn
                 size="small"
@@ -94,13 +149,19 @@
                 <v-icon size="small" class="mr-1">mdi-content-copy</v-icon>
                 Copy
               </v-btn>
-            </th>
-            <td class="py-2">
+            </div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <div class="overflow-y-auto overflow-x-auto" style="max-height: 400px">
               <pre>{{ JSON.stringify(book.zim_metadata, null, 2) }}</pre>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left pa-4 align-top">
+            </div>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">
               Zimcheck Result
               <v-btn
                 size="small"
@@ -111,100 +172,88 @@
                 <v-icon size="small" class="mr-1">mdi-content-copy</v-icon>
                 Copy
               </v-btn>
-            </th>
-            <td class="py-2">
+            </div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <div class="overflow-y-auto overflow-x-auto" style="max-height: 400px">
               <pre>{{ JSON.stringify(book.zimcheck_result, null, 2) }}</pre>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left pa-4 align-top">Current Locations</th>
-            <td class="py-2">
-              <div v-if="book.current_locations.length > 0">
-                <v-table size="small">
-                  <thead>
-                    <tr>
-                      <th class="text-left">Warehouse</th>
-                      <th class="text-left">Folder</th>
-                      <th class="text-left">Filename</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr
-                      v-for="location in book.current_locations"
-                      :key="`current-${location.warehouse_name}-${location.path}`"
-                    >
-                      <td>{{ location.warehouse_name }}</td>
-                      <td>{{ location.path }}</td>
-                      <td>
-                        <code>{{ location.filename }}</code>
-                      </td>
-                    </tr>
-                  </tbody>
-                </v-table>
-              </div>
-              <div v-else class="text-grey">No current locations</div>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left pa-4 align-top">Target Locations</th>
-            <td class="py-2">
-              <div v-if="book.target_locations.length > 0">
-                <v-table size="small">
-                  <thead>
-                    <tr>
-                      <th class="text-left">Warehouse</th>
-                      <th class="text-left">Folder</th>
-                      <th class="text-left">Filename</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr
-                      v-for="location in book.target_locations"
-                      :key="`target-${location.warehouse_name}-${location.path}`"
-                    >
-                      <td>{{ location.warehouse_name }}</td>
-                      <td>{{ location.path }}</td>
-                      <td>
-                        <code>{{ location.filename }}</code>
-                      </td>
-                    </tr>
-                  </tbody>
-                </v-table>
-              </div>
-              <div v-else class="text-grey">No target locations</div>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left pa-4 align-top">
-              Events
-              <v-btn
-                size="small"
-                variant="outlined"
-                class="ml-2"
-                @click="copyToClipboard(book.events.join('\n'))"
-              >
-                <v-icon size="small" class="mr-1">mdi-content-copy</v-icon>
-                Copy
-              </v-btn>
-            </th>
-            <td class="py-2">
-              <pre v-for="event in book.events" :key="event">{{ event }}</pre>
-            </td>
-          </tr>
-        </tbody>
-      </v-table>
+            </div>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Current Locations</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <v-data-table
+              v-if="book.current_locations.length > 0"
+              :headers="locationHeaders"
+              :items="book.current_locations"
+              :items-per-page="-1"
+              :mobile="smAndDown"
+              density="compact"
+              hide-default-footer
+            >
+              <template #[`item.filename`]="{ item }">
+                <code>{{ item.filename }}</code>
+              </template>
+            </v-data-table>
+            <span v-else class="text-grey">No current locations</span>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Target Locations</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <v-data-table
+              v-if="book.target_locations.length > 0"
+              :headers="locationHeaders"
+              :items="book.target_locations"
+              :items-per-page="-1"
+              :mobile="smAndDown"
+              density="compact"
+              hide-default-footer
+            >
+              <template #[`item.filename`]="{ item }">
+                <code>{{ item.filename }}</code>
+              </template>
+            </v-data-table>
+            <span v-else class="text-grey">No target locations</span>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Events</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <EventsList :events="book.events" />
+          </v-col>
+        </v-row>
+      </div>
     </div>
   </v-container>
 </template>
 
 <script setup lang="ts">
 import BookStatus from '@/components/BookStatus.vue'
+import EventsList from '@/components/EventsList.vue'
+import ZimUrlButtons from '@/components/ZimUrlButtons.vue'
 import { useLoadingStore } from '@/stores/loading'
 import { useNotificationStore } from '@/stores/notification'
 import { useBookStore } from '@/stores/book'
-import type { Book } from '@/types/book'
+import type { Book, ZimUrl } from '@/types/book'
 import { formatDt, fromNow } from '@/utils/format'
 import { onMounted, ref } from 'vue'
+import { useDisplay } from 'vuetify'
+
+const { smAndDown } = useDisplay()
 
 const loadingStore = useLoadingStore()
 const bookStore = useBookStore()
@@ -213,12 +262,20 @@ const notificationStore = useNotificationStore()
 const error = ref<string | null>(null)
 const book = ref<Book | null>(null)
 const dataLoaded = ref(false)
+const loadingUrls = ref(false)
+const zimUrls = ref<ZimUrl[]>([])
 
 interface Props {
   id: string
 }
 
 const props = withDefaults(defineProps<Props>(), {})
+
+const locationHeaders = [
+  { title: 'Warehouse', value: 'warehouse_name', sortable: false },
+  { title: 'Folder', value: 'path', sortable: false },
+  { title: 'Filename', value: 'filename', sortable: false },
+]
 
 const loadData = async () => {
   loadingStore.startLoading('Fetching book...')
@@ -238,6 +295,27 @@ const loadData = async () => {
   if (loadingStore.isLoading) {
     loadingStore.stopLoading()
   }
+
+  if (book.value) {
+    loadZimUrls()
+  }
+}
+
+const loadZimUrls = async () => {
+  if (!book.value) return
+
+  loadingUrls.value = true
+
+  const response = await bookStore.fetchZimUrls([book.value.id])
+  if (response?.urls && response.urls[book.value.id]) {
+    zimUrls.value = response.urls[book.value.id]
+  } else {
+    for (const err of bookStore.errors) {
+      notificationStore.showError(err)
+    }
+  }
+
+  loadingUrls.value = false
 }
 
 onMounted(async () => {

--- a/frontend/src/views/TitleView.vue
+++ b/frontend/src/views/TitleView.vue
@@ -15,110 +15,116 @@
         </v-btn>
       </div>
 
-      <v-table>
-        <tbody>
-          <tr>
-            <th class="text-left" style="width: 200px">Id</th>
-            <td>
-              <code>{{ title.id }}</code>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left" style="width: 200px">Name</th>
-            <td>
-              {{ title.name }}
-            </td>
-          </tr>
+      <div>
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Id</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <code>{{ title.id }}</code>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
 
-          <tr>
-            <th class="text-left" style="width: 200px">Collections</th>
-            <td>
-              <div v-if="title.collections && title.collections.length > 0">
-                <div
-                  v-for="tc in title.collections"
-                  :key="`collection-${tc.collection_id}`"
-                  class="mb-2"
-                >
-                  {{ tc.collection_name }}: {{ tc.path }}
-                </div>
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Name</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            {{ title.name }}
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
+
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Collections</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <div v-if="title.collections && title.collections.length > 0">
+              <div
+                v-for="tc in title.collections"
+                :key="`collection-${tc.collection_id}`"
+                class="mb-2"
+              >
+                {{ tc.collection_name }}: {{ tc.path }}
               </div>
-              <span v-else class="text-grey">This title is not published in any collection</span>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left" style="width: 200px">Maturity</th>
-            <td>
-              {{ title.maturity }}
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left pa-4 align-top">
-              Events
-              <v-btn
-                v-if="title.events.length > 0"
-                size="small"
-                variant="outlined"
-                class="ml-2"
-                @click="copyToClipboard(title.events.join('\n'))"
-              >
-                <v-icon size="small" class="mr-1">mdi-content-copy</v-icon>
-                Copy
-              </v-btn>
-            </th>
-            <td class="py-2">
-              <pre v-for="event in title.events" :key="event">{{ event }}</pre>
-              <span v-if="title.events.length == 0" class="text-grey">No events</span>
-            </td>
-          </tr>
-          <tr>
-            <th class="text-left pa-4 align-top">Books</th>
-            <td class="py-2">
-              <v-data-table
-                v-if="title.books.length > 0"
-                :headers="bookHeaders"
-                :items="sortedBooks"
-                :items-per-page="-1"
-                density="compact"
-                class="table-borderless"
-                hide-default-footer
-              >
-                <template #[`item.id`]="{ item }">
-                  <router-link :to="{ name: 'book-detail', params: { id: item.id } }">
-                    <code>{{ item.id }}</code>
-                  </router-link>
-                </template>
+            </div>
+            <span v-else class="text-grey">This title is not published in any collection</span>
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
 
-                <template #[`item.created_at`]="{ item }">
-                  <v-tooltip location="bottom">
-                    <template #activator="{ props }">
-                      <span v-bind="props">
-                        {{ fromNow(item.created_at) }}
-                      </span>
-                    </template>
-                    <span>{{ formatDt(item.created_at) }}</span>
-                  </v-tooltip>
-                </template>
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Maturity</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            {{ title.maturity }}
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
 
-                <template #[`item.name`]="{ item }">
-                  <span v-if="item.name">{{ item.name }}</span>
-                  <span v-else class="text-grey">-</span>
-                </template>
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Events</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <EventsList :events="title.events" />
+          </v-col>
+        </v-row>
+        <v-divider class="my-2"></v-divider>
 
-                <template #[`item.date`]="{ item }">
-                  <span v-if="item.date">{{ item.date }}</span>
-                  <span v-else class="text-grey">-</span>
-                </template>
+        <v-row no-gutters class="py-2">
+          <v-col cols="12" md="3">
+            <div class="text-subtitle-2">Books</div>
+          </v-col>
+          <v-col cols="12" md="9">
+            <v-data-table
+              v-if="title.books.length > 0"
+              :headers="bookHeaders"
+              :items="sortedBooks"
+              :items-per-page="-1"
+              :mobile="smAndDown"
+              density="compact"
+              hide-default-footer
+            >
+              <template #[`item.created_at`]="{ item }">
+                <TimestampLink :id="item.id" :route="'book-detail'" :timestamp="item.created_at" />
+              </template>
 
-                <template #[`item.flavour`]="{ item }">
-                  <span v-if="item.flavour">{{ item.flavour }}</span>
-                  <span v-else class="text-grey">-</span>
-                </template>
-              </v-data-table>
-              <span v-else class="text-grey">No books</span>
-            </td>
-          </tr>
-        </tbody>
-      </v-table>
+              <template #[`item.status`]="{ item }">
+                <BookStatus :book="item" :icon-only="true" />
+              </template>
+
+              <template #[`item.name`]="{ item }">
+                <span v-if="item.name">{{ item.name }}</span>
+                <span v-else class="text-grey">-</span>
+              </template>
+
+              <template #[`item.date`]="{ item }">
+                <span v-if="item.date">{{ item.date }}</span>
+                <span v-else class="text-grey">-</span>
+              </template>
+
+              <template #[`item.flavour`]="{ item }">
+                <span v-if="item.flavour">{{ item.flavour }}</span>
+                <span v-else class="text-grey">-</span>
+              </template>
+
+              <template #[`item.urls`]="{ item }">
+                <ZimUrlButtons
+                  :urls="zimUrls[item.id]"
+                  :loading="loadingUrls"
+                  :compact="true"
+                  empty-text=""
+                />
+              </template>
+            </v-data-table>
+            <span v-else class="text-grey">No books</span>
+          </v-col>
+        </v-row>
+      </div>
     </div>
 
     <EditTitleDialog v-model="editDialogOpen" :title="title" @updated="handleTitleUpdated" />
@@ -126,17 +132,26 @@
 </template>
 
 <script setup lang="ts">
+import BookStatus from '@/components/BookStatus.vue'
 import EditTitleDialog from '@/components/EditTitleDialog.vue'
+import EventsList from '@/components/EventsList.vue'
+import TimestampLink from '@/components/TimestampLink.vue'
+import ZimUrlButtons from '@/components/ZimUrlButtons.vue'
 import { useLoadingStore } from '@/stores/loading'
 import { useNotificationStore } from '@/stores/notification'
 import { useTitleStore } from '@/stores/title'
+import { useBookStore } from '@/stores/book'
 import { useAuthStore } from '@/stores/auth'
 import type { Title } from '@/types/title'
-import { formatDt, fromNow } from '@/utils/format'
+import type { ZimUrl } from '@/types/book'
 import { computed, onMounted, ref } from 'vue'
+import { useDisplay } from 'vuetify'
+
+const { smAndDown } = useDisplay()
 
 const loadingStore = useLoadingStore()
 const titleStore = useTitleStore()
+const bookStore = useBookStore()
 const notificationStore = useNotificationStore()
 const authStore = useAuthStore()
 
@@ -144,6 +159,8 @@ const error = ref<string | null>(null)
 const title = ref<Title | null>(null)
 const dataLoaded = ref(false)
 const editDialogOpen = ref(false)
+const loadingUrls = ref(false)
+const zimUrls = ref<Record<string, ZimUrl[]>>({})
 
 interface Props {
   id: string
@@ -152,12 +169,12 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {})
 
 const bookHeaders = [
-  { title: 'Created', value: 'created_at', sortable: true },
-  { title: 'Name', value: 'name', sortable: true },
-  { title: 'Flavour', value: 'flavour', sortable: true },
-  { title: 'Date', value: 'date', sortable: true },
-  { title: 'Status', value: 'status', sortable: true },
-  { title: 'ID', value: 'id', sortable: false },
+  { title: 'Created', value: 'created_at', sortable: false },
+  { title: 'Name', value: 'name', sortable: false },
+  { title: 'Flavour', value: 'flavour', sortable: false },
+  { title: 'Status', value: 'status', sortable: false },
+  { title: 'Date', value: 'date', sortable: false },
+  { title: 'URLs', value: 'urls', sortable: false },
 ]
 
 const canEditTitle = computed(() => authStore.hasPermission('title', 'update'))
@@ -187,20 +204,33 @@ const loadData = async (forceReload: boolean = false) => {
   if (loadingStore.isLoading) {
     loadingStore.stopLoading()
   }
+
+  if (title.value?.books && title.value.books.length > 0) {
+    loadZimUrls()
+  }
+}
+
+const loadZimUrls = async () => {
+  if (!title.value?.books || title.value.books.length === 0) return
+
+  loadingUrls.value = true
+  const bookIds = title.value.books.map((book) => book.id)
+
+  const response = await bookStore.fetchZimUrls(bookIds)
+  if (response?.urls) {
+    zimUrls.value = response.urls
+  } else {
+    for (const err of bookStore.errors) {
+      notificationStore.showError(err)
+    }
+  }
+
+  loadingUrls.value = false
 }
 
 onMounted(async () => {
   await loadData()
 })
-
-const copyToClipboard = async (text: string) => {
-  try {
-    await navigator.clipboard.writeText('```\n' + text + '\n```\n')
-    notificationStore.showSuccess(`Copied to Clipboard!`)
-  } catch {
-    notificationStore.showError(`Unable to copy to clipboard 😞. Please copy it manually.`)
-  }
-}
 
 const openEditDialog = () => {
   editDialogOpen.value = true


### PR DESCRIPTION
## Rationale
This PR enhances the CMS views with new components and re-orders the way data is rendered across the book and title views. It adds support for showing links to view/download a zim on the UI and further enhances the API to allow retrieving a book by name instead of by only ID

## Changes
- move get_zim_urls route function to top so it doesn't get shadowed by the route which expects a param.
- retrieve titles by name or ID
- add `TimestampLink` component for showing link to an item with it's timestamp as a tooltip since. Used in title detail view to show the links to books as it helps reduce the number of columns for the table and avoids showing the ID explicitly since it's most likely not going to be used by a user
- show book view/download buttons in title detail and book detail views
- adapt `BookStatus` component to support icon only mode which renders text over tooltip
- add component to render events in striped rows
- keep tables responsive

<img width="1118" height="821" alt="Screenshot_20260227_124640" src="https://github.com/user-attachments/assets/030a99d9-69de-48f2-acd8-9a117da7ce70" />
<img width="996" height="517" alt="Screenshot_20260227_123149" src="https://github.com/user-attachments/assets/caae5ad4-a1ec-47f0-80c8-2a5f644b3c4e" />



This closes #186 