### PR TITLE
rename title maturity

### DIFF
--- a/backend/maint-scripts/populate_cms_database.py
+++ b/backend/maint-scripts/populate_cms_database.py
@@ -501,13 +501,13 @@ def process_zim_file(
             get_collection(session, UUID("96fb60c0-2de6-46bd-8e67-41213298a5e8"))
         ]
         title_path = get_kiwix_path_from_staging_name(normalized_name)
-        title_maturity = "dev"
+        title_maturity = "unstable"
     else:
         collections = find_collections_for_zim(
             session, warehouse_id, zim_path_in_warehouse
         )
         title_path = zim_path_in_warehouse.parent
-        title_maturity = "robust"
+        title_maturity = "stable"
 
     if not collections:
         logger.error(

--- a/backend/src/cms_backend/api/routes/titles.py
+++ b/backend/src/cms_backend/api/routes/titles.py
@@ -69,12 +69,12 @@ class BaseTitleCreateUpdateSchema(BaseModel):
 
 class TitleCreateSchema(BaseTitleCreateUpdateSchema):
     name: NotEmptyString
-    maturity: Literal["dev", "robust"] = "dev"
+    maturity: Literal["unstable", "stable"] = "unstable"
 
 
 class TitleUpdateSchema(BaseTitleCreateUpdateSchema):
     name: NotEmptyString | None = None
-    maturity: Literal["dev", "robust"] | None = None
+    maturity: Literal["unstable", "stable"] | None = None
 
 
 @router.get("")

--- a/backend/src/cms_backend/db/models.py
+++ b/backend/src/cms_backend/db/models.py
@@ -196,7 +196,7 @@ class Title(Base):
         init=False, primary_key=True, server_default=text("uuid_generate_v4()")
     )
     name: Mapped[str] = mapped_column(unique=True, index=True)
-    maturity: Mapped[str] = mapped_column(init=False, index=True, default="dev")
+    maturity: Mapped[str] = mapped_column(init=False, index=True, default="unstable")
     events: Mapped[list[str]] = mapped_column(init=False, default_factory=list)
     archived: Mapped[bool] = mapped_column(default=False, server_default=false())
 

--- a/backend/src/cms_backend/migrations/versions/a8f64135b053_update_title_maturity_values_to_.py
+++ b/backend/src/cms_backend/migrations/versions/a8f64135b053_update_title_maturity_values_to_.py
@@ -1,0 +1,43 @@
+"""update_title_maturity_values_to_unstable_and_stable
+
+Revision ID: a8f64135b053
+Revises: efb5f2ffd65f
+Create Date: 2026-05-21 09:32:53.631838
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a8f64135b053"
+down_revision = "efb5f2ffd65f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        UPDATE title
+        SET maturity = 'unstable'
+        WHERE maturity = 'dev'
+    """)
+
+    op.execute("""
+        UPDATE title
+        SET maturity = 'stable'
+        WHERE maturity = 'robust'
+    """)
+
+
+def downgrade():
+    op.execute("""
+        UPDATE title
+        SET maturity = 'dev'
+        WHERE maturity = 'unstable'
+    """)
+
+    op.execute("""
+        UPDATE title
+        SET maturity = 'robust'
+        WHERE maturity = 'stable'
+    """)

--- a/backend/src/cms_backend/mill/processors/title.py
+++ b/backend/src/cms_backend/mill/processors/title.py
@@ -40,9 +40,9 @@ def add_book_to_title(session: OrmSession, book: Book, title: Title):
         )
 
         # Determine if this book goes to staging or prod based on title maturity
-        # For now, only 'robust' maturity move straight to prod, other maturity moves
+        # For now, only 'stable' maturity move straight to prod, other maturity moves
         # through staging first
-        goes_to_staging = title.maturity != "robust"
+        goes_to_staging = title.maturity != "stable"
 
         target_locations = (
             [

--- a/backend/tests/api/routes/test_titles.py
+++ b/backend/tests/api/routes/test_titles.py
@@ -128,7 +128,7 @@ def test_create_title_all_fields(
     collection = create_collection(name="wikipedia")
     title_data = {
         "name": "wikipedia_en_test",
-        "maturity": "dev",
+        "maturity": "unstable",
         "collection_titles": [
             {
                 "collection_name": "wikipedia",
@@ -149,7 +149,7 @@ def test_create_title_all_fields(
     assert "name" in data
     assert data["name"] == "wikipedia_en_test"
     assert "maturity" in data
-    assert data["maturity"] == "dev"
+    assert data["maturity"] == "unstable"
 
     # Verify the title was created in the database and belongs to the collection
     title = dbsession.get(Title, data["id"])
@@ -174,7 +174,7 @@ def test_create_title_with_duplicate_collection_name(
     """Test creating a title with the same collection repeated."""
     title_data = {
         "name": "wikipedia_en_test",
-        "maturity": "dev",
+        "maturity": "unstable",
         "collection_titles": [
             {
                 "collection_name": "wikipedia",
@@ -328,7 +328,7 @@ def test_update_title_required_permissions(
     """Test updating a title with different roles"""
     title = create_title(name="wikipedia_en_test")
     update_data = {
-        "maturity": "robust",
+        "maturity": "stable",
     }
 
     account = create_account(permission=permission)
@@ -351,10 +351,10 @@ def test_update_title(
 ):
     """Test updating a title's data"""
     title = create_title(name="wikipedia_en_test")
-    assert title.maturity == "dev"
+    assert title.maturity == "unstable"
 
     update_data = {
-        "maturity": "robust",
+        "maturity": "stable",
         "name": "wikipedia_en",
     }
 
@@ -368,7 +368,7 @@ def test_update_title(
 
     assert data["id"] == str(title.id)
     assert data["name"] == "wikipedia_en"
-    assert data["maturity"] == "robust"
+    assert data["maturity"] == "stable"
 
     events = dbsession.scalars(
         select(Event).where(Event.topic == "title_modified")
@@ -388,7 +388,7 @@ def test_update_title_with_existing_title_name(
     create_title(name="wikipedia_fr_test")
     title = create_title(name="wikipedia_en_test")
     update_data = {
-        "maturity": "robust",
+        "maturity": "stable",
         "name": "wikipedia_fr_test",
     }
 

--- a/backend/tests/mill/processors/test_zimfarm_notification.py
+++ b/backend/tests/mill/processors/test_zimfarm_notification.py
@@ -236,10 +236,10 @@ class TestValidNotificationMissingZimMetadata:
         assert book.needs_file_operation is False
 
 
-class TestValidNotificationWithMatchingTitleDevMaturity:
-    """Test valid notifications that match an existing title with dev maturity.
+class TestValidNotificationWithMatchingTitleUnstableMaturity:
+    """Test valid notifications that match an existing title with unstable maturity.
 
-    Dev maturity titles should have their books moved to staging.
+    Unstable maturity titles should have their books moved to staging.
     """
 
     def test_moves_book_to_staging(
@@ -249,10 +249,12 @@ class TestValidNotificationWithMatchingTitleDevMaturity:
         create_zimfarm_notification: Callable[..., ZimfarmNotification],
         create_title: Callable[..., Title],
     ):
-        """Valid notification + matching dev maturity title → book moves to staging."""
+        """
+        Valid notification + matching unstable maturity title → book moves to staging.
+        """
         # Create title that matches book name
         title = create_title(name="test_en_all")
-        title.maturity = "dev"
+        title.maturity = "unstable"
         dbsession.flush()
 
         notification = create_zimfarm_notification(content=VALID_NOTIFICATION_CONTENT)
@@ -291,12 +293,12 @@ class TestValidNotificationWithMatchingTitleDevMaturity:
         create_title: Callable[..., Title],
     ):
         """
-        Valid notification with empty folder_name + dev maturity title → book
+        Valid notification with empty folder_name + unstable maturity title → book
         moves to staging.
         """
         # Create title that matches book name
         title = create_title(name="test_en_all")
-        title.maturity = "dev"
+        title.maturity = "unstable"
         dbsession.flush()
 
         content = VALID_NOTIFICATION_CONTENT.copy()
@@ -329,10 +331,10 @@ class TestValidNotificationWithMatchingTitleDevMaturity:
         assert book.needs_processing is False
 
 
-class TestValidNotificationWithMatchingTitleRobustMaturity:
-    """Test valid notifications that match a robust maturity title.
+class TestValidNotificationWithMatchingTitleStableMaturity:
+    """Test valid notifications that match a stable maturity title.
 
-    Robust maturity titles have their books moved directly to production collections.
+    Stable maturity titles have their books moved directly to production collections.
     """
 
     def test_moves_book_to_collection_warehouses(
@@ -344,10 +346,10 @@ class TestValidNotificationWithMatchingTitleRobustMaturity:
         create_collection: Callable[..., Collection],
         create_warehouse: Callable[..., Warehouse],
     ):
-        """Valid notification + robust title → book has collection warehouse targets."""
+        """Valid notification + stable title → book has collection warehouse targets."""
 
         title = create_title(name="test_en_all")
-        title.maturity = "robust"
+        title.maturity = "stable"
 
         prod = create_warehouse(
             name="prod", warehouse_id=UUID("00000000-0000-0000-0000-000000000003")
@@ -398,12 +400,12 @@ class TestValidNotificationWithMatchingTitleRobustMaturity:
         create_warehouse: Callable[..., Warehouse],
     ):
         """
-        Valid notification with empty folder_name + robust title → book has collection
+        Valid notification with empty folder_name + stable title → book has collection
         warehouse targets.
         """
 
         title = create_title(name="test_en_all")
-        title.maturity = "robust"
+        title.maturity = "stable"
 
         prod = create_warehouse(
             name="prod", warehouse_id=UUID("00000000-0000-0000-0000-000000000003")
@@ -459,7 +461,7 @@ class TestValidNotificationOnArchivedTitle:
         create_warehouse: Callable[..., Warehouse],
     ):
         title = create_title(name="test_en_all", archived=True)
-        title.maturity = "robust"
+        title.maturity = "stable"
 
         prod = create_warehouse(
             name="prod", warehouse_id=UUID("00000000-0000-0000-0000-000000000003")

--- a/frontend/src/components/TitleFormDialog.vue
+++ b/frontend/src/components/TitleFormDialog.vue
@@ -16,15 +16,20 @@
             class="mb-2"
           />
 
-          <v-select
-            v-model="formData.maturity"
-            label="Maturity"
-            :items="maturityOptions"
-            :rules="[rules.required]"
-            variant="outlined"
+          <v-switch
+            v-model="isStable"
+            color="primary"
             density="comfortable"
             class="mb-2"
-          />
+            :hint="maturityHint"
+            persistent-hint
+          >
+            <template #label>
+              <span class="text-subtitle-1"
+                >Maturity: <strong>{{ formData.maturity }}</strong></span
+              >
+            </template>
+          </v-switch>
 
           <v-divider class="my-4" />
 
@@ -157,12 +162,26 @@ const loading = ref(false)
 const loadingCollections = ref(false)
 const error = ref('')
 
-const maturityOptions = ['dev', 'robust']
-
 const formData = ref<TitleCreate>({
   name: '',
-  maturity: 'dev',
+  maturity: 'unstable',
   collection_titles: [],
+})
+
+const maturityHint = computed(() => {
+  if (formData.value.maturity === 'unstable') {
+    return 'ZIM files will go through staging first before moving to production.'
+  } else if (formData.value.maturity === 'stable') {
+    return 'ZIM files will go directly to production.'
+  }
+  return ''
+})
+
+const isStable = computed({
+  get: () => formData.value.maturity === 'stable',
+  set: (value: boolean) => {
+    formData.value.maturity = value ? 'stable' : 'unstable'
+  },
 })
 
 const originalCollections = ref<BaseTitleCollection[]>([])
@@ -373,7 +392,7 @@ function resetForm() {
   } else {
     formData.value = {
       name: '',
-      maturity: 'dev',
+      maturity: 'unstable',
       collection_titles: [],
     }
     originalCollections.value = []

--- a/frontend/src/components/TitlesBaseView.vue
+++ b/frontend/src/components/TitlesBaseView.vue
@@ -132,7 +132,10 @@ const props = withDefaults(
 // Define headers for the table
 const headers = [
   { title: 'Name', value: 'name' },
-  { title: 'Maturity', value: 'maturity' },
+  {
+    title: 'Maturity',
+    value: 'maturity',
+  },
 ]
 
 // Reactive state

--- a/frontend/src/components/TitlesTable.vue
+++ b/frontend/src/components/TitlesTable.vue
@@ -57,6 +57,26 @@
           </div>
         </template>
 
+        <template #[`header.maturity`]="{ column }">
+          <div class="d-flex align-center">
+            <span>{{ column.title }}</span>
+            <v-tooltip location="top">
+              <template #activator="{ props: tooltipProps }">
+                <v-icon v-bind="tooltipProps" size="small" class="ml-1" color="grey-darken-1">
+                  mdi-information-outline
+                </v-icon>
+              </template>
+              <div>
+                <div>
+                  <strong>Unstable:</strong> ZIM files go through staging first before moving to
+                  production
+                </div>
+                <div><strong>Stable:</strong> ZIM files go directly to production</div>
+              </div>
+            </v-tooltip>
+          </div>
+        </template>
+
         <template #[`item.name`]="{ item }">
           <span class="d-flex align-center">
             {{ item.name }}


### PR DESCRIPTION
## Rationale

This PR changes the title maturity levels from dev to unstable and robust to stable across the codebase
<img width="912" height="629" alt="Screenshot_20260521_104044" src="https://github.com/user-attachments/assets/348dbddb-08b8-46b5-afa0-fd58f33dbea6" />

<img width="1196" height="275" alt="Screenshot_20260521_100721" src="https://github.com/user-attachments/assets/7c64653c-221d-4479-bcd4-485bbbe24e92" />


## Changes
- add migration script to rename existing entries in DB
- update UI to support the new options

This closes #129 