### PR TITLE
differentiate between staging and prod books status

### DIFF
--- a/frontend/src/components/BookStatus.vue
+++ b/frontend/src/components/BookStatus.vue
@@ -30,6 +30,10 @@
         <v-icon size="small" color="warning" icon="mdi-alert-circle-outline"></v-icon>
         <span class="text-caption ml-1">Pending Title</span>
       </template>
+      <template v-else-if="isStaging">
+        <v-icon size="small" color="warning" icon="mdi-eye-outline"></v-icon>
+        <span class="text-caption ml-1">Staging</span>
+      </template>
       <template v-else>
         <v-icon size="small" color="success" icon="mdi-check-circle"></v-icon>
         <span class="text-caption ml-1">Published</span>
@@ -64,6 +68,7 @@ const props = withDefaults(
 const isErrored = computed(() => props.book.has_error)
 const isDeleted = computed(() => props.book.location_kind === 'deleted')
 const isToBeDeleted = computed(() => props.book.location_kind === 'to_delete')
+const isStaging = computed(() => props.book.location_kind === 'staging')
 const isProcessing = computed(() => props.book.needs_processing && !props.book.has_error)
 const isMovingFiles = computed(
   () =>


### PR DESCRIPTION
## Changes
- use eye icon for books in staging that don't have any errors
- chnage text from published to staging for books in staging that don't have any errors

<img width="1422" height="301" alt="Screenshot_20260507_092413" src="https://github.com/user-attachments/assets/85345d73-fc38-4a6b-8634-4ad581efe25c" />


This closes #234 