### PR TITLE
deduplicate catalog entries based on title_id and book flavour

### DIFF
--- a/backend/src/cms_backend/db/collection.py
+++ b/backend/src/cms_backend/db/collection.py
@@ -81,6 +81,7 @@ def get_latest_books_for_collection(
     stmt = (
         select(
             Book,
+            Title.id.label("title_id"),
             Collection.download_base_url,
             CollectionTitle.path.label("subpath"),
             BookLocation.filename,
@@ -100,14 +101,14 @@ def get_latest_books_for_collection(
                 Collection.id == collection_id,
             )
         )
-        .order_by(Book.name, Book.flavour, Book.created_at.desc())
+        .order_by(Title.id, Book.flavour, Book.created_at.desc())
     )
     # Filter to keep only the latest book per name+flavour combination
     seen: set[tuple[str | None, str | None]] = set()
     latest_books: list[CollectionBook] = []
     for row in session.execute(stmt).all():
         book = cast(Book, row.Book)
-        key = (book.name, book.flavour)
+        key = (row.title_id, book.flavour)
         if key not in seen:
             seen.add(key)
             latest_books.append(

--- a/backend/tests/api/routes/test_library.py
+++ b/backend/tests/api/routes/test_library.py
@@ -491,3 +491,89 @@ def test_get_collection_catalog_xml_latest_book_per_name_flavour(
     # Should be the newer book
     assert books[0].get("title") == "Wikipedia New"
     assert books[0].get("id") == str(newer_book.id)
+
+
+def test_get_collection_catalog_xml_grouping_by_title_id_not_name(
+    client: TestClient,
+    dbsession: OrmSession,
+    create_collection: Callable[..., Collection],
+    create_title: Callable[..., Title],
+    create_book: Callable[..., Book],
+    create_book_location: Callable[..., BookLocation],
+    create_warehouse: Callable[..., Warehouse],
+):
+    """Test that grouping is done by title_id, not by title name.
+
+    This demonstrates that renaming a title doesn't affect the catalog output
+    because books are grouped by title_id and flavour, not by the title name.
+    """
+    warehouse = create_warehouse()
+    collection = create_collection(warehouse=warehouse)
+
+    title = create_title(name="wiki_original")
+
+    path = "wikipedia"
+    _add_title_to_collection(dbsession, collection, title, path)
+
+    older_book = create_book(
+        created_at=getnow() - timedelta(days=30),
+        zim_metadata={
+            "Name": "wiki_original",
+            "Title": "Wikipedia Old Version",
+            "Description": "Old version with original name",
+            "Language": "eng",
+            "Creator": "Kiwix",
+            "Publisher": "Kiwix",
+            "Date": "2024-12-01",
+            "Flavour": "maxi",
+        },
+    )
+    older_book.title = title
+    older_book.needs_processing = False
+    older_book.has_error = False
+    older_book.needs_file_operation = False
+    dbsession.flush()
+
+    create_book_location(
+        book=older_book, warehouse_id=warehouse.id, path=path, status="current"
+    )
+
+    # Rename the title
+    title.name = "wiki_renamed"
+    dbsession.flush()
+
+    newer_book = create_book(
+        created_at=getnow(),
+        zim_metadata={
+            "Name": "wiki_renamed",
+            "Title": "Wikipedia New Version",
+            "Description": "New version with renamed title",
+            "Language": "eng",
+            "Creator": "Kiwix",
+            "Publisher": "Kiwix",
+            "Date": "2025-01-15",
+            "Flavour": "maxi",
+        },
+    )
+    newer_book.title = title
+    newer_book.needs_processing = False
+    newer_book.has_error = False
+    newer_book.needs_file_operation = False
+    dbsession.flush()
+
+    create_book_location(
+        book=newer_book, warehouse_id=warehouse.id, path=path, status="current"
+    )
+    dbsession.flush()
+
+    response = client.get(f"/v1/collections/{collection.id}/catalog.xml")
+    assert response.status_code == HTTPStatus.OK
+
+    root = ET.fromstring(response.text)
+    books = list(root.findall("book"))
+
+    assert len(books) == 1
+
+    assert books[0].get("title") == "Wikipedia New Version"
+    assert books[0].get("id") == str(newer_book.id)
+    assert books[0].get("name") == "wiki_renamed"


### PR DESCRIPTION
## Rationale
This PR refactors the logic to get latest books for collection to group books based on title_id and book flavour instead of book name and flavour.

This closes #191 