### PR TITLE
set catalog flavour from book

### DIFF
--- a/backend/src/cms_backend/api/routes/utils.py
+++ b/backend/src/cms_backend/api/routes/utils.py
@@ -61,7 +61,7 @@ def build_library_xml(
 
             book_elem.set("path", f"{path_prefix}/{path / filename}")
 
-        if flavour := zim_meta.get("Flavour"):
+        if flavour := book.flavour:
             book_elem.set("flavour", flavour)
 
     ET.indent(library_elem, space="  ", level=0)


### PR DESCRIPTION
## Changes
- set catalog flavour from book instead of zim metadata since book flavours can now be updated (see #299)

This fixes #306 