### PR TITLE
view books and update book flavour

### DIFF
--- a/backend/src/cms_backend/api/routes/books.py
+++ b/backend/src/cms_backend/api/routes/books.py
@@ -14,11 +14,16 @@ from cms_backend.db.book import delete_book as db_delete_book
 from cms_backend.db.book import get_book as db_get_book
 from cms_backend.db.book import move_book as db_move_book
 from cms_backend.db.book import recover_book as db_recover_book
+from cms_backend.db.book import update_book as db_update_book
+from cms_backend.db.books import get_book_flavours as db_get_book_flavours
 from cms_backend.db.books import get_book_languages as db_get_book_languages
 from cms_backend.db.books import get_books as db_get_books
 from cms_backend.db.books import get_zim_urls as db_get_zim_urls
 from cms_backend.schemas import BaseModel
-from cms_backend.schemas.models import BookLanguagesSchema, ZimUrlsSchema
+from cms_backend.schemas.models import (
+    BookLanguagesSchema,
+    ZimUrlsSchema,
+)
 from cms_backend.schemas.orms import (
     BookFullSchema,
     BookLightSchema,
@@ -43,6 +48,12 @@ class BooksGetSchema(BaseModel):
     needs_attention: bool | None = None
     updated_before: datetime.datetime | None = None
     updated_after: datetime.datetime | None = None
+    name: NotEmptyString | None = None
+    flavour: NotEmptyString | None = None
+
+
+class BookUpdateSchema(BaseModel):
+    flavour: NotEmptyString
 
 
 @router.get("")
@@ -65,6 +76,8 @@ def get_books(
         needs_attention=params.needs_attention,
         updated_before=params.updated_before,
         updated_after=params.updated_after,
+        name=params.name,
+        flavour=params.flavour,
     )
 
     return ListResponse[BookLightSchema](
@@ -93,6 +106,22 @@ def get_book_languages(
     return db_get_book_languages(session)
 
 
+@router.get("/flavours")
+def get_book_flavours(
+    session: Annotated[OrmSession, Depends(gen_dbsession)],
+) -> ListResponse[str]:
+    results = db_get_book_flavours(session)
+    return ListResponse[str](
+        meta=calculate_pagination_metadata(
+            nb_records=results.nb_records,
+            skip=0,
+            limit=len(results.records),
+            page_size=len(results.records),
+        ),
+        items=results.records,
+    )
+
+
 @router.get("/{book_id}")
 def get_book(
     book_id: Annotated[UUID, Path()],
@@ -100,6 +129,20 @@ def get_book(
 ) -> BookFullSchema:
     """Get a book by ID"""
     return create_book_full_schema(db_get_book(session=session, book_id=book_id))
+
+
+@router.patch(
+    "/{book_id}",
+    dependencies=[Depends(require_permission(namespace="book", name="update"))],
+)
+def update_book(
+    book_id: Annotated[UUID, Path()],
+    session: Annotated[OrmSession, Depends(gen_dbsession)],
+    request: BookUpdateSchema,
+) -> BookFullSchema:
+    return create_book_full_schema(
+        db_update_book(session, book_id=book_id, flavour=request.flavour)
+    )
 
 
 @router.delete(

--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -337,3 +337,23 @@ def recover_book(session: OrmSession, book_id: UUID) -> Book:
     session.add(book)
     session.flush()
     return book
+
+
+def update_book(session: OrmSession, book_id: UUID, *, flavour: str) -> Book:
+    book = get_book(session, book_id)
+    if book.location_kind == "deleted":
+        raise RecordDoesNotExistError(f"Book {book_id} is already deleted.")
+
+    if book.title and book.title.archived:
+        raise ValueError(f"Book title {book.title_id} is currently archived")
+
+    if book.flavour == flavour:
+        return book
+
+    book.events.append(
+        f"{getnow()}: flavour updated from '{book.flavour}' to '{flavour}'"
+    )
+    book.flavour = flavour
+    session.add(book)
+    session.flush()
+    return book

--- a/backend/src/cms_backend/db/books.py
+++ b/backend/src/cms_backend/db/books.py
@@ -20,6 +20,8 @@ def get_books(
     skip: int,
     limit: int,
     book_id: str | None = None,
+    name: str | None = None,
+    flavour: str | None = None,
     has_title: bool | None = None,
     needs_processing: bool | None = None,
     has_error: bool | None = None,
@@ -53,6 +55,12 @@ def get_books(
 
     if book_id is not None:
         stmt = stmt.where(Book.id.cast(String).ilike(f"%{book_id}%"))
+
+    if name is not None:
+        stmt = stmt.where(Book.name.ilike(f"%{name}%"))
+
+    if flavour is not None:
+        stmt = stmt.where(Book.flavour == flavour)
 
     if has_title is not None:
         if has_title:
@@ -91,7 +99,7 @@ def get_books(
     elif needs_attention is False:
         stmt = stmt.where(
             and_(
-                Book.location_kind.not_in(["quarantine", "staging"]),
+                Book.location_kind.not_in(["quarantine", "staging", "deleted"]),
                 Book.title_id.is_not(None),
                 Book.needs_processing.is_(False),
                 Book.needs_file_operation.is_(False),
@@ -313,3 +321,19 @@ def get_book_languages(session: OrmSession) -> BookLanguagesSchema:
                 languages.add(normalized_language)
 
     return BookLanguagesSchema(languages=sorted(languages))
+
+
+def get_book_flavours(session: OrmSession) -> ListResult[str]:
+    """Get a list of book falavours"""
+    stmt = (
+        select(Book.flavour)
+        .distinct()
+        .order_by(Book.flavour)
+        .where(Book.flavour.isnot(None))
+    )
+    return ListResult[str](
+        nb_records=count_from_stmt(session, stmt),
+        records=[
+            flavour for flavour in session.scalars(stmt).all() if flavour is not None
+        ],
+    )

--- a/backend/tests/api/routes/test_books.py
+++ b/backend/tests/api/routes/test_books.py
@@ -7,7 +7,9 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session as OrmSession
 
-from cms_backend.db.models import Book, Title
+from cms_backend.api.token import generate_access_token
+from cms_backend.db.models import Account, Book, Title
+from cms_backend.roles import RoleEnum
 from cms_backend.utils.datetime import getnow
 
 
@@ -293,6 +295,21 @@ def test_get_book_languages(
     assert response.json() == {"languages": ["deu", "eng", "fra", "spa"]}
 
 
+def test_get_book_flavours(
+    client: TestClient,
+    create_book: Callable[..., Book],
+):
+    """Test books flavours endpoint returns sorted distinct flavours."""
+    for flavour in ["maxi", "mini", "nopic", "maxi", "mini"]:
+        create_book(flavour=flavour)
+
+    response = client.get("/v1/books/flavours")
+    assert response.status_code == HTTPStatus.OK
+    response_doc = response.json()
+    assert response_doc["items"] == ["maxi", "mini", "nopic"]
+    assert response_doc["meta"]["count"] == 3
+
+
 def test_get_book_by_id(
     client: TestClient,
     book: Book,
@@ -391,3 +408,31 @@ def test_get_books_filter_by_date_range(
     assert response.status_code == HTTPStatus.OK
     response_doc = response.json()
     assert response_doc["meta"]["count"] == 1  # only two days ago
+
+
+@pytest.mark.parametrize(
+    "permission,expected_status_code",
+    [
+        pytest.param(RoleEnum.EDITOR, HTTPStatus.OK, id="editor"),
+        pytest.param(RoleEnum.VIEWER, HTTPStatus.UNAUTHORIZED, id="viewer"),
+    ],
+)
+def test_update_book_required_permissions(
+    client: TestClient,
+    create_account: Callable[..., Account],
+    create_book: Callable[..., Book],
+    permission: RoleEnum,
+    expected_status_code: HTTPStatus,
+):
+    """Test updating a book with different roles"""
+    book = create_book(flavour="maxi")
+    account = create_account(permission=permission)
+    access_token = generate_access_token(
+        account_id=str(account.id), issue_time=getnow()
+    )
+    response = client.patch(
+        f"/v1/books/{book.id}",
+        json={"flavour": "mini"},
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == expected_status_code

--- a/backend/tests/db/test_book.py
+++ b/backend/tests/db/test_book.py
@@ -1,8 +1,13 @@
+from collections.abc import Callable
+
+import pytest
 from faker import Faker
 from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend.db.book import create_book as db_create_book
-from cms_backend.db.models import ZimfarmNotification
+from cms_backend.db.book import update_book
+from cms_backend.db.exceptions import RecordDoesNotExistError
+from cms_backend.db.models import Book, Title, ZimfarmNotification
 
 
 def test_create_book(
@@ -32,3 +37,46 @@ def test_create_book(
     assert any(
         event for event in book.events if "created from Zimfarm notification" in event
     )
+
+
+def test_update_deleted_book(dbsession: OrmSession, create_book: Callable[..., Book]):
+    book = create_book(location_kind="deleted")
+    with pytest.raises(RecordDoesNotExistError, match=r"Book .* is already deleted"):
+        update_book(dbsession, book.id, flavour="maxi")
+
+
+def test_update_book_belonging_to_archived_title(
+    dbsession: OrmSession,
+    create_title: Callable[..., Title],
+    create_book: Callable[..., Book],
+):
+    book = create_book()
+    title = create_title(archived=True)
+    book.title = title
+    dbsession.add(book)
+    dbsession.flush()
+
+    with pytest.raises(ValueError, match=r"Book title .* is currently archived"):
+        update_book(dbsession, book.id, flavour="maxi")
+
+
+def test_update_book_with_same_flavour(
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+):
+    book = create_book(flavour="maxi")
+    assert book.flavour is not None
+    update_book(dbsession, book.id, flavour=book.flavour)
+    assert len(book.events) == 0
+
+
+def test_update_book_with_different_flavour(
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+):
+    book = create_book(flavour="maxi")
+    assert book.flavour is not None
+    book = update_book(dbsession, book.id, flavour="mini")
+    assert book.flavour == "mini"
+    assert len(book.events) == 1
+    assert any("flavour updated from" in event for event in book.events)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -36,6 +36,14 @@ const navigationItems = computed<NavigationItem[]>(() => [
     show: true,
   },
   {
+    name: 'books',
+    label: 'Books',
+    route: 'books',
+    icon: 'mdi-book-multiple',
+    disabled: false,
+    show: true,
+  },
+  {
     name: 'titles',
     label: 'Titles',
     route: 'titles',

--- a/frontend/src/components/BooksViewFilters.vue
+++ b/frontend/src/components/BooksViewFilters.vue
@@ -1,0 +1,186 @@
+<template>
+  <v-card flat class="mb-4">
+    <v-card-text>
+      <v-row>
+        <v-col cols="12" sm="6" md="3">
+          <v-text-field
+            v-model="localFilters.id"
+            label="ID"
+            placeholder="Search by ID..."
+            variant="outlined"
+            density="compact"
+            hide-details
+            @change="emitFilters"
+          />
+        </v-col>
+        <v-col cols="12" sm="6" md="3">
+          <v-text-field
+            v-model="localFilters.name"
+            label="Name"
+            placeholder="Search by name..."
+            variant="outlined"
+            density="compact"
+            hide-details
+            @change="emitFilters"
+          />
+        </v-col>
+        <v-col cols="12" sm="6" md="3">
+          <v-select
+            v-model="localFilters.flavour"
+            label="Flavour"
+            :items="formattedFlavourOptions"
+            placeholder="Select flavour"
+            variant="outlined"
+            density="compact"
+            hide-details
+            clearable
+            :loading="loadingFlavours"
+            @update:model-value="emitFilters"
+          />
+        </v-col>
+        <v-col cols="12" sm="6" md="3">
+          <v-select
+            v-model="localFilters.needs_attention"
+            label="Needs Attention"
+            :items="needsAttentionOptions"
+            placeholder="Select needs attention"
+            variant="outlined"
+            density="compact"
+            hide-details
+            clearable
+            @update:model-value="emitFilters"
+          />
+        </v-col>
+        <v-col cols="12" sm="6" md="3">
+          <v-select
+            v-model="localFilters.location_kind"
+            label="Location"
+            :items="formattedLocationKindOptions"
+            placeholder="Select location kind"
+            variant="outlined"
+            density="compact"
+            hide-details
+            clearable
+            @update:model-value="emitFilters"
+          />
+        </v-col>
+        <v-col
+          v-if="hasActiveFilters"
+          cols="12"
+          class="d-flex flex-sm-row flex-column align-sm-center"
+        >
+          <v-btn size="small" variant="outlined" @click="handleClearFilters">
+            <v-icon size="small" class="mr-1">mdi-close-circle</v-icon>
+            clear filters
+          </v-btn>
+        </v-col>
+      </v-row>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+// Props
+interface Props {
+  filters: {
+    id: string
+    name: string
+    flavour: string
+    needs_attention: string
+    location_kind: string
+  }
+  locationKindOptions?: string[]
+  flavourOptions?: string[]
+  loadingFlavours?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  locationKindOptions: () => ['quarantine', 'staging', 'prod'],
+  flavourOptions: () => [],
+  loadingFlavours: false,
+})
+
+// Define emits
+const emit = defineEmits<{
+  filtersChanged: [
+    filters: {
+      id: string
+      name: string
+      flavour: string
+      needs_attention: string
+      location_kind: string
+    },
+  ]
+  clearFilters: []
+}>()
+
+// Local filters state
+const localFilters = ref({
+  id: props.filters.id,
+  name: props.filters.name,
+  flavour: props.filters.flavour,
+  needs_attention: props.filters.needs_attention,
+  location_kind: props.filters.location_kind,
+})
+
+// Watch for prop changes and update local state
+watch(
+  () => props.filters,
+  (newFilters) => {
+    localFilters.value = {
+      id: newFilters.id,
+      name: newFilters.name,
+      flavour: newFilters.flavour,
+      needs_attention: newFilters.needs_attention,
+      location_kind: newFilters.location_kind,
+    }
+  },
+)
+
+const formattedLocationKindOptions = computed(() => {
+  return props.locationKindOptions.map((option) => ({
+    title: option.charAt(0).toUpperCase() + option.slice(1),
+    value: option,
+  }))
+})
+
+const formattedFlavourOptions = computed(() => {
+  return props.flavourOptions.map((option) => ({
+    title: option,
+    value: option,
+  }))
+})
+
+const needsAttentionOptions = [
+  { title: 'All', value: 'all' },
+  { title: 'Yes', value: 'yes' },
+  { title: 'No', value: 'no' },
+]
+
+const hasActiveFilters = computed(() => {
+  return (
+    props.filters.id.length > 0 ||
+    props.filters.name.length > 0 ||
+    props.filters.flavour.length > 0 ||
+    props.filters.needs_attention.length > 0 ||
+    props.filters.location_kind.length > 0
+  )
+})
+
+// Emit filters when they change
+function emitFilters() {
+  emit('filtersChanged', {
+    id: localFilters.value.id,
+    name: localFilters.value.name,
+    flavour: localFilters.value.flavour,
+    needs_attention: localFilters.value.needs_attention,
+    location_kind: localFilters.value.location_kind,
+  })
+}
+
+function handleClearFilters() {
+  emit('clearFilters')
+}
+</script>

--- a/frontend/src/components/EditBookForm.vue
+++ b/frontend/src/components/EditBookForm.vue
@@ -1,0 +1,103 @@
+<template>
+  <v-card flat>
+    <v-card-text>
+      <v-form ref="formRef" @submit.prevent="handleSubmit">
+        <v-row>
+          <v-col cols="12">
+            <v-select
+              v-model="localBook.flavour"
+              label="Flavour"
+              :items="formattedFlavourOptions"
+              :rules="[rules.required]"
+              variant="outlined"
+              :loading="loadingFlavours"
+              :disabled="loading"
+            />
+          </v-col>
+        </v-row>
+
+        <v-row>
+          <v-col cols="12" class="d-flex justify-end">
+            <v-btn
+              :color="isDisabled ? undefined : 'primary'"
+              type="submit"
+              :loading="loading"
+              :disabled="isDisabled"
+            >
+              Save Changes
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-form>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+import type { Book } from '@/types/book'
+import { computed, ref, watch } from 'vue'
+
+interface Props {
+  book: Book | null
+  loading?: boolean
+  flavourOptions?: string[]
+  loadingFlavours?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  loading: false,
+  flavourOptions: () => [],
+  loadingFlavours: false,
+})
+
+const emit = defineEmits<{
+  submit: [book: { flavour: string }]
+}>()
+
+const formRef = ref()
+
+const localBook = ref({
+  flavour: props.book?.flavour || '',
+})
+
+const rules = {
+  required: (value: string) => !!value || 'This field is required',
+}
+
+const isDisabled = computed(() => {
+  return props.loading || !hasChanges.value
+})
+
+const formattedFlavourOptions = computed(() => {
+  return props.flavourOptions.map((option) => ({
+    title: option,
+    value: option,
+  }))
+})
+
+const hasChanges = computed(() => {
+  if (!props.book) return false
+  return localBook.value.flavour !== props.book.flavour
+})
+
+watch(
+  () => props.book,
+  (newBook) => {
+    if (newBook) {
+      localBook.value = {
+        flavour: newBook.flavour || '',
+      }
+    }
+  },
+  { deep: true, immediate: true },
+)
+
+const handleSubmit = async () => {
+  const { valid } = await formRef.value.validate()
+  if (valid) {
+    emit('submit', {
+      flavour: localBook.value.flavour,
+    })
+  }
+}
+</script>

--- a/frontend/src/components/InboxBookFilters.vue
+++ b/frontend/src/components/InboxBookFilters.vue
@@ -22,9 +22,8 @@
             variant="outlined"
             density="compact"
             hide-details
-            :clearable="hasActiveFilters"
+            clearable
             @update:model-value="emitFilters"
-            @click:clear="handleClearFilters"
           />
         </v-col>
         <v-col cols="12" sm="6" md="3">
@@ -36,9 +35,8 @@
             variant="outlined"
             density="compact"
             hide-details
-            :clearable="hasActiveFilters"
+            clearable
             @update:model-value="emitFilters"
-            @click:clear="handleClearFilters"
           />
         </v-col>
         <v-col

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -12,6 +12,7 @@ import { createRouter, createWebHistory, type RouteLocationNormalized } from 'vu
 import TitlesView from '@/views/TitlesView.vue'
 import TitleView from '@/views/TitleView.vue'
 import BookView from '@/views/BookView.vue'
+import BooksView from '@/views/BooksView.vue'
 import ZimfarmNotificationView from '@/views/ZimfarmNotificationView.vue'
 
 const routes = [
@@ -43,6 +44,12 @@ const routes = [
     name: 'inbox',
     component: InboxView,
     meta: { title: 'CMS | Inbox' },
+  },
+  {
+    path: '/books',
+    name: 'books',
+    component: BooksView,
+    meta: { title: 'CMS | Books' },
   },
   {
     path: '/titles',
@@ -77,6 +84,15 @@ const routes = [
   {
     path: '/book/:id',
     name: 'book-detail',
+    component: BookView,
+    props: true,
+    meta: {
+      title: (to: RouteLocationNormalized) => `CMS | Book • ${to.params.id}`,
+    },
+  },
+  {
+    path: '/book/:id/:selectedTab',
+    name: 'book-detail-tab',
     component: BookView,
     props: true,
     meta: {

--- a/frontend/src/stores/book.ts
+++ b/frontend/src/stores/book.ts
@@ -48,6 +48,8 @@ export const useBookStore = defineStore('book', () => {
     id: string | undefined = undefined,
     location_kinds: string[] | undefined = undefined,
     flag: string | undefined = undefined,
+    name: string | undefined = undefined,
+    flavour: string | undefined = undefined,
   ) => {
     const service = await authStore.getApiService('books')
 
@@ -68,6 +70,8 @@ export const useBookStore = defineStore('book', () => {
         needs_processing,
         has_error,
         has_title,
+        name,
+        flavour,
       }).filter(
         ([name, value]) => !!value || (!['limit', 'skip'].includes(name) && value !== undefined),
       ),
@@ -151,6 +155,36 @@ export const useBookStore = defineStore('book', () => {
     }
   }
 
+  const fetchBookFlavours = async () => {
+    const service = await authStore.getApiService('books')
+    try {
+      const response = await service.get<null, ListResponse<string>>('/flavours')
+      errors.value = []
+      return response.items
+    } catch (_error) {
+      console.error('Failed to fetch book flavours', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
+  const updateBook = async (bookId: string, bookData: Partial<{ flavour: string }>) => {
+    const service = await authStore.getApiService('books')
+    try {
+      errors.value = []
+      const response = await service.patch<Partial<{ flavour: string }>, Book>(
+        `/${bookId}`,
+        bookData,
+      )
+      book.value = response
+      return response
+    } catch (_error) {
+      console.error('Failed to update book', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
   return {
     // State
     defaultLimit,
@@ -166,5 +200,7 @@ export const useBookStore = defineStore('book', () => {
     deleteBook,
     recoverBook,
     moveBook,
+    fetchBookFlavours,
+    updateBook,
   }
 })

--- a/frontend/src/views/BookView.vue
+++ b/frontend/src/views/BookView.vue
@@ -38,234 +38,290 @@
         </v-btn>
       </div>
 
-      <div>
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Id</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <code>{{ book.id }}</code>
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+      <v-tabs
+        v-model="currentTab"
+        class="mb-4"
+        color="primary"
+        slider-color="primary"
+        :grow="!smAndDown"
+        show-arrows
+      >
+        <v-tab
+          base-color="primary"
+          value="info"
+          :to="{
+            name: 'book-detail',
+            params: { id: book.id },
+          }"
+        >
+          <v-icon class="mr-2">mdi-information</v-icon>
+          Info
+        </v-tab>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Title Id</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <router-link
-              v-if="book.title_id"
-              :to="{ name: 'title-detail', params: { id: book.title_id } }"
-            >
-              {{ book.title_id }}
-            </router-link>
-            <span v-else class="text-grey">None</span>
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+        <v-tab
+          base-color="primary"
+          v-if="canEditBook"
+          value="edit"
+          :to="{
+            name: 'book-detail-tab',
+            params: { id: book.id, selectedTab: 'edit' },
+          }"
+        >
+          <v-icon class="mr-2">mdi-pencil</v-icon>
+          Edit
+        </v-tab>
+      </v-tabs>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Status</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <BookStatus :book="book" force-row />
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+      <v-window v-model="currentTab">
+        <!-- Info Tab -->
+        <v-window-item value="info">
+          <v-card flat>
+            <v-card-text class="pa-0">
+              <div class="ml-4 mr-4 mt-2 mb-2">
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Id</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <code>{{ book.id }}</code>
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Created</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <v-tooltip location="bottom">
-              <template #activator="{ props }">
-                <span v-bind="props">
-                  {{ fromNow(book.created_at) }}
-                </span>
-              </template>
-              <span>{{ formatDt(book.created_at) }}</span>
-            </v-tooltip>
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Title Id</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <router-link
+                      v-if="book.title_id"
+                      :to="{ name: 'title-detail', params: { id: book.title_id } }"
+                    >
+                      {{ book.title_id }}
+                    </router-link>
+                    <span v-else class="text-grey">None</span>
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Name</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <span v-if="book.name">{{ book.name }}</span>
-            <span v-else class="text-grey">-</span>
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Status</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <BookStatus :book="book" force-row />
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Flavour</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <span v-if="book.flavour">{{ book.flavour }}</span>
-            <span v-else class="text-grey">-</span>
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Created</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <v-tooltip location="bottom">
+                      <template #activator="{ props }">
+                        <span v-bind="props">
+                          {{ fromNow(book.created_at) }}
+                        </span>
+                      </template>
+                      <span>{{ formatDt(book.created_at) }}</span>
+                    </v-tooltip>
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Date</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <span v-if="book.date">{{ book.date }}</span>
-            <span v-else class="text-grey">-</span>
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Name</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <span v-if="book.name">{{ book.name }}</span>
+                    <span v-else class="text-grey">-</span>
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">URLs</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <ZimUrlButtons :urls="zimUrls" :loading="loadingUrls" />
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Flavour</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <span v-if="book.flavour">{{ book.flavour }}</span>
+                    <span v-else class="text-grey">-</span>
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Article Count</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            {{ book.article_count.toLocaleString() }}
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Date</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <span v-if="book.date">{{ book.date }}</span>
+                    <span v-else class="text-grey">-</span>
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Media Count</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            {{ book.media_count.toLocaleString() }}
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">URLs</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <ZimUrlButtons :urls="zimUrls" :loading="loadingUrls" />
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Size</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            {{ formatBytes(book.size) }}
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Article Count</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    {{ book.article_count.toLocaleString() }}
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">
-              ZIM Metadata
-              <v-btn
-                size="small"
-                variant="outlined"
-                class="ml-2"
-                @click="copyToClipboard(JSON.stringify(book.zim_metadata, null, 2))"
-              >
-                <v-icon size="small" class="mr-1">mdi-content-copy</v-icon>
-                Copy
-              </v-btn>
-            </div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <div class="overflow-y-auto overflow-x-auto" style="max-height: 400px">
-              <pre>{{ JSON.stringify(book.zim_metadata, null, 2) }}</pre>
-            </div>
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Media Count</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    {{ book.media_count.toLocaleString() }}
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">
-              Zimcheck Result
-              <v-btn
-                size="small"
-                variant="outlined"
-                class="ml-2"
-                @click="copyToClipboard(JSON.stringify(book.zimcheck_result, null, 2))"
-              >
-                <v-icon size="small" class="mr-1">mdi-content-copy</v-icon>
-                Copy
-              </v-btn>
-            </div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <div class="overflow-y-auto overflow-x-auto" style="max-height: 400px">
-              <pre>{{ JSON.stringify(book.zimcheck_result, null, 2) }}</pre>
-            </div>
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Size</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    {{ formatBytes(book.size) }}
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Current Locations</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <v-data-table
-              v-if="book.current_locations.length > 0"
-              :headers="locationHeaders"
-              :items="book.current_locations"
-              :items-per-page="-1"
-              :mobile="smAndDown"
-              density="compact"
-              hide-default-footer
-            >
-              <template #[`item.filename`]="{ item }">
-                <code>{{ item.filename }}</code>
-              </template>
-            </v-data-table>
-            <span v-else class="text-grey">No current locations</span>
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">
+                      ZIM Metadata
+                      <v-btn
+                        size="small"
+                        variant="outlined"
+                        class="ml-2"
+                        @click="copyToClipboard(JSON.stringify(book.zim_metadata, null, 2))"
+                      >
+                        <v-icon size="small" class="mr-1">mdi-content-copy</v-icon>
+                        Copy
+                      </v-btn>
+                    </div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <div class="overflow-y-auto overflow-x-auto" style="max-height: 400px">
+                      <pre>{{ JSON.stringify(book.zim_metadata, null, 2) }}</pre>
+                    </div>
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Target Locations</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <v-data-table
-              v-if="book.target_locations.length > 0"
-              :headers="locationHeaders"
-              :items="book.target_locations"
-              :items-per-page="-1"
-              :mobile="smAndDown"
-              density="compact"
-              hide-default-footer
-            >
-              <template #[`item.filename`]="{ item }">
-                <code>{{ item.filename }}</code>
-              </template>
-            </v-data-table>
-            <span v-else class="text-grey">No target locations</span>
-          </v-col>
-        </v-row>
-        <v-divider class="my-2"></v-divider>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">
+                      Zimcheck Result
+                      <v-btn
+                        size="small"
+                        variant="outlined"
+                        class="ml-2"
+                        @click="copyToClipboard(JSON.stringify(book.zimcheck_result, null, 2))"
+                      >
+                        <v-icon size="small" class="mr-1">mdi-content-copy</v-icon>
+                        Copy
+                      </v-btn>
+                    </div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <div class="overflow-y-auto overflow-x-auto" style="max-height: 400px">
+                      <pre>{{ JSON.stringify(book.zimcheck_result, null, 2) }}</pre>
+                    </div>
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
 
-        <v-row no-gutters class="py-2">
-          <v-col cols="12" md="3">
-            <div class="text-subtitle-2">Events</div>
-          </v-col>
-          <v-col cols="12" md="9">
-            <EventsList :events="book.events" />
-          </v-col>
-        </v-row>
-      </div>
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Current Locations</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <v-data-table
+                      v-if="book.current_locations.length > 0"
+                      :headers="locationHeaders"
+                      :items="book.current_locations"
+                      :items-per-page="-1"
+                      :mobile="smAndDown"
+                      density="compact"
+                      hide-default-footer
+                    >
+                      <template #[`item.filename`]="{ item }">
+                        <code>{{ item.filename }}</code>
+                      </template>
+                    </v-data-table>
+                    <span v-else class="text-grey">No current locations</span>
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
+
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Target Locations</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <v-data-table
+                      v-if="book.target_locations.length > 0"
+                      :headers="locationHeaders"
+                      :items="book.target_locations"
+                      :items-per-page="-1"
+                      :mobile="smAndDown"
+                      density="compact"
+                      hide-default-footer
+                    >
+                      <template #[`item.filename`]="{ item }">
+                        <code>{{ item.filename }}</code>
+                      </template>
+                    </v-data-table>
+                    <span v-else class="text-grey">No target locations</span>
+                  </v-col>
+                </v-row>
+                <v-divider class="my-2"></v-divider>
+
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Events</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <EventsList :events="book.events" />
+                  </v-col>
+                </v-row>
+              </div>
+            </v-card-text>
+          </v-card>
+        </v-window-item>
+
+        <!-- Edit Tab -->
+        <v-window-item value="edit">
+          <div v-if="canEditBook" class="pa-4">
+            <EditBookForm
+              :book="book"
+              :loading="updatingBook"
+              :flavour-options="flavours"
+              :loading-flavours="loadingFlavours"
+              @submit="handleUpdateBook"
+            />
+          </div>
+        </v-window-item>
+      </v-window>
     </div>
 
     <MoveBookDialog v-model="moveDialogOpen" :book="book" @moved="handleBookMoved" />
@@ -277,6 +333,7 @@
 <script setup lang="ts">
 import BookStatus from '@/components/BookStatus.vue'
 import DeleteBookDialog from '@/components/DeleteBookDialog.vue'
+import EditBookForm from '@/components/EditBookForm.vue'
 import EventsList from '@/components/EventsList.vue'
 import MoveBookDialog from '@/components/MoveBookDialog.vue'
 import RecoverBookDialog from '@/components/RecoverBookDialog.vue'
@@ -305,18 +362,31 @@ const zimUrls = ref<ZimUrl[]>([])
 const moveDialogOpen = ref(false)
 const recoverDialogOpen = ref(false)
 const deleteDialogOpen = ref(false)
+const updatingBook = ref(false)
+const flavours = ref<string[]>([])
+const loadingFlavours = ref(false)
 
 interface Props {
   id: string
+  selectedTab?: string
 }
 
-const props = withDefaults(defineProps<Props>(), {})
+const props = withDefaults(defineProps<Props>(), {
+  selectedTab: 'info',
+})
 
 const locationHeaders = [
   { title: 'Warehouse', value: 'warehouse_name', sortable: false },
   { title: 'Folder', value: 'path', sortable: false },
   { title: 'Filename', value: 'filename', sortable: false },
 ]
+
+const currentTab = ref(props.selectedTab)
+
+const canEditBook = computed(() => {
+  if (!book.value) return false
+  return authStore.hasPermission('book', 'update') && !book.value.title_archived
+})
 
 const canMoveBook = computed(() => {
   if (!book.value) return false
@@ -404,14 +474,6 @@ onMounted(async () => {
   await loadData(true)
 })
 
-// Watch for book id changes (e.g. navigating between books without remounting)
-watch(
-  () => props.id,
-  async () => {
-    await loadData(true)
-  },
-)
-
 const copyToClipboard = async (text: string) => {
   try {
     await navigator.clipboard.writeText('```\n' + text + '\n```\n')
@@ -457,4 +519,43 @@ const handleBookDeleted = async () => {
   notificationStore.showSuccess('Book deleted successfully!')
   await loadData()
 }
+
+const handleUpdateBook = async (bookData: { flavour: string }) => {
+  updatingBook.value = true
+  const updatedBook = await bookStore.updateBook(props.id, bookData)
+  if (updatedBook) {
+    book.value = updatedBook
+    notificationStore.showSuccess('Book updated successfully!')
+  } else {
+    for (const error of bookStore.errors) {
+      notificationStore.showError(error)
+    }
+  }
+  updatingBook.value = false
+}
+
+watch(
+  () => props.selectedTab,
+  async (newTab) => {
+    if (newTab === 'edit' && flavours.value.length == 0) {
+      loadingFlavours.value = true
+      const fetchedFlavours = await bookStore.fetchBookFlavours()
+      if (fetchedFlavours) {
+        flavours.value = fetchedFlavours
+      }
+      loadingFlavours.value = false
+    }
+    currentTab.value = newTab
+  },
+  { immediate: true },
+)
+
+watch(
+  () => props.id,
+  async () => {
+    book.value = null
+    currentTab.value = 'info'
+    await loadData(true)
+  },
+)
 </script>

--- a/frontend/src/views/BooksView.vue
+++ b/frontend/src/views/BooksView.vue
@@ -1,0 +1,236 @@
+<template>
+  <BooksViewFilters
+    :filters="bookFilters"
+    :flavour-options="flavours"
+    :loading-flavours="loadingFlavours"
+    @filters-changed="handleBookFiltersChange"
+    @clear-filters="clearFilters"
+  />
+  <BookTable
+    :headers="headers"
+    :books="books"
+    :paginator="paginator"
+    :loading="loadingStore.isLoading"
+    :loading-text="loadingStore.loadingText"
+    :errors="errors"
+    @limit-changed="handleLimitChange"
+    @load-data="loadData"
+  />
+</template>
+
+<script setup lang="ts">
+import BooksViewFilters from '@/components/BooksViewFilters.vue'
+import BookTable from '@/components/BookTable.vue'
+import { useLoadingStore } from '@/stores/loading'
+import { useBookStore } from '@/stores/book'
+import type { BookLight } from '@/types/book'
+import type { Paginator } from '@/types/base'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+
+const router = useRouter()
+const route = useRoute()
+
+const bookStore = useBookStore()
+const loadingStore = useLoadingStore()
+
+const flavours = ref<string[]>([])
+const loadingFlavours = ref(false)
+
+// Define headers for the table
+const headers = [
+  { title: 'Name', value: 'name' },
+  { title: 'Flavour', value: 'flavour' },
+  { title: 'Status', value: 'status' },
+  { title: 'Date', value: 'date' },
+  { title: 'Deletion Date', value: 'deletion_date' },
+]
+
+const defaultLimit = computed(() => bookStore.defaultLimit)
+
+const books = ref<BookLight[]>([])
+const paginator = ref<Paginator>({
+  page: Number(route.query.page) || 1,
+  page_size: defaultLimit.value,
+  skip: 0,
+  limit: defaultLimit.value,
+  count: 0,
+})
+const errors = ref<string[]>([])
+
+const bookFilters = computed(() => {
+  const query = router.currentRoute.value.query
+  const derived = {
+    id: '',
+    name: '',
+    flavour: '',
+    needs_attention: '',
+    location_kind: '',
+  }
+  if (query.id && typeof query.id === 'string') {
+    derived.id = query.id
+  }
+
+  if (query.name && typeof query.name === 'string') {
+    derived.name = query.name
+  }
+
+  if (query.flavour && typeof query.flavour === 'string') {
+    derived.flavour = query.flavour
+  }
+
+  if (query.needs_attention && typeof query.needs_attention === 'string') {
+    derived.needs_attention = query.needs_attention
+  }
+
+  if (query.location_kind && typeof query.location_kind === 'string') {
+    derived.location_kind = query.location_kind
+  }
+
+  return derived
+})
+
+const intervalId = ref<number | null>(null)
+
+async function loadData(limit: number, skip: number, hideLoading: boolean = false) {
+  if (!hideLoading) {
+    loadingStore.startLoading('Fetching books...')
+    books.value = []
+  }
+
+  // Convert needs_attention filter to boolean or undefined
+  let needsAttention: boolean | undefined = undefined
+  if (bookFilters.value.needs_attention === 'yes') {
+    needsAttention = true
+  } else if (bookFilters.value.needs_attention === 'no') {
+    needsAttention = false
+  }
+  // 'all' or empty string maps to undefined
+
+  // Fetch books with the selected filters
+  await bookStore.fetchBooks(
+    limit,
+    skip,
+    needsAttention,
+    bookFilters.value.id || undefined,
+    bookFilters.value.location_kind ? [bookFilters.value.location_kind] : undefined,
+    undefined, // flag not used in this view
+    bookFilters.value.name || undefined,
+    bookFilters.value.flavour || undefined,
+  )
+
+  books.value = bookStore.books
+  errors.value = bookStore.errors
+  bookStore.savePaginatorLimit(limit)
+  paginator.value = { ...bookStore.paginator }
+
+  if (loadingStore.isLoading) {
+    loadingStore.stopLoading()
+  }
+}
+
+async function handleLimitChange(newLimit: number) {
+  bookStore.savePaginatorLimit(newLimit)
+
+  if (paginator.value.page != 1) {
+    paginator.value = {
+      ...paginator.value,
+      limit: newLimit,
+      page: 1,
+      skip: 0,
+    }
+  } else {
+    await loadData(newLimit, 0)
+  }
+}
+
+function updateUrlFilters(sourceFilters: typeof bookFilters.value) {
+  // create query object from selected filters
+  const query: Record<string, string | string[]> = {}
+
+  if (sourceFilters.id) {
+    query.id = sourceFilters.id
+  }
+
+  if (sourceFilters.name) {
+    query.name = sourceFilters.name
+  }
+
+  if (sourceFilters.flavour) {
+    query.flavour = sourceFilters.flavour
+  }
+
+  if (sourceFilters.needs_attention) {
+    query.needs_attention = sourceFilters.needs_attention
+  }
+
+  if (sourceFilters.location_kind) {
+    query.location_kind = sourceFilters.location_kind
+  }
+
+  router.push({
+    name: route.name,
+    query: Object.keys(query).length > 0 ? query : undefined,
+  })
+}
+
+async function clearFilters() {
+  updateUrlFilters({ id: '', name: '', flavour: '', needs_attention: '', location_kind: '' })
+}
+
+async function handleBookFiltersChange(newFilters: typeof bookFilters.value) {
+  updateUrlFilters(newFilters)
+}
+
+watch(
+  () => router.currentRoute.value.query,
+  async () => {
+    const query = router.currentRoute.value.query
+    let page = 1
+    if (query.page && typeof query.page === 'string') {
+      const parsedPage = parseInt(query.page, 10)
+      if (!isNaN(parsedPage) && parsedPage > 1) {
+        page = parsedPage
+      }
+    }
+    const newSkip = (page - 1) * paginator.value.limit
+    await loadData(paginator.value.limit, newSkip)
+  },
+  { deep: true, immediate: false },
+)
+
+onMounted(async () => {
+  loadingFlavours.value = true
+  const fetchedFlavours = await bookStore.fetchBookFlavours()
+  if (fetchedFlavours) {
+    flavours.value = fetchedFlavours
+  }
+  loadingFlavours.value = false
+
+  // Set default needs_attention to 'no' if not already set
+  if (!route.query.needs_attention) {
+    await router.replace({
+      name: route.name ?? undefined,
+      query: {
+        ...route.query,
+        needs_attention: 'no',
+      },
+    })
+  } else {
+    // Load data if needs_attention is already set
+    const page = Number(route.query.page) || 1
+    const newSkip = (page - 1) * paginator.value.limit
+    await loadData(paginator.value.limit, newSkip)
+  }
+
+  intervalId.value = window.setInterval(async () => {
+    await loadData(paginator.value.limit, paginator.value.skip, true)
+  }, 60000)
+})
+
+onBeforeUnmount(() => {
+  if (intervalId.value) {
+    clearInterval(intervalId.value)
+  }
+})
+</script>

--- a/frontend/src/views/InboxView.vue
+++ b/frontend/src/views/InboxView.vue
@@ -2,7 +2,7 @@
 
 <template>
   <TabsList :active-tab="currentTab" :tab-options="tabOptions" @tab-changed="handleTabChange" />
-  <BookFilters
+  <InboxBookFilters
     v-if="currentTab == 'books'"
     :filters="bookFilters"
     :location-kind-options="['quarantine', 'staging']"
@@ -60,7 +60,7 @@
 
 <script setup lang="ts">
 import TabsList from '@/components/TabsList.vue'
-import BookFilters from '@/components/BookFilters.vue'
+import InboxBookFilters from '@/components/InboxBookFilters.vue'
 import BookTable from '@/components/BookTable.vue'
 import ZimfarmNotificationFilters from '@/components/ZimfarmNotificationFilters.vue'
 import ZimfarmNotificationTable from '@/components/ZimfarmNotificationTable.vue'
@@ -240,6 +240,8 @@ async function loadData(limit: number, skip: number, tab?: string, hideLoading: 
         bookFilters.value.id || undefined,
         bookFilters.value.location_kind ? [bookFilters.value.location_kind] : undefined,
         bookFilters.value.flag || undefined,
+        undefined, // name not used in inbox
+        undefined, // flavour not used in inbox
       )
       books.value = bookStore.books
       errors.value = bookStore.errors


### PR DESCRIPTION
## Rationale
This PR enhances the UI to have a dedicated books view (different from the books tab in the Inbox view). Whereas the books in the inbox tab are set to fetch books that "need attention", the books view allows user to fetch even those that do not, along with newer filters. The PR also adds capability to update a book's flavour

<img width="1183" height="522" alt="Screenshot_20260526_120640" src="https://github.com/user-attachments/assets/9b29f504-e60a-4f34-9929-8964f2249c5a" />
<img width="1073" height="396" alt="Screenshot_20260526_120620" src="https://github.com/user-attachments/assets/4f507760-99c5-4123-9073-548459e9ddeb" />

## Changes
- create dedicated book view for listing all books
- add capability to edit book flavour via API/UI
- create different set of filters for the new book view differnt from the inbox view filters

This closes #293 