### PR TITLE
use path prefix query param in generating library catalog path

### DIFF
--- a/backend/src/cms_backend/api/routes/collection.py
+++ b/backend/src/cms_backend/api/routes/collection.py
@@ -128,7 +128,7 @@ def update_collection(
 
 
 def _get_catalog_xml_content(
-    collection_id_or_name: str, session: OrmSession
+    collection_id_or_name: str, session: OrmSession, path_prefix: str | None
 ) -> tuple[str, int]:
     # Try to parse as UUID first, otherwise treat as name
     collection = None
@@ -150,7 +150,7 @@ def _get_catalog_xml_content(
         )
 
     entries = get_latest_books_for_collection(session, collection.id)
-    xml_content = build_library_xml(entries)
+    xml_content = build_library_xml(entries, path_prefix=path_prefix)
 
     return xml_content, HTTPStatus.OK
 
@@ -159,9 +159,12 @@ def _get_catalog_xml_content(
 def get_library_catalog_xml(
     collection_id_or_name: Annotated[str, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
+    path_prefix: Annotated[str | None, Query()] = None,
 ):
     """Get collection catalog as XML library by collection ID (UUID) or name."""
-    xml_content, status_code = _get_catalog_xml_content(collection_id_or_name, session)
+    xml_content, status_code = _get_catalog_xml_content(
+        collection_id_or_name, session, path_prefix
+    )
     etag = xxhash.xxh64(xml_content.encode("utf-8")).hexdigest()
 
     return Response(
@@ -176,9 +179,12 @@ def get_library_catalog_xml(
 def head_library_catalog_xml(
     collection_id_or_name: Annotated[str, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
+    path_prefix: Annotated[str | None, Query()] = None,
 ):
     """Get collection catalog as XML library by collection ID (UUID) or name."""
-    xml_content, status_code = _get_catalog_xml_content(collection_id_or_name, session)
+    xml_content, status_code = _get_catalog_xml_content(
+        collection_id_or_name, session, path_prefix
+    )
     etag = xxhash.xxh64(xml_content.encode("utf-8")).hexdigest()
     return Response(
         status_code=status_code,

--- a/backend/src/cms_backend/api/routes/staging.py
+++ b/backend/src/cms_backend/api/routes/staging.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 from typing import Annotated
 
 import xxhash
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import Response
 from sqlalchemy.orm import Session as OrmSession
 
@@ -16,11 +16,12 @@ router = APIRouter(prefix="/staging", tags=["staging"])
 @router.get("/catalog.xml")
 async def get_library_catalog_xml(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
+    path_prefix: Annotated[str | None, Query()] = None,
 ):
     """Get staging catalog as XML library."""
 
     entries = get_staging_books_library_data(session)
-    xml_content = build_library_xml(entries, staging=True)
+    xml_content = build_library_xml(entries, path_prefix=path_prefix)
     etag = xxhash.xxh64(xml_content.encode("utf-8")).hexdigest()
 
     return Response(
@@ -34,9 +35,10 @@ async def get_library_catalog_xml(
 @router.head("/catalog.xml")
 async def head_library_catalog_xml(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
+    path_prefix: Annotated[str | None, Query()] = None,
 ):
     entries = get_staging_books_library_data(session)
-    xml_content = build_library_xml(entries, staging=True)
+    xml_content = build_library_xml(entries, path_prefix=path_prefix)
     etag = xxhash.xxh64(xml_content.encode("utf-8")).hexdigest()
     return Response(
         status_code=HTTPStatus.OK,

--- a/backend/src/cms_backend/api/routes/utils.py
+++ b/backend/src/cms_backend/api/routes/utils.py
@@ -1,13 +1,14 @@
 import math
 from xml.etree import ElementTree as ET
 
-from cms_backend.context import Context
 from cms_backend.db.collection import LibraryBookData
 from cms_backend.utils.filename import construct_download_url
 from cms_backend.utils.zim import convert_tags
 
 
-def build_library_xml(entries: list[LibraryBookData], *, staging: bool = False) -> str:
+def build_library_xml(
+    entries: list[LibraryBookData], *, path_prefix: str | None = None
+) -> str:
     """Build XML library catalog from books."""
     library_elem = ET.Element("library")
     library_elem.set("version", "20110515")
@@ -50,8 +51,11 @@ def build_library_xml(entries: list[LibraryBookData], *, staging: bool = False) 
             download_url = construct_download_url(download_base_url, path, filename)
             book_elem.set("url", f"{download_url}.meta4")
 
-        if staging:
-            book_elem.set("path", f"{Context.staging_library_xml_base_path}{filename}")
+        if path_prefix is not None:
+            if path_prefix.endswith("/"):
+                path_prefix = path_prefix[:-1]
+
+            book_elem.set("path", f"{path_prefix}/{filename}")
 
         if flavour := zim_meta.get("Flavour"):
             book_elem.set("flavour", flavour)

--- a/backend/tests/api/routes/test_library.py
+++ b/backend/tests/api/routes/test_library.py
@@ -209,7 +209,9 @@ def test_get_collection_catalog_xml_single_book(
     dbsession.flush()
 
     # Test
-    response = client.get(f"/v1/collections/{collection.id}/catalog.xml")
+    response = client.get(
+        f"/v1/collections/{collection.id}/catalog.xml?path_prefix=/data/dev"
+    )
     assert response.status_code == HTTPStatus.OK
     assert response.headers["content-type"] == "application/xml"
 
@@ -243,6 +245,7 @@ def test_get_collection_catalog_xml_single_book(
         == "https://download.kiwix.org/zim/wikipedia/test_en_all.zim.meta4"
     )
     assert book_elem.get("flavour") == "test"
+    assert book_elem.get("path") == "/data/dev/test_en_all.zim"
 
 
 def test_get_collection_catalog_xml_root_path(
@@ -956,7 +959,7 @@ def test_get_prod_and_staging_catalog_xml(
     assert books[0].get("path") is None
 
     # Test staging
-    response = client.get("/v1/staging/catalog.xml")
+    response = client.get("/v1/staging/catalog.xml?path_prefix=/data/dev")
     assert response.status_code == HTTPStatus.OK
 
     root = ET.fromstring(response.text)


### PR DESCRIPTION
## Changes
- add query parameter `path_prefix` used in building the path property of the XML content for each book

This closes #282 