### PR TITLE
single view link for multiple books with same title and flavour

### DIFF
--- a/backend/src/cms_backend/db/books.py
+++ b/backend/src/cms_backend/db/books.py
@@ -117,6 +117,8 @@ def get_zim_urls(session: OrmSession, zim_ids: list[UUID]) -> ZimUrlsSchema:
     stmt = (
         select(
             Book.id.label("book_id"),
+            Title.id.label("title_id"),
+            Book.flavour.label("book_flavour"),
             Collection.name.label("collection_name"),
             Collection.download_base_url,
             Collection.view_base_url,
@@ -143,10 +145,14 @@ def get_zim_urls(session: OrmSession, zim_ids: list[UUID]) -> ZimUrlsSchema:
                 Book.needs_file_operation.is_(False),
             )
         )
+        .order_by(Title.id, Book.flavour, Book.created_at.desc())
     )
 
     result = ZimUrlsSchema(urls={zim_id: [] for zim_id in zim_ids})
 
+    # Filter to keep only one view link for the latest book per title+flavour
+    # combination
+    seen: set[tuple[str | None, str | None]] = set()
     for row in session.execute(stmt).all():
         if row.download_base_url:
             result.urls[row.book_id].append(
@@ -162,15 +168,20 @@ def get_zim_urls(session: OrmSession, zim_ids: list[UUID]) -> ZimUrlsSchema:
             )
 
         if row.view_base_url:
-            filename_without_suffix = (
-                row.filename[:-4] if row.filename.endswith(".zim") else row.filename
-            )
-            result.urls[row.book_id].append(
-                ZimUrlSchema(
-                    kind="view",
-                    url=AnyUrl(f"{row.view_base_url}/viewer#{filename_without_suffix}"),
-                    collection=row.collection_name,
+            key = (row.title_id, row.book_flavour)
+            if key not in seen:
+                seen.add(key)
+                filename_without_suffix = (
+                    row.filename[:-4] if row.filename.endswith(".zim") else row.filename
                 )
-            )
+                result.urls[row.book_id].append(
+                    ZimUrlSchema(
+                        kind="view",
+                        url=AnyUrl(
+                            f"{row.view_base_url}/viewer#{filename_without_suffix}"
+                        ),
+                        collection=row.collection_name,
+                    )
+                )
 
     return result

--- a/backend/tests/db/test_books.py
+++ b/backend/tests/db/test_books.py
@@ -1,3 +1,4 @@
+import datetime
 from collections.abc import Callable
 from pathlib import Path
 from uuid import uuid4
@@ -15,6 +16,7 @@ from cms_backend.db.models import (
     Title,
     Warehouse,
 )
+from cms_backend.utils.datetime import getnow
 
 
 def test_get_book_or_none_not_found(
@@ -357,3 +359,70 @@ def test_get_zim_urls_book_with_subpath(
     assert view_url is not None
     assert str(view_url.url) == "https://browse.library.kiwix.org/viewer#test_en_all"
     assert view_url.collection == collection.name
+
+
+def test_get_zim_urls_single_view_link_for_multiple_books_with_same_title_flavour(
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+    create_title: Callable[..., Title],
+    create_warehouse: Callable[..., Warehouse],
+    create_collection: Callable[..., Collection],
+    create_collection_title: Callable[..., CollectionTitle],
+    create_book_location: Callable[..., BookLocation],
+):
+    warehouse = create_warehouse()
+    title = create_title(name="test_en_all")
+    collection = create_collection(
+        warehouse=warehouse,
+        download_base_url="https://download.kiwix.org",
+        view_base_url="https://browse.library.kiwix.org",
+    )
+    create_collection_title(title=title, collection=collection, path=Path(""))
+    now = getnow()
+
+    book1 = create_book(
+        zim_metadata={"Name": title.name},
+        created_at=now - datetime.timedelta(days=7),
+        flavour="test",
+    )
+    book1.title = title
+    title.books.append(book1)
+
+    create_book_location(
+        book=book1,
+        warehouse_id=warehouse.id,
+        path=Path(""),
+        filename="test_en_all.zim",
+        status="current",
+    )
+
+    book2 = create_book(
+        zim_metadata={"Name": title.name},
+        created_at=now - datetime.timedelta(days=14),
+        flavour="test",
+    )
+    book2.title = title
+    title.books.append(book2)
+
+    create_book_location(
+        book=book2,
+        warehouse_id=warehouse.id,
+        path=Path(""),
+        filename="test_en_all-2.zim",
+        status="current",
+    )
+
+    dbsession.flush()
+
+    result = get_zim_urls(dbsession, zim_ids=[book1.id, book2.id])
+
+    assert book1.id in result.urls
+    assert book2.id in result.urls
+    assert len(result.urls[book1.id]) == 2
+    assert len(result.urls[book2.id]) == 1
+
+    book1_view_url = next((u for u in result.urls[book1.id] if u.kind == "view"), None)
+    assert book1_view_url is not None
+
+    book2_view_url = next((u for u in result.urls[book2.id] if u.kind == "view"), None)
+    assert book2_view_url is None


### PR DESCRIPTION
## Rationale
This PR enhances the logic to get zim (book) URLs to return only one view link for multiple books that have the same title and flavour. This view link is assigned only to the latest book.

## Changes
- order query to fetch records by (book_name, book_flavour and creation_date)
- assign one view link per title/flavour combination

<img width="1116" height="443" alt="Screenshot_20260302_044922" src="https://github.com/user-attachments/assets/70b159fd-d1f8-4abc-98e9-48353ffc2ced" />


This closes #189 