### PR TITLE
fix(frontend): say 'Unexpected error' instead of 'Network error' for HTTP failures (#251)

### DIFF
--- a/frontend/src/utils/errors.spec.ts
+++ b/frontend/src/utils/errors.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { translateErrors } from './errors'
+
+describe('translateErrors', () => {
+  it('returns the message and per-field errors from a structured ErrorResponse', () => {
+    const result = translateErrors({
+      success: false,
+      message: 'Validation failed',
+      errors: { title: 'is required', author: 'too long' },
+    })
+    expect(result).toEqual([
+      'Validation failed',
+      'title: is required',
+      'author: too long',
+    ])
+  })
+
+  it('returns just the message when ErrorResponse has no per-field errors', () => {
+    expect(
+      translateErrors({ success: false, message: 'Forbidden' }),
+    ).toEqual(['Forbidden'])
+  })
+
+  // Regression for #251: HTTP error from the server (an AxiosResponse came
+  // through the interceptor when the body was empty / not an ErrorResponse).
+  // The previous code returned the generic "An unknown error occurred"
+  // banner; now we surface the status code so the user knows the server
+  // responded.
+  it('treats an AxiosResponse fallthrough as an unexpected HTTP error, not a network error', () => {
+    const fakeAxiosResponse = {
+      status: 502,
+      statusText: 'Bad Gateway',
+      headers: {},
+      data: '',
+    }
+    expect(translateErrors(fakeAxiosResponse)).toEqual([
+      'Unexpected error (HTTP 502 Bad Gateway)',
+    ])
+  })
+
+  it('expands the "Network Error" axios message on real transport failures', () => {
+    expect(translateErrors({ message: 'Network Error' })).toEqual([
+      'Network error: could not reach the server',
+    ])
+  })
+
+  it('falls back to "An unknown error occurred" for shapes it cannot read', () => {
+    expect(translateErrors(undefined)).toEqual(['An unknown error occurred'])
+    expect(translateErrors({})).toEqual(['An unknown error occurred'])
+    expect(translateErrors('string error')).toEqual([
+      'An unknown error occurred',
+    ])
+  })
+})

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -1,20 +1,50 @@
 import { type ErrorResponse } from '@/types/errors'
 
-export function translateErrors(error: ErrorResponse) {
-  // build up a list of the errors
-  const errors = []
-  if (error.errors) {
-    if (error.message) {
-      errors.push(error.message)
-    }
-    for (const [key, value] of Object.entries(error.errors)) {
-      errors.push(`${key}: ${value}`)
-    }
-    return errors
-  }
+// Loose shape of what httpRequest's response interceptor passes to
+// `Promise.reject` — `error.response.data` if present, otherwise the
+// AxiosResponse, otherwise the Axios Error itself. Each of those has a
+// different shape, so translateErrors has to check structurally.
+interface MaybeAxiosResponse {
+  status?: number
+  statusText?: string
+}
 
-  if (error.message) {
-    return [error.message]
+export function translateErrors(error: ErrorResponse | unknown): string[] {
+  // The standard ErrorResponse path (API returned a JSON body matching
+  // the ErrorResponse interface).
+  if (error && typeof error === 'object') {
+    const e = error as Partial<ErrorResponse>
+    if (e.errors) {
+      const errors: string[] = []
+      if (e.message) {
+        errors.push(e.message)
+      }
+      for (const [key, value] of Object.entries(e.errors)) {
+        errors.push(`${key}: ${value}`)
+      }
+      return errors
+    }
+    if (e.message) {
+      // Axios's "Network Error" case — true transport failure (DNS,
+      // timeout, no connectivity). The previous code surfaced this
+      // verbatim; expand it slightly so the user knows what kind of
+      // failure this was.
+      if (e.message === 'Network Error') {
+        return ['Network error: could not reach the server']
+      }
+      return [e.message]
+    }
+
+    // The AxiosResponse fallthrough from httpRequest's interceptor:
+    // the API returned a non-success status whose body wasn't a
+    // structured ErrorResponse (empty body, HTML error page, etc.).
+    // Don't say "Network error" here — there *was* a response, the
+    // server just sent us something we don't understand. (#251)
+    const r = error as MaybeAxiosResponse
+    if (typeof r.status === 'number') {
+      const detail = r.statusText ? ` ${r.statusText}` : ''
+      return [`Unexpected error (HTTP ${r.status}${detail})`]
+    }
   }
 
   return ['An unknown error occurred']


### PR DESCRIPTION
Closes #251.

## Why

`utils/httpRequest`'s response interceptor unwraps an HTTP failure as

```ts
error.response.data || error.response || error
```

so the value `translateErrors` actually receives can be one of three
different shapes:

1. **API ErrorResponse** — JSON body matching the `ErrorResponse`
   interface. The existing path handles this correctly.
2. **AxiosResponse fallthrough** — non-success status with an empty
   or non-JSON body (the issue's case). The previous code returned
   the generic *"An unknown error occurred"* with no status info.
3. **Axios Error fallthrough** — true transport failure (DNS,
   timeout, no connectivity). The previous code surfaced the bare
   `"Network Error"` string verbatim.

Mode 2 was the user-visible *"Network error"* surprise the issue
flags. Even when the previous code didn't literally emit
`"Network Error"`, it was easy to misread the generic banner as a
network failure when in fact the server *had* responded.

## Fix

Reshape `translateErrors` to recognise all three shapes:

- `ErrorResponse` with per-field `.errors` → existing behaviour.
- `ErrorResponse` with just `.message` → existing behaviour, **plus** an
  expansion of the bare `"Network Error"` axios message to
  `"Network error: could not reach the server"` so a true transport
  failure is unambiguous.
- AxiosResponse fallthrough (detected by `typeof status === 'number'`)
  → `"Unexpected error (HTTP <status> <statusText>)"`. This is the
  string the issue asked for.
- Anything else → the existing `"An unknown error occurred"`.

## Tests

`frontend/src/utils/errors.spec.ts` (new — there was no prior unit
test for this module). 5 cases:

- ErrorResponse with per-field errors → message + every key/value.
- ErrorResponse with only `.message` → that message.
- AxiosResponse with `status: 502, statusText: 'Bad Gateway'` →
  `"Unexpected error (HTTP 502 Bad Gateway)"` (the #251 regression).
- Bare `{ message: 'Network Error' }` → expanded
  `"Network error: could not reach the server"`.
- `undefined` / `{}` / `'string error'` → fallback banner.

## Verification

- `npx tsc --noEmit` clean.
- The vitest run is currently broken on Node 25 by an upstream
  `@vue/devtools-kit` localStorage issue (unrelated to this PR);
  CI on the project's pinned Node will exercise the new tests.