### PR TITLE
raise conflict errors on title update with existing name

### DIFF
--- a/backend/src/cms_backend/api/main.py
+++ b/backend/src/cms_backend/api/main.py
@@ -80,7 +80,7 @@ def create_app(*, debug: bool = True):
     return app
 
 
-app = create_app()
+app = create_app(debug=Context.debug)
 
 
 @app.exception_handler(RequestValidationError)

--- a/backend/src/cms_backend/db/title.py
+++ b/backend/src/cms_backend/db/title.py
@@ -215,6 +215,13 @@ def update_title(
         title.name = name
         title.events.append(f"{getnow()}: name updated from {old_name} to {name}")
         name_changed = True
+        session.add(title)
+        try:
+            session.flush()
+        except IntegrityError as exc:
+            raise RecordAlreadyExistsError(
+                f"Title with name '{name}' already exists"
+            ) from exc
 
     # Determine if collection titles changed
     collection_titles_changed = False

--- a/backend/tests/api/routes/test_titles.py
+++ b/backend/tests/api/routes/test_titles.py
@@ -371,3 +371,24 @@ def test_update_title(
     assert events[0].payload["action"] == "updated"
     assert events[0].payload["name"] == "wikipedia_en"
     assert events[0].payload["id"] == str(title.id)
+
+
+def test_update_title_with_existing_title_name(
+    client: TestClient,
+    create_title: Callable[..., Title],
+    access_token: str,
+):
+    """Test updating a title's data"""
+    create_title(name="wikipedia_fr_test")
+    title = create_title(name="wikipedia_en_test")
+    update_data = {
+        "maturity": "robust",
+        "name": "wikipedia_fr_test",
+    }
+
+    response = client.patch(
+        f"/v1/titles/{title.id}",
+        json=update_data,
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == HTTPStatus.CONFLICT


### PR DESCRIPTION
## Rationale
This PR catches integrity errors when title name is updated with another title's name
<img width="1008" height="846" alt="Screenshot_20260428_105037" src="https://github.com/user-attachments/assets/db7a0ea1-3c71-46dc-83e6-a171d5cb223b" />



## Changes
- raise `RecordAlreadyExistsError` if integrity error is raised during title name update
- pass Context debug mode to app during creation to avoid throwing traceback errors to clients

This closes #250 