### PR TITLE
show button to configure 2FA on Ory

### DIFF
--- a/backend/src/cms_backend/api/token.py
+++ b/backend/src/cms_backend/api/token.py
@@ -66,8 +66,6 @@ class LocalTokenDecoder(TokenDecoder):
         return "local"
 
     def can_decode(self, token: str) -> bool:
-        return "local" in Context.auth_modes
-
         if "local" not in Context.auth_modes:
             return False
         try:
@@ -155,9 +153,10 @@ class OAuthTokenDecoder(TokenDecoder):
         except Exception:
             return False
 
-        if (
-            payload.get("iss") != Context.oauth_issuer
-            or Context.oauth_session_audience_id not in payload.get("aud", [])
+        if payload.get(
+            "iss"
+        ) != Context.oauth_issuer or Context.oauth_session_audience_id not in payload.get(
+            "aud", []
         ):
             return False
         return True

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -302,6 +302,7 @@ export const useAuthStore = defineStore('auth', () => {
 
       // Fetch user info from backend using the Kiwix token
       await fetchUserInfo(newToken.access_token)
+      if (!user.value) return false
 
       errors.value = []
       provider.saveToken(newToken)

--- a/frontend/src/views/OAuthCallbackView.vue
+++ b/frontend/src/views/OAuthCallbackView.vue
@@ -26,7 +26,18 @@
               <v-alert type="error" variant="tonal" class="mb-4 text-left">
                 {{ error }}
               </v-alert>
-              <v-btn color="primary" :to="{ name: 'sign-in' }"> Back to Sign In </v-btn>
+              <v-btn v-if="!is2FAError" color="primary" :to="{ name: 'sign-in' }">
+                Back to Sign In
+              </v-btn>
+              <v-btn
+                v-else
+                color="primary"
+                :href="settingsUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Configure 2FA
+              </v-btn>
             </div>
           </v-card-text>
         </v-card>
@@ -37,14 +48,28 @@
 
 <script setup lang="ts">
 import { useAuthStore } from '@/stores/auth'
-import { onMounted, ref } from 'vue'
+import { onMounted, ref, computed, inject } from 'vue'
 import { useRouter } from 'vue-router'
+import type { Config } from '@/config'
+import constants from '@/constants'
 
 const router = useRouter()
 const authStore = useAuthStore()
+const config = inject<Config>(constants.config)
+if (!config) {
+  throw new Error('Config is not defined')
+}
 
 const loading = ref(true)
 const error = ref<string | null>(null)
+
+const is2FAError = computed(() => {
+  return error.value?.startsWith('2FA authentication is mandatory on CMS') ?? false
+})
+
+const settingsUrl = computed(() => {
+  return `${config.OAUTH_BASE_URL}/settings`
+})
 
 onMounted(async () => {
   try {


### PR DESCRIPTION
## Rationale
<img width="654" height="546" alt="Screenshot_20260511_100007" src="https://github.com/user-attachments/assets/df3cd223-4941-49be-8618-fbc13b04cf7e" />


## Changes
- add button to configure 2FA on Ory
- hide button to sign in when error is 2FA error
- fix bug in local token decoder always returning true for `can_decode`
