### PR TITLE
edit title name

### DIFF
--- a/backend/src/cms_backend/api/routes/titles.py
+++ b/backend/src/cms_backend/api/routes/titles.py
@@ -56,6 +56,7 @@ class TitleCreateSchema(BaseTitleCreateUpdateSchema):
 
 
 class TitleUpdateSchema(BaseTitleCreateUpdateSchema):
+    name: NotEmptyString | None = None
     maturity: Literal["dev", "robust"] | None = None
 
 
@@ -128,6 +129,7 @@ def update_title(
     title = db_update_title(
         session,
         title_id=title_id,
+        name=title_data.name,
         maturity=title_data.maturity,
         collection_titles=title_data.collection_titles,
     )

--- a/backend/src/cms_backend/db/title.py
+++ b/backend/src/cms_backend/db/title.py
@@ -176,8 +176,9 @@ def update_title(
     session: OrmSession,
     *,
     title_id: UUID,
-    maturity: str | None,
-    collection_titles: list[BaseTitleCollectionSchema] | None,
+    maturity: str | None = None,
+    name: str | None = None,
+    collection_titles: list[BaseTitleCollectionSchema] | None = None,
 ) -> Title:
     """Update a title's maturity and/or collection_titles.
 
@@ -195,6 +196,12 @@ def update_title(
         title.events.append(
             f"{getnow()}: maturity updated from {old_maturity} to {maturity}"
         )
+
+    # Update name if provided
+    if name and name != title.name:
+        old_name = title.name
+        title.name = name
+        title.events.append(f"{getnow()}: name updated from {old_name} to {name}")
 
     # Determine if collection titles changed
     collection_titles_changed = False

--- a/backend/tests/api/routes/test_titles.py
+++ b/backend/tests/api/routes/test_titles.py
@@ -319,17 +319,18 @@ def test_update_title_required_permissions(
     assert response.status_code == expected_status_code
 
 
-def test_update_title_maturity(
+def test_update_title(
     client: TestClient,
     create_title: Callable[..., Title],
     access_token: str,
 ):
-    """Test updating a title's maturity"""
+    """Test updating a title's data"""
     title = create_title(name="wikipedia_en_test")
     assert title.maturity == "dev"
 
     update_data = {
         "maturity": "robust",
+        "name": "wikipedia_en",
     }
 
     response = client.patch(
@@ -341,5 +342,5 @@ def test_update_title_maturity(
     data = response.json()
 
     assert data["id"] == str(title.id)
-    assert data["name"] == "wikipedia_en_test"
+    assert data["name"] == "wikipedia_en"
     assert data["maturity"] == "robust"

--- a/backend/tests/db/test_title.py
+++ b/backend/tests/db/test_title.py
@@ -89,6 +89,22 @@ def test_get_titles_skip(
     assert len(results.records) == expected_count
 
 
+def test_update_title_name(
+    dbsession: OrmSession,
+    create_title: Callable[..., Title],
+    create_collection: Callable[..., Collection],
+):
+    """Test updating a title's name"""
+    create_collection(name="wikipedia")
+
+    title = create_title(name="wikipedia_en_test")
+
+    update_title(dbsession, title_id=title.id, name="wikipedia_en")
+
+    dbsession.refresh(title)
+    assert title.name == "wikipedia_en"
+
+
 def test_update_title_collection_titles(
     dbsession: OrmSession,
     create_title: Callable[..., Title],

--- a/frontend/src/components/EditTitleDialog.vue
+++ b/frontend/src/components/EditTitleDialog.vue
@@ -16,7 +16,7 @@ const props = defineProps<Props>()
 
 const emit = defineEmits<{
   'update:modelValue': [value: boolean]
-  updated: []
+  updated: [updatedTitle: { id: string; name: string }]
 }>()
 
 const isOpen = computed({
@@ -24,7 +24,7 @@ const isOpen = computed({
   set: (value) => emit('update:modelValue', value),
 })
 
-function handleUpdated() {
-  emit('updated')
+function handleUpdated(updatedTitle: { id: string; name: string }) {
+  emit('updated', updatedTitle)
 }
 </script>

--- a/frontend/src/components/TitleFormDialog.vue
+++ b/frontend/src/components/TitleFormDialog.vue
@@ -10,12 +10,10 @@
           <v-text-field
             v-model="formData.name"
             label="Title Name"
-            :rules="isEditMode ? [] : [rules.required]"
+            :rules="[rules.required]"
             variant="outlined"
             density="comfortable"
             class="mb-2"
-            :disabled="isEditMode"
-            :readonly="isEditMode"
           />
 
           <v-select
@@ -132,7 +130,7 @@
 <script setup lang="ts">
 import { useCollectionsStore } from '@/stores/collections'
 import { useTitleStore } from '@/stores/title'
-import type { BaseTitleCollection, Title, TitleCreate } from '@/types/title'
+import type { BaseTitleCollection, Title, TitleCreate, TitleUpdate } from '@/types/title'
 import { computed, onMounted, ref, watch } from 'vue'
 
 interface Props {
@@ -147,7 +145,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   'update:modelValue': [value: boolean]
   created: []
-  updated: []
+  updated: [updatedTitle: { id: string; name: string }]
 }>()
 
 const titleStore = useTitleStore()
@@ -240,8 +238,9 @@ const hasCollectionChanges = computed(() => {
 const hasChanges = computed(() => {
   if (!isEditMode.value) return true
 
+  const nameChanged = formData.value.name !== props.title?.name
   const maturityChanged = formData.value.maturity !== props.title?.maturity
-  return maturityChanged || hasCollectionChanges.value
+  return nameChanged || maturityChanged || hasCollectionChanges.value
 })
 
 const rules = {
@@ -332,11 +331,22 @@ async function handleSubmit() {
 
   try {
     if (isEditMode.value && props.title) {
-      await titleStore.updateTitle(props.title.id, {
-        maturity: formData.value.maturity,
-        collection_titles: formData.value.collection_titles,
-      })
-      emit('updated')
+      const updatePayload: Partial<TitleUpdate> = {}
+
+      if (formData.value.name !== props.title.name) {
+        updatePayload.name = formData.value.name
+      }
+
+      if (formData.value.maturity !== props.title.maturity) {
+        updatePayload.maturity = formData.value.maturity
+      }
+
+      if (hasCollectionChanges.value) {
+        updatePayload.collection_titles = formData.value.collection_titles
+      }
+
+      const response = await titleStore.updateTitle(props.title.id, updatePayload)
+      emit('updated', { id: response.id, name: response.name })
     } else {
       await titleStore.createTitle(formData.value)
       emit('created')

--- a/frontend/src/stores/title.ts
+++ b/frontend/src/stores/title.ts
@@ -86,7 +86,7 @@ export const useTitleStore = defineStore('title', () => {
     }
   }
 
-  const updateTitle = async (titleId: string, titleData: TitleUpdate) => {
+  const updateTitle = async (titleId: string, titleData: Partial<TitleUpdate>) => {
     const service = await authStore.getApiService('titles')
     try {
       errors.value = []

--- a/frontend/src/types/title.ts
+++ b/frontend/src/types/title.ts
@@ -37,6 +37,7 @@ export interface TitleCreate {
 }
 
 export interface TitleUpdate {
+  name?: string
   maturity: string
   collection_titles: BaseTitleCollection[]
 }

--- a/frontend/src/views/TitleView.vue
+++ b/frontend/src/views/TitleView.vue
@@ -146,8 +146,10 @@ import type { Title } from '@/types/title'
 import type { ZimUrl } from '@/types/book'
 import { computed, onMounted, ref } from 'vue'
 import { useDisplay } from 'vuetify'
+import { useRouter } from 'vue-router'
 
 const { smAndDown } = useDisplay()
+const router = useRouter()
 
 const loadingStore = useLoadingStore()
 const titleStore = useTitleStore()
@@ -236,8 +238,13 @@ const openEditDialog = () => {
   editDialogOpen.value = true
 }
 
-const handleTitleUpdated = async () => {
+const handleTitleUpdated = async (updatedTitle: { id: string; name: string }) => {
   notificationStore.showSuccess('Title updated successfully!')
+
+  // If the name changed, navigate to the new URL
+  if (updatedTitle.name !== props.id) {
+    await router.push({ name: 'title-detail', params: { id: updatedTitle.name } })
+  }
   await loadData(true)
 }
 </script>


### PR DESCRIPTION
## Rationale
This PR enhances the API and UI with the ability to update a title's name

## Changes
- make parameters for update to be optional
- update route if name was changed so that when update is fetched, it won't be with old name

This closes #194 