### PR TITLE
compute etags for collection catalog xml response

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "regex == 2025.10.23",
     "humanfriendly == 10.0",
     "Werkzeug == 3.1.5",
+    "xxhash == 3.7.0",
 ]
 dynamic = ["version"]
 

--- a/backend/src/cms_backend/api/routes/collection.py
+++ b/backend/src/cms_backend/api/routes/collection.py
@@ -2,6 +2,7 @@ from http import HTTPStatus
 from typing import Annotated
 from uuid import UUID
 
+import xxhash
 from fastapi import APIRouter, Depends, Path, Query
 from fastapi.responses import Response
 from sqlalchemy.orm import Session as OrmSession
@@ -48,12 +49,9 @@ async def get_collections(
     )
 
 
-@router.get("/{collection_id_or_name}/catalog.xml")
-async def get_library_catalog_xml(
-    collection_id_or_name: Annotated[str, Path()],
-    session: Annotated[OrmSession, Depends(gen_dbsession)],
-):
-    """Get collection catalog as XML library by collection ID (UUID) or name."""
+def _get_catalog_xml_content(
+    collection_id_or_name: str, session: OrmSession
+) -> tuple[str, int]:
     # Try to parse as UUID first, otherwise treat as name
     collection = None
     try:
@@ -67,18 +65,45 @@ async def get_library_catalog_xml(
         collection = get_collection_by_name_or_none(session, collection_id_or_name)
 
     if collection is None:
-        return Response(
-            content='<?xml version="1.0" encoding="UTF-8"?>'
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?>'
             '<library version="20110515"></library>',
-            status_code=HTTPStatus.NOT_FOUND,
-            media_type="application/xml",
+            HTTPStatus.NOT_FOUND,
         )
 
     entries = get_latest_books_for_collection(session, collection.id)
     xml_content = build_library_xml(entries)
 
+    return xml_content, HTTPStatus.OK
+
+
+@router.get("/{collection_id_or_name}/catalog.xml")
+async def get_library_catalog_xml(
+    collection_id_or_name: Annotated[str, Path()],
+    session: Annotated[OrmSession, Depends(gen_dbsession)],
+):
+    """Get collection catalog as XML library by collection ID (UUID) or name."""
+    xml_content, status_code = _get_catalog_xml_content(collection_id_or_name, session)
+    etag = xxhash.xxh64(xml_content.encode("utf-8")).hexdigest()
+
     return Response(
         content=xml_content,
-        status_code=HTTPStatus.OK,
+        status_code=status_code,
+        media_type="application/xml",
+        headers={"ETag": f"{etag}"},
+    )
+
+
+@router.head("/{collection_id_or_name}/catalog.xml")
+async def head_library_catalog_xml(
+    collection_id_or_name: Annotated[str, Path()],
+    session: Annotated[OrmSession, Depends(gen_dbsession)],
+):
+    """Get collection catalog as XML library by collection ID (UUID) or name."""
+    xml_content, status_code = _get_catalog_xml_content(collection_id_or_name, session)
+    etag = xxhash.xxh64(xml_content.encode("utf-8")).hexdigest()
+    return Response(
+        status_code=status_code,
+        headers={"ETag": f"{etag}"},
         media_type="application/xml",
     )

--- a/backend/src/cms_backend/api/routes/staging.py
+++ b/backend/src/cms_backend/api/routes/staging.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from typing import Annotated
 
+import xxhash
 from fastapi import APIRouter, Depends
 from fastapi.responses import Response
 from sqlalchemy.orm import Session as OrmSession
@@ -20,9 +21,25 @@ async def get_library_catalog_xml(
 
     entries = get_staging_books_library_data(session)
     xml_content = build_library_xml(entries, staging=True)
+    etag = xxhash.xxh64(xml_content.encode("utf-8")).hexdigest()
 
     return Response(
         content=xml_content,
+        headers={"ETag": f"{etag}"},
         status_code=HTTPStatus.OK,
+        media_type="application/xml",
+    )
+
+
+@router.head("/catalog.xml")
+async def head_library_catalog_xml(
+    session: Annotated[OrmSession, Depends(gen_dbsession)],
+):
+    entries = get_staging_books_library_data(session)
+    xml_content = build_library_xml(entries, staging=True)
+    etag = xxhash.xxh64(xml_content.encode("utf-8")).hexdigest()
+    return Response(
+        status_code=HTTPStatus.OK,
+        headers={"ETag": f"{etag}"},
         media_type="application/xml",
     )

--- a/backend/tests/api/routes/test_library.py
+++ b/backend/tests/api/routes/test_library.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from xml.etree import ElementTree as ET
 
 import pytest
+import xxhash
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session as OrmSession
 
@@ -19,6 +20,19 @@ from cms_backend.db.models import (
     Warehouse,
 )
 from cms_backend.utils.datetime import getnow
+
+
+def test_head_collection_catalog_xml(
+    client: TestClient,
+    dbsession: OrmSession,
+    create_collection: Callable[..., Collection],
+):
+    collection = create_collection()
+    dbsession.flush()
+
+    response = client.head(f"/v1/collections/{collection.id}/catalog.xml")
+    assert response.status_code == HTTPStatus.OK
+    assert "ETag" in response.headers
 
 
 def test_get_collection_catalog_xml_not_found_by_id(
@@ -35,6 +49,7 @@ def test_get_collection_catalog_xml_not_found_by_id(
     assert root.tag == "library"
     assert root.get("version") == "20110515"
     assert len(list(root)) == 0
+    assert "ETag" in response.headers
 
 
 def test_get_collection_catalog_xml_not_found_by_name(
@@ -50,6 +65,7 @@ def test_get_collection_catalog_xml_not_found_by_name(
     assert root.tag == "library"
     assert root.get("version") == "20110515"
     assert len(list(root)) == 0
+    assert "ETag" in response.headers
 
 
 def test_get_collection_catalog_xml_empty(
@@ -134,6 +150,10 @@ def test_get_collection_catalog_xml_by_name(
     books = list(root.findall("book"))
     assert len(books) == 1
     assert books[0].get("title") == "Test Title"
+
+    assert "ETag" in response.headers
+    expected_etag = xxhash.xxh64(response.content).hexdigest()
+    assert response.headers["ETag"] == expected_etag
 
 
 def test_get_collection_catalog_xml_single_book(


### PR DESCRIPTION
## Rationale

This PR computes the hash of the XML response of the collections catalog and adds it in the response headers of the request both for the `GET` and `HEAD` requests

## Changes
- add endpoint to compute hash of XML response (accessible via `HEAD` requests)
- add `Etag` header in `GET` requests. Header value is the hash of the XML response

This closes #237 