### PR TITLE
Move cross volume mounts does not work, let's copy and delete

### DIFF
--- a/backend/src/cms_backend/shuttle/move_files.py
+++ b/backend/src/cms_backend/shuttle/move_files.py
@@ -105,7 +105,8 @@ def move_book_files(session: OrmSession, book: Book):
         )
 
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(current_path, target_path)
+        shutil.copy(current_path, target_path)
+        current_path.unlink()
         logger.debug(f"Moved book {book.id} from {current_path} to {target_path}")
         book.events.append(
             f"{getnow()}: moved book from {current_location.full_str} to "

--- a/backend/tests/shuttle/test_move_files.py
+++ b/backend/tests/shuttle/test_move_files.py
@@ -129,14 +129,14 @@ def test_move_book_files_copy_operation(
             patch("cms_backend.shuttle.move_files.ShuttleContext")
         )
         mock_copy = stack.enter_context(patch("shutil.copy"))
-        stack.enter_context(patch("shutil.move"))
+        mock_unlink = stack.enter_context(patch("pathlib.Path.unlink"))
         stack.enter_context(patch("pathlib.Path.mkdir"))
 
         mock_context.local_warehouse_paths = {warehouse.id: Path("/warehouse")}
         move_book_files(dbsession, book)
 
-        # Should have copied once (target_loc2 > current_loc)
-        assert mock_copy.call_count == 1
+        assert mock_copy.call_count == 2
+        assert mock_unlink.call_count == 1
 
     assert book.needs_processing is False
     assert book.has_error is False
@@ -173,14 +173,16 @@ def test_move_book_files_move_operation(
         mock_context = stack.enter_context(
             patch("cms_backend.shuttle.move_files.ShuttleContext")
         )
-        mock_move = stack.enter_context(patch("shutil.move"))
+        mock_copy = stack.enter_context(patch("shutil.copy"))
+        mock_unlink = stack.enter_context(patch("pathlib.Path.unlink"))
         stack.enter_context(patch("pathlib.Path.mkdir"))
 
         mock_context.local_warehouse_paths = {warehouse.id: Path("/warehouse")}
         move_book_files(dbsession, book)
 
         # Should have moved once
-        assert mock_move.call_count == 1
+        assert mock_copy.call_count == 1
+        assert mock_unlink.call_count == 1
 
     assert book.needs_processing is False
     assert book.has_error is False
@@ -220,7 +222,7 @@ def test_move_book_files_delete_operation(
         mock_context = stack.enter_context(
             patch("cms_backend.shuttle.move_files.ShuttleContext")
         )
-        stack.enter_context(patch("shutil.move"))
+        mock_copy = stack.enter_context(patch("shutil.copy"))
         stack.enter_context(patch("pathlib.Path.mkdir"))
         mock_unlink = stack.enter_context(patch("pathlib.Path.unlink"))
 
@@ -228,7 +230,8 @@ def test_move_book_files_delete_operation(
         move_book_files(dbsession, book)
 
         # Should have deleted one extra location
-        assert mock_unlink.call_count == 1
+        assert mock_copy.call_count == 1
+        assert mock_unlink.call_count == 2
 
     assert book.needs_processing is False
     assert book.has_error is False
@@ -263,7 +266,8 @@ def test_move_book_files_updates_book_locations(
         mock_context = stack.enter_context(
             patch("cms_backend.shuttle.move_files.ShuttleContext")
         )
-        stack.enter_context(patch("shutil.move"))
+        stack.enter_context(patch("shutil.copy"))
+        stack.enter_context(patch("pathlib.Path.unlink"))
         stack.enter_context(patch("pathlib.Path.mkdir"))
 
         mock_context.local_warehouse_paths = {warehouse.id: Path("/warehouse")}


### PR DESCRIPTION
Since in k8s we are using different volume mounts (e.g. for quarantine and Kiwix collection), we cannot move files, we need to copy and then delete the original file.

Obviously this has some disk consumption implications, but we will live with it