### PR TITLE
apply retention rules during manual move of book from staging to prod

### DIFF
--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Literal
 from uuid import UUID
 
@@ -8,17 +6,13 @@ from sqlalchemy.orm import Session as OrmSession
 from sqlalchemy.orm import selectinload
 
 from cms_backend.context import Context
+from cms_backend.db.book_location import create_book_target_locations
 from cms_backend.db.exceptions import RecordDoesNotExistError
-from cms_backend.db.models import Book, BookLocation, Warehouse, ZimfarmNotification
+from cms_backend.db.models import Book, ZimfarmNotification
+from cms_backend.db.title import apply_retention_rules
+from cms_backend.schemas.models import FileLocation
 from cms_backend.schemas.orms import BookFullSchema, BookLocationSchema
 from cms_backend.utils.datetime import getnow
-
-
-@dataclass(eq=True, frozen=True)
-class FileLocation:
-    warehouse_id: UUID
-    path: Path
-    filename: str
 
 
 def get_book_or_none(
@@ -147,134 +141,6 @@ def create_book(
     )
 
     return book
-
-
-def create_book_location(
-    session: OrmSession,
-    *,
-    book: Book,
-    warehouse_id: UUID,
-    path: Path,
-    filename: str,
-    status: str = "current",
-) -> BookLocation:
-    """Create a new book location.
-
-    Args:
-        session: SQLAlchemy session
-        book: Book instance
-        warehouse_id: ID of the warehouse
-        path: Folder path within the warehouse (e.g., "dev-zim")
-        filename: Filename in warehouse
-        status: Location status ('current' or 'target'), defaults to 'current'
-
-    Returns:
-        Created BookLocation instance
-    """
-    # Get warehouse info for event message
-    warehouse = session.get(Warehouse, warehouse_id)
-    if not warehouse:
-        raise ValueError(f"Warehouse with id {warehouse_id} not found")
-
-    warehouse_name = warehouse.name
-
-    location = BookLocation(
-        book_id=book.id,
-        warehouse_id=warehouse_id,
-        path=path,
-        status=status,
-        filename=filename,
-    )
-    session.add(location)
-    book.locations.append(location)
-    book.events.append(
-        f"{getnow()}: added {status} location: {filename} in {warehouse_name}: "
-        f"{path} ({warehouse_id})"
-    )
-
-    return location
-
-
-def current_locations_match_targets(
-    book: Book,
-    target_locations: list[FileLocation],
-) -> bool:
-    """Check if book's current locations exactly match the target locations.
-
-    Args:
-        book: The book to check
-        target_locations: List of file locations representing target locations
-
-    Returns:
-        True if the set of current locations is strictly identical to target locations
-    """
-    # Extract current locations as set of (warehouse_id, path, filename) tuples
-    current_set = {
-        FileLocation(
-            warehouse_id=loc.warehouse_id, path=loc.path, filename=loc.filename
-        )
-        for loc in book.locations
-        if loc.status == "current"
-    }
-
-    # Convert target list to set
-    target_set = set(target_locations)
-
-    # Must be strictly identical
-    return current_set == target_set
-
-
-def create_book_target_locations(
-    session: OrmSession,
-    book: Book,
-    target_locations: list[FileLocation],
-) -> None:
-    """Create target locations for a book if not already at expected locations.
-
-    Computes target locations based on the provided warehouse paths and filename,
-    then checks if the book's current locations already match. If they do, no new
-    target locations are created. Otherwise, target locations are created for each
-    warehouse path.
-
-    Args:
-        session: SQLAlchemy session
-        book: Book to create target locations for
-        target_locations: List of FileLocation where the book should be
-
-    Side effects:
-        - Adds event to book if targets already match current locations
-        - Creates BookLocation records if targets don't match current locations
-        - Updates book needs_file_operation flag
-    """
-
-    if not book.name:
-        raise Exception("book name is missing or invalid")
-
-    if not book.date:
-        raise Exception("book date is missing or invalid")
-
-    # Check if current locations already match targets exactly
-    if current_locations_match_targets(book, target_locations):
-        # Book is already at all expected locations - skip creating targets
-        book.events.append(
-            f"{getnow()}: book already at all target locations, skipping target "
-            "creation"
-        )
-        book.needs_file_operation = False
-        return
-
-    # Create target locations for each applicable warehouse path
-    for target_location in target_locations:
-        create_book_location(
-            session=session,
-            book=book,
-            warehouse_id=target_location.warehouse_id,
-            path=target_location.path,
-            filename=target_location.filename,
-            status="target",
-        )
-
-    book.needs_file_operation = True
 
 
 def get_next_book_to_move_files_or_none(
@@ -409,6 +275,10 @@ def move_book(
     book.location_kind = "staging" if goes_to_staging else "prod"
     session.add(book)
     session.flush()
+
+    if not goes_to_staging:
+        apply_retention_rules(session, book.title)
+
     return book
 
 

--- a/backend/src/cms_backend/db/book_location.py
+++ b/backend/src/cms_backend/db/book_location.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+from uuid import UUID
+
+from sqlalchemy.orm import Session as OrmSession
+
+from cms_backend.db.models import Book, BookLocation, Warehouse
+from cms_backend.schemas.models import FileLocation
+from cms_backend.utils.datetime import getnow
+
+
+def create_book_location(
+    session: OrmSession,
+    *,
+    book: Book,
+    warehouse_id: UUID,
+    path: Path,
+    filename: str,
+    status: str = "current",
+) -> BookLocation:
+    """Create a new book location.
+
+    Args:
+        session: SQLAlchemy session
+        book: Book instance
+        warehouse_id: ID of the warehouse
+        path: Folder path within the warehouse (e.g., "dev-zim")
+        filename: Filename in warehouse
+        status: Location status ('current' or 'target'), defaults to 'current'
+
+    Returns:
+        Created BookLocation instance
+    """
+    # Get warehouse info for event message
+    warehouse = session.get(Warehouse, warehouse_id)
+    if not warehouse:
+        raise ValueError(f"Warehouse with id {warehouse_id} not found")
+
+    warehouse_name = warehouse.name
+
+    location = BookLocation(
+        book_id=book.id,
+        warehouse_id=warehouse_id,
+        path=path,
+        status=status,
+        filename=filename,
+    )
+    session.add(location)
+    book.locations.append(location)
+    book.events.append(
+        f"{getnow()}: added {status} location: {filename} in {warehouse_name}: "
+        f"{path} ({warehouse_id})"
+    )
+
+    return location
+
+
+def current_locations_match_targets(
+    book: Book,
+    target_locations: list[FileLocation],
+) -> bool:
+    """Check if book's current locations exactly match the target locations.
+
+    Args:
+        book: The book to check
+        target_locations: List of file locations representing target locations
+
+    Returns:
+        True if the set of current locations is strictly identical to target locations
+    """
+    # Extract current locations as set of (warehouse_id, path, filename) tuples
+    current_set = {
+        FileLocation(
+            warehouse_id=loc.warehouse_id, path=loc.path, filename=loc.filename
+        )
+        for loc in book.locations
+        if loc.status == "current"
+    }
+
+    # Convert target list to set
+    target_set = set(target_locations)
+
+    # Must be strictly identical
+    return current_set == target_set
+
+
+def create_book_target_locations(
+    session: OrmSession,
+    book: Book,
+    target_locations: list[FileLocation],
+) -> None:
+    """Create target locations for a book if not already at expected locations.
+
+    Computes target locations based on the provided warehouse paths and filename,
+    then checks if the book's current locations already match. If they do, no new
+    target locations are created. Otherwise, target locations are created for each
+    warehouse path.
+
+    Args:
+        session: SQLAlchemy session
+        book: Book to create target locations for
+        target_locations: List of FileLocation where the book should be
+
+    Side effects:
+        - Adds event to book if targets already match current locations
+        - Creates BookLocation records if targets don't match current locations
+        - Updates book needs_file_operation flag
+    """
+
+    if not book.name:
+        raise Exception("book name is missing or invalid")
+
+    if not book.date:
+        raise Exception("book date is missing or invalid")
+
+    # Check if current locations already match targets exactly
+    if current_locations_match_targets(book, target_locations):
+        # Book is already at all expected locations - skip creating targets
+        book.events.append(
+            f"{getnow()}: book already at all target locations, skipping target "
+            "creation"
+        )
+        book.needs_file_operation = False
+        return
+
+    # Create target locations for each applicable warehouse path
+    for target_location in target_locations:
+        create_book_location(
+            session=session,
+            book=book,
+            warehouse_id=target_location.warehouse_id,
+            path=target_location.path,
+            filename=target_location.filename,
+            status="target",
+        )
+
+    book.needs_file_operation = True

--- a/backend/src/cms_backend/db/title.py
+++ b/backend/src/cms_backend/db/title.py
@@ -1,23 +1,28 @@
 import datetime
+from collections import defaultdict
 from pathlib import Path
 from uuid import UUID
 
 from psycopg.errors import UniqueViolation
-from sqlalchemy import select
+from sqlalchemy import Date, select
+from sqlalchemy import cast as sql_cast
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session as OrmSession
 from sqlalchemy.orm import selectinload
 
 from cms_backend import logger
+from cms_backend.context import Context
 from cms_backend.db import count_from_stmt
-from cms_backend.db.book import (
-    FileLocation,
-    create_book_target_locations,
-)
+from cms_backend.db.book_location import create_book_target_locations
 from cms_backend.db.collection import get_collection_by_name
 from cms_backend.db.event import create_title_modified_event
 from cms_backend.db.exceptions import RecordAlreadyExistsError, RecordDoesNotExistError
-from cms_backend.db.models import CollectionTitle, Title
+from cms_backend.db.models import (
+    Book,
+    CollectionTitle,
+    Title,
+)
+from cms_backend.schemas.models import FileLocation
 from cms_backend.schemas.orms import (
     BaseTitleCollectionSchema,
     BookLightSchema,
@@ -27,6 +32,10 @@ from cms_backend.schemas.orms import (
     TitleLightSchema,
 )
 from cms_backend.utils.datetime import getnow
+from cms_backend.utils.filename import (
+    PERIOD_LENGTH,
+    get_period_and_suffix_from_filename,
+)
 
 
 def create_title_full_schema(title: Title) -> TitleFullSchema:
@@ -322,3 +331,89 @@ def update_title(
             session, action="updated", title_name=title.name, title_id=title.id
         )
     return get_title_by_id(session, title_id=title.id)
+
+
+def sort_books_by_filename_period(books: list[Book]) -> list[Book]:
+    """Sort a list of books by period.
+
+    Assumes:
+    - the book's location exists since it contains the filename of the book
+    """
+
+    def sort_fn(book: Book) -> tuple[str, int, str]:
+        period, suffix = get_period_and_suffix_from_filename(book.locations[0].filename)
+        return (period, len(suffix), suffix)
+
+    return sorted(
+        books,
+        key=sort_fn,
+        reverse=True,
+    )
+
+
+def apply_retention_rules(session: OrmSession, title: Title):
+    """Apply retention rules to `prod` books belonging to same title and flavour group.
+
+    The retention rules are described in https://wiki.openzim.org/wiki/ZIM_Updates
+    - Keep last version of two ZIM files from the two last distinct months (e.g
+        if we have `2024-04`, `2024-04a`, `2024-06`, `2024-06a`, `2024-06b`,
+        then we keep `2024-04a` and `2024-06b`)
+    - AND keep every version which is 30 days old or less.
+    """
+
+    now = getnow()
+
+    books_by_flavour: dict[str, list[Book]] = defaultdict(list)
+    for book in session.scalars(
+        select(Book).where(
+            Book.title_id == title.id,
+            Book.has_error.is_(False),
+            Book.date.is_not(None),
+            sql_cast(Book.date, Date) <= (now - datetime.timedelta(days=30)).date(),
+            Book.location_kind == "prod",
+            Book.needs_file_operation.is_(False),
+        )
+    ).all():
+        books_by_flavour[book.flavour or ""].append(book)
+
+    books_to_delete: list[Book] = []
+
+    for _, books in books_by_flavour.items():
+        # Group books by period (without the suffix)
+        books_by_period: dict[str, list[Book]] = defaultdict(list)
+        for book in books:
+            if not book.date:
+                continue
+            books_by_period[book.date[:PERIOD_LENGTH]].append(book)
+
+        # Keep last version from each of the 2 most recent periods
+        sorted_periods = sorted(books_by_period.keys(), reverse=True)
+        for period in sorted_periods[:2]:
+            sorted_books_by_period = sort_books_by_filename_period(
+                books_by_period[period]
+            )
+            # Mark all but the most recent one for deletion
+            books_to_delete.extend(sorted_books_by_period[1:])
+
+        # Mark the remainder of the books to be deleted.
+        for period in sorted_periods[2:]:
+            books_to_delete.extend(books_by_period[period])
+
+    deletion_date = now + Context.book_deletion_delay
+
+    for book in books_to_delete:
+        logger.info(
+            f"Marking book {book.id} for deletion, deletion_date={deletion_date}"
+        )
+        book.location_kind = "to_delete"
+        book.deletion_date = deletion_date
+        book.needs_file_operation = True
+        book.events.append(
+            f"{now}: marked for deletion due to retention policy, "
+            f"will be deleted after {deletion_date}"
+        )
+        title.events.append(f"{now}: book {book.id} marked for deletion.")
+        session.add(book)
+        session.add(title)
+
+    session.flush()

--- a/backend/src/cms_backend/mill/processors/title.py
+++ b/backend/src/cms_backend/mill/processors/title.py
@@ -1,88 +1,13 @@
-import datetime
-from collections import defaultdict
-
-from sqlalchemy import Date, select
-from sqlalchemy import cast as sql_cast
 from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend import logger
 from cms_backend.context import Context
-from cms_backend.db.book import FileLocation, create_book_target_locations
+from cms_backend.db.book import create_book_target_locations
 from cms_backend.db.models import Book, Title
+from cms_backend.db.title import apply_retention_rules
+from cms_backend.schemas.models import FileLocation
 from cms_backend.utils.datetime import getnow
-from cms_backend.utils.filename import (
-    PERIOD_LENGTH,
-    compute_target_filename,
-    get_period_and_suffix_from_filename,
-)
-
-
-def apply_retention_rules(session: OrmSession, title: Title):
-    """Apply retention rules to `prod` books belonging to same title and flavour group.
-
-    The retention rules are described in https://wiki.openzim.org/wiki/ZIM_Updates
-    - Keep last version of two ZIM files from the two last distinct months (e.g
-        if we have `2024-04`, `2024-04a`, `2024-06`, `2024-06a`, `2024-06b`,
-        then we keep `2024-04a` and `2024-06b`)
-    - AND keep every version which is 30 days old or less.
-    """
-
-    now = getnow()
-
-    books_by_flavour: dict[str, list[Book]] = defaultdict(list)
-    for book in session.scalars(
-        select(Book).where(
-            Book.title_id == title.id,
-            Book.has_error.is_(False),
-            Book.date.is_not(None),
-            sql_cast(Book.date, Date) <= (now - datetime.timedelta(days=30)).date(),
-            Book.location_kind == "prod",
-            Book.needs_file_operation.is_(False),
-        )
-    ).all():
-        books_by_flavour[book.flavour or ""].append(book)
-
-    books_to_delete: list[Book] = []
-
-    for _, books in books_by_flavour.items():
-        # Group books by period (without the suffix)
-        books_by_period: dict[str, list[Book]] = defaultdict(list)
-        for book in books:
-            if not book.date:
-                continue
-            books_by_period[book.date[:PERIOD_LENGTH]].append(book)
-
-        # Keep last version from each of the 2 most recent periods
-        sorted_periods = sorted(books_by_period.keys(), reverse=True)
-        for period in sorted_periods[:2]:
-            sorted_books_by_period = sort_books_by_filename_period(
-                books_by_period[period]
-            )
-            # Mark all but the most recent one for deletion
-            books_to_delete.extend(sorted_books_by_period[1:])
-
-        # Mark the remainder of the books to be deleted.
-        for period in sorted_periods[2:]:
-            books_to_delete.extend(books_by_period[period])
-
-    deletion_date = now + Context.book_deletion_delay
-
-    for book in books_to_delete:
-        logger.info(
-            f"Marking book {book.id} for deletion, deletion_date={deletion_date}"
-        )
-        book.location_kind = "to_delete"
-        book.deletion_date = deletion_date
-        book.needs_file_operation = True
-        book.events.append(
-            f"{now}: marked for deletion due to retention policy, "
-            f"will be deleted after {deletion_date}"
-        )
-        title.events.append(f"{now}: book {book.id} marked for deletion.")
-        session.add(book)
-        session.add(title)
-
-    session.flush()
+from cms_backend.utils.filename import compute_target_filename
 
 
 def add_book_to_title(session: OrmSession, book: Book, title: Title):
@@ -154,21 +79,3 @@ def add_book_to_title(session: OrmSession, book: Book, title: Title):
         )
         book.has_error = True
         logger.exception(f"Failed to add book {book.id} to title {title.id}")
-
-
-def sort_books_by_filename_period(books: list[Book]) -> list[Book]:
-    """Sort a list of books by period.
-
-    Assumes:
-    - the book's location exists since it contains the filename of the book
-    """
-
-    def sort_fn(book: Book) -> tuple[str, int, str]:
-        period, suffix = get_period_and_suffix_from_filename(book.locations[0].filename)
-        return (period, len(suffix), suffix)
-
-    return sorted(
-        books,
-        key=sort_fn,
-        reverse=True,
-    )

--- a/backend/src/cms_backend/mill/processors/zimfarm_notification.py
+++ b/backend/src/cms_backend/mill/processors/zimfarm_notification.py
@@ -2,7 +2,8 @@ from sqlalchemy.orm import Session as ORMSession
 
 from cms_backend import logger
 from cms_backend.context import Context
-from cms_backend.db.book import create_book, create_book_location
+from cms_backend.db.book import create_book
+from cms_backend.db.book_location import create_book_location
 from cms_backend.db.models import ZimfarmNotification
 from cms_backend.mill.processors.book import process_book
 from cms_backend.utils.datetime import getnow

--- a/backend/src/cms_backend/schemas/models.py
+++ b/backend/src/cms_backend/schemas/models.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 from uuid import UUID
 
@@ -20,3 +22,10 @@ class ZimUrlsSchema(BaseModel):
 
 class BookLanguagesSchema(BaseModel):
     languages: list[str]
+
+
+@dataclass(eq=True, frozen=True)
+class FileLocation:
+    warehouse_id: UUID
+    path: Path
+    filename: str

--- a/backend/tests/mill/processors/test_title.py
+++ b/backend/tests/mill/processors/test_title.py
@@ -8,9 +8,9 @@ import pytest
 from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend.db.models import Book, BookLocation, Title
+from cms_backend.db.title import sort_books_by_filename_period
 from cms_backend.mill.processors.title import (
     apply_retention_rules,
-    sort_books_by_filename_period,
 )
 from cms_backend.utils.datetime import getnow
 
@@ -177,7 +177,7 @@ def test_apply_retention_rules_keeps_last_version_of_two_most_recent_months(
     dbsession.flush()
 
     with patch(
-        "cms_backend.mill.processors.title.getnow",
+        "cms_backend.db.title.getnow",
         return_value=datetime.datetime(2024, 4, 1),
     ):
         apply_retention_rules(dbsession, title)
@@ -265,7 +265,7 @@ def test_apply_retention_rules_handles_different_flavours_separately(
     dbsession.flush()
 
     with patch(
-        "cms_backend.mill.processors.title.getnow",
+        "cms_backend.db.title.getnow",
         return_value=datetime.datetime(2024, 2, 1),
     ):
         apply_retention_rules(dbsession, title)


### PR DESCRIPTION
## Rationale
This PR applies the retention rules to the books belonging to a title when a book is moved from staging to prod manually

## Changes
- add new module `book_location.py` for keeping book location related logic and avoid circular imports
- move retention rules to `db/title.py` module
- apply retention rules if book does not go to staging

This closes #246 