### PR TITLE
sort books by multiple columns

### DIFF
--- a/backend/src/cms_backend/db/books.py
+++ b/backend/src/cms_backend/db/books.py
@@ -40,7 +40,13 @@ def get_books(
         Book.name,
         Book.date,
         Book.flavour,
-    ).order_by(Book.id)
+    ).order_by(
+        Book.has_error.desc(),
+        Book.location_kind,
+        Book.needs_file_operation.desc(),
+        Book.created_at.desc(),
+        Book.id,
+    )
 
     if book_id is not None:
         stmt = stmt.where(Book.id.cast(String).ilike(f"%{book_id}%"))


### PR DESCRIPTION
## Rationale

This PR implements the sorting order described in https://github.com/openzim/cms/issues/205#issue-4050909565.

Books are sorted by:
- `has_error` (truthy values come first)
- `location_kind`: alpahabetical sort, thus, quarantine comes before staging
- `needs_file_operation`: (truthy values come first)
- `created_at`: in descending order


This closes #205 