### PR TITLE
Add books languages endpoint

### DIFF
--- a/backend/src/cms_backend/api/routes/books.py
+++ b/backend/src/cms_backend/api/routes/books.py
@@ -13,10 +13,11 @@ from cms_backend.db.book import delete_book as db_delete_book
 from cms_backend.db.book import get_book as db_get_book
 from cms_backend.db.book import move_book as db_move_book
 from cms_backend.db.book import recover_book as db_recover_book
+from cms_backend.db.books import get_book_languages as db_get_book_languages
 from cms_backend.db.books import get_books as db_get_books
 from cms_backend.db.books import get_zim_urls as db_get_zim_urls
 from cms_backend.schemas import BaseModel
-from cms_backend.schemas.models import ZimUrlsSchema
+from cms_backend.schemas.models import BookLanguagesSchema, ZimUrlsSchema
 from cms_backend.schemas.orms import (
     BookFullSchema,
     BookLightSchema,
@@ -78,6 +79,13 @@ def get_zim_urls(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> ZimUrlsSchema:
     return db_get_zim_urls(session, zim_ids)
+
+
+@router.get("/languages")
+def get_book_languages(
+    session: Annotated[OrmSession, Depends(gen_dbsession)],
+) -> BookLanguagesSchema:
+    return db_get_book_languages(session)
 
 
 @router.get("/{book_id}")

--- a/backend/src/cms_backend/db/books.py
+++ b/backend/src/cms_backend/db/books.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session as OrmSession
 from cms_backend.context import Context
 from cms_backend.db import count_from_stmt
 from cms_backend.db.models import Book, BookLocation, Collection, CollectionTitle, Title
-from cms_backend.schemas.models import ZimUrlSchema, ZimUrlsSchema
+from cms_backend.schemas.models import BookLanguagesSchema, ZimUrlSchema, ZimUrlsSchema
 from cms_backend.schemas.orms import BookLightSchema, ListResult
 from cms_backend.utils.filename import construct_download_url
 
@@ -228,3 +228,20 @@ def get_zim_urls(session: OrmSession, zim_ids: list[UUID]) -> ZimUrlsSchema:
                 )
 
     return result
+
+
+def get_book_languages(session: OrmSession) -> BookLanguagesSchema:
+    """Get the sorted list of language codes used by production books."""
+    stmt = select(Book.zim_metadata).where(Book.location_kind == "prod")
+
+    languages: set[str] = set()
+    for zim_metadata in session.scalars(stmt):
+        language_value = zim_metadata.get("Language")
+        if not isinstance(language_value, str):
+            continue
+
+        for language in language_value.split(","):
+            if normalized_language := language.strip():
+                languages.add(normalized_language)
+
+    return BookLanguagesSchema(languages=sorted(languages))

--- a/backend/src/cms_backend/schemas/models.py
+++ b/backend/src/cms_backend/schemas/models.py
@@ -16,3 +16,7 @@ class ZimUrlSchema(BaseModel):
 
 class ZimUrlsSchema(BaseModel):
     urls: dict[UUID, list[ZimUrlSchema]]
+
+
+class BookLanguagesSchema(BaseModel):
+    languages: list[str]

--- a/backend/tests/api/routes/test_books.py
+++ b/backend/tests/api/routes/test_books.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend.db.models import Book, Title
 
@@ -256,6 +257,35 @@ def test_get_books_filter_by_id(
     response_doc = response.json()
     assert response_doc["meta"]["count"] == 1
     assert response_doc["items"][0]["id"] == str(book1.id)
+
+
+def test_get_book_languages(
+    client: TestClient,
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+):
+    """Test books languages endpoint returns sorted distinct production languages."""
+    prod_book = create_book(zim_metadata={"Language": "eng, fra"})
+    prod_book.location_kind = "prod"
+
+    other_prod_book = create_book(zim_metadata={"Language": " deu ,eng, ,spa "})
+    other_prod_book.location_kind = "prod"
+
+    create_book(zim_metadata={"Language": "hin"})
+    staging_book = create_book(zim_metadata={"Language": "ita"})
+    staging_book.location_kind = "staging"
+
+    blank_language_book = create_book(zim_metadata={"Language": " , "})
+    blank_language_book.location_kind = "prod"
+
+    missing_language_book = create_book(zim_metadata={"Name": "no-language"})
+    missing_language_book.location_kind = "prod"
+
+    dbsession.flush()
+
+    response = client.get("/v1/books/languages")
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == {"languages": ["deu", "eng", "fra", "spa"]}
 
 
 def test_get_book_by_id(

--- a/backend/tests/db/test_books.py
+++ b/backend/tests/db/test_books.py
@@ -14,7 +14,7 @@ from cms_backend.db.book import (
     move_book,
     recover_book,
 )
-from cms_backend.db.books import get_books, get_zim_urls
+from cms_backend.db.books import get_book_languages, get_books, get_zim_urls
 from cms_backend.db.exceptions import RecordDoesNotExistError
 from cms_backend.db.models import (
     Book,
@@ -370,6 +370,34 @@ def test_get_zim_urls(
     assert view_url is not None
     assert str(view_url.url) == "https://browse.library.kiwix.org/viewer#test_en_all"
     assert view_url.collection == collection.name
+
+
+def test_get_book_languages(
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+):
+    """Return the sorted distinct language codes from production books only."""
+    prod_book = create_book(zim_metadata={"Language": "eng, fra"})
+    prod_book.location_kind = "prod"
+
+    other_prod_book = create_book(zim_metadata={"Language": " deu ,eng, ,spa "})
+    other_prod_book.location_kind = "prod"
+
+    create_book(zim_metadata={"Language": "hin"})
+    staging_book = create_book(zim_metadata={"Language": "ita"})
+    staging_book.location_kind = "staging"
+
+    blank_language_book = create_book(zim_metadata={"Language": " , "})
+    blank_language_book.location_kind = "prod"
+
+    missing_language_book = create_book(zim_metadata={"Name": "no-language"})
+    missing_language_book.location_kind = "prod"
+
+    dbsession.flush()
+
+    result = get_book_languages(dbsession)
+
+    assert result.languages == ["deu", "eng", "fra", "spa"]
 
 
 def test_get_zim_urls_book_with_subpath(


### PR DESCRIPTION

## Summary

This PR adds a new public endpoint to expose the list of ISO639-3 language codes currently used by books managed in the CMS.

The new endpoint is:

`GET /v1/books/languages`

It returns a sorted list of distinct language codes collected from production books only.

Example response:

```json
{
  "languages": ["deu", "eng", "fra", "spa"]
}
```

## What changed

- added `GET /v1/books/languages` under the existing books API
- added a backend helper to collect language codes from `Book.zim_metadata["Language"]`
- restricted the result set to books with `location_kind = "prod"`
- split comma-separated language values
- trimmed surrounding whitespace
- ignored empty values
- removed duplicates
- returned the final list in sorted order
- added API and DB-level tests for the new behavior

## Why

The `Language` metadata can contain multiple comma-separated ISO639-3 codes. Exposing the normalized set of codes used by production books makes it easier for downstream consumers to know which values they may encounter and validate their support accordingly.

## Notes

- only production books are considered
- the endpoint is public, in line with the intended use of this metadata
- the route is placed under `/v1/books` because the source of truth is `Book.zim_metadata`

## Testing

I verified the change with:

- `hatch run lint:black`
- `hatch run lint:ruff`
- `hatch run check:pyright`
- targeted DB test for language extraction
- targeted API test for the new endpoint
- full backend test suite with CI-equivalent environment settings
- backend Docker image builds for API, mill, and shuttle
- container smoke checks for mill and shuttle entrypoints
- API container healthcheck after applying Alembic migrations

Full backend result:

- `267 passed`

## Related

Closes #102 