### PR TITLE
add/remove language codes and refuse to publish books with invalid codes

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "humanfriendly == 10.0",
     "Werkzeug == 3.1.5",
     "xxhash == 3.7.0",
+    "pycountry == 26.2.16",
 ]
 dynamic = ["version"]
 

--- a/backend/src/cms_backend/__init__.py
+++ b/backend/src/cms_backend/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+import pycountry
+
 from cms_backend.context import Context
 
 logger = logging.getLogger("backend")
@@ -9,3 +11,17 @@ if not logger.hasHandlers():
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter("[%(asctime)s: %(levelname)s] %(message)s"))
     logger.addHandler(handler)
+
+
+def update_language_codes():
+    for code in Context.disallowed_language_codes:
+        try:
+            pycountry.languages.remove_entry(alpha_3=code)  # pyright: ignore[reportUnknownMemberType]
+        except Exception as exc:
+            logger.warning(f"failed to remove language code '{code}': {exc}")
+
+    for code in Context.custom_language_codes:
+        pycountry.languages.add_entry(alpha_3=code)  # pyright: ignore[reportUnknownMemberType]
+
+
+update_language_codes()

--- a/backend/src/cms_backend/api/routes/fields.py
+++ b/backend/src/cms_backend/api/routes/fields.py
@@ -1,6 +1,7 @@
 import base64
 from typing import Annotated, Any
 
+import pycountry
 from pydantic import (
     AfterValidator,
     Field,
@@ -54,3 +55,36 @@ SkipField = Annotated[int, Field(ge=0), WrapValidator(skip_validation)]
 LimitFieldMax200 = Annotated[int, Field(ge=1, le=200), WrapValidator(skip_validation)]
 
 Base64Str = Annotated[NotEmptyString, AfterValidator(validate_base64)]
+
+
+def validate_language_code(value: str | None, info: ValidationInfo) -> str | None:
+    """Validate that string is a valid ISO-693-3 language code"""
+    if value is None:
+        return value
+    context = info.context
+    if context and context.get("skip_validation"):
+        return value
+
+    if pycountry.languages.get(alpha_3=value):  # pyright: ignore[reportUnknownMemberType]
+        return value
+    raise ValueError(
+        f"Language code '{value}' is not a supported ISO-639-3 language code"
+    )
+
+
+def validate_comma_separated_lang_code(
+    value: str | None, info: ValidationInfo
+) -> str | None:
+    """Validate that string is a comma separated list of ISO-693-3 language codes"""
+    if value is None:
+        return value
+    for lang_code in value.split(","):
+        validate_language_code(lang_code, info)
+    return value
+
+
+LangCode = Annotated[
+    str,
+    WrapValidator(skip_validation),
+    AfterValidator(validate_comma_separated_lang_code),
+]

--- a/backend/src/cms_backend/context.py
+++ b/backend/src/cms_backend/context.py
@@ -3,9 +3,10 @@ import os
 from dataclasses import field
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, ClassVar, TypeVar
 from uuid import UUID
 
+import pycountry
 from humanfriendly import parse_timespan
 
 T = TypeVar("T")
@@ -21,6 +22,25 @@ def get_mandatory_env(key: str) -> str:
     if not value:
         raise Exception(f"{key} environment variable must be set")
     return value
+
+
+def _parse_custom_language_codes(language_code: str | None) -> list[str]:
+    """Transform the env language codes (comma-seperated) into a list."""
+    if language_code is None:
+        return []
+
+    codes = language_code.split(",")
+    for code in codes:
+        if len(code) != 3:  # noqa: PLR2004
+            raise ValueError(f"Custom code '{code}' must be 3 characters long.")
+    return codes
+
+
+def _validate_language_codes(language_codes: list[str]) -> list[str]:
+    for code in language_codes:
+        if pycountry.languages.get(alpha_3=code) is None:  # pyright: ignore[reportUnknownMemberType]
+            raise ValueError(f"Code '{code}' is not a valid ISO 639-3 code.")
+    return language_codes
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -65,4 +85,11 @@ class Context:
     )
     quarantine_base_path: Path = field(
         default=Path(os.getenv("QUARANTINE_BASE_PATH", ""))
+    )
+    # Comma-seperated list of custom iso639-3 language codes
+    custom_language_codes: ClassVar[list[str]] = _parse_custom_language_codes(
+        os.getenv("CUSTOM_LANGUAGE_CODES")
+    )
+    disallowed_language_codes: ClassVar[list[str]] = _validate_language_codes(
+        _parse_custom_language_codes(os.getenv("DISALLOWED_LANGUAGE_CODES"))
     )

--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -1,6 +1,7 @@
 from typing import Any, Literal
 from uuid import UUID
 
+import pycountry
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session as OrmSession
 from sqlalchemy.orm import selectinload
@@ -541,6 +542,18 @@ def update_book_issues(session: OrmSession, book: Book, *, update_events: bool =
         return
 
     issues: list[str] = []
+
+    unknown_languages: list[str] = []
+    for language_code in book.zim_metadata["Language"].split(","):
+        if pycountry.languages.get(alpha_3=language_code) is None:  # pyright: ignore[reportUnknownMemberType]
+            unknown_languages.append(language_code)
+
+    if unknown_languages:
+        issues.append("invalid language code")
+        if update_events:
+            book.events.append(
+                f"{getnow()}: book has unknown language code(s) {unknown_languages}"
+            )
 
     different_metadata_keys = get_differing_metadata_keys(book)
     if different_metadata_keys:

--- a/backend/src/cms_backend/schemas/models.py
+++ b/backend/src/cms_backend/schemas/models.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from pydantic import AnyUrl, model_validator
 
-from cms_backend.api.routes.fields import Base64Str, NotEmptyString
+from cms_backend.api.routes.fields import Base64Str, LangCode, NotEmptyString
 from cms_backend.roles import RoleEnum
 from cms_backend.schemas import BaseModel
 from cms_backend.schemas.orms import BaseTitleCollectionSchema
@@ -62,7 +62,7 @@ class BaseTitleCreateUpdateSchema(BaseModel):
     creator: NotEmptyString | None = None
     description: NotEmptyString | None = None
     publisher: NotEmptyString | None = None
-    language: NotEmptyString | None = None
+    language: LangCode | None = None
     illustration_48x48_at_1: Base64Str | None = None
     flavours: list[str] | None = None
     archived: bool | None = None

--- a/backend/tests/mill/processors/test_zimfarm_notification.py
+++ b/backend/tests/mill/processors/test_zimfarm_notification.py
@@ -7,10 +7,15 @@ implementation details.
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 from uuid import UUID
 
+import pycountry
+import pytest
+from pytest import MonkeyPatch
 from sqlalchemy.orm import Session as OrmSession
 
+from cms_backend import update_language_codes
 from cms_backend.context import Context
 from cms_backend.db.models import (
     Book,
@@ -22,7 +27,7 @@ from cms_backend.db.models import (
 )
 from cms_backend.mill.processors.zimfarm_notification import process_notification
 
-VALID_NOTIFICATION_CONTENT = {
+VALID_NOTIFICATION_CONTENT: dict[str, Any] = {
     "article_count": 1000,
     "media_count": 500,
     "size": 1000000,
@@ -44,6 +49,28 @@ VALID_NOTIFICATION_CONTENT = {
     "folder_name": "test_folder",
     "filename": "test.zim",
 }
+
+
+@pytest.fixture(autouse=True)
+def restore_language_codes():
+    """Fixture to restore pycountry language codes after test modifications."""
+    original_entries = list(pycountry.languages)  # pyright: ignore[reportUnknownVariableType]
+    yield
+    current_entries = list(pycountry.languages)  # pyright: ignore[reportUnknownVariableType]
+    for entry in current_entries:  # pyright: ignore[reportUnknownVariableType]
+        try:
+            pycountry.languages.remove_entry(alpha_3=entry.alpha_3)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+        except Exception:  # noqa: S110
+            pass
+
+    for entry in original_entries:  # pyright: ignore[reportUnknownVariableType]
+        try:
+            pycountry.languages.add_entry(  # pyright: ignore[reportUnknownMemberType]
+                alpha_3=entry.alpha_3,  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+                name=entry.name,  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+            )
+        except Exception:  # noqa: S110
+            pass
 
 
 class TestBadNotifications:
@@ -630,6 +657,161 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         assert book.location_kind == "staging"
         assert len(book.issues) == 1
         assert set(book.issues) == {"flavour mismatch"}
+        assert book.has_error is False
+        assert book.needs_file_operation is True
+        assert book.needs_processing is False
+
+    def test_moves_book_to_staging_due_to_invalid_language(
+        self,
+        dbsession: OrmSession,
+        warehouse: Warehouse,  # noqa: ARG002
+        create_zimfarm_notification: Callable[..., ZimfarmNotification],
+        create_title: Callable[..., Title],
+        create_collection: Callable[..., Collection],
+        create_warehouse: Callable[..., Warehouse],
+    ):
+        """
+        Test that book goes to staging because it has an invalid language code
+        """
+
+        title = create_title(name="test_en_all")
+        title.maturity = "stable"
+
+        prod = create_warehouse(
+            name="prod", warehouse_id=UUID("00000000-0000-0000-0000-000000000003")
+        )
+        collection = create_collection(warehouse=prod)
+
+        ct = CollectionTitle(path=Path("wikipedia"))
+        ct.title = title
+        ct.collection = collection
+        dbsession.add(ct)
+        dbsession.flush()
+
+        content = VALID_NOTIFICATION_CONTENT.copy()
+        content["folder_name"] = ""
+        content["metadata"]["Language"] = "xyz"
+
+        notification = create_zimfarm_notification(content=content)
+        dbsession.flush()
+
+        process_notification(dbsession, notification)
+
+        assert notification.status == "processed"
+
+        book = dbsession.query(Book).filter_by(id=notification.id).first()
+        assert book is not None
+        assert book.title_id == title.id
+        assert book.location_kind == "staging"
+        assert len(book.issues) == 1
+        assert set(book.issues) == {"invalid language code"}
+        assert book.has_error is False
+        assert book.needs_file_operation is True
+        assert book.needs_processing is False
+
+    def test_moves_book_to_prod_due_to_invalid_language_code_being_supported(
+        self,
+        dbsession: OrmSession,
+        warehouse: Warehouse,  # noqa: ARG002
+        monkeypatch: MonkeyPatch,
+        create_zimfarm_notification: Callable[..., ZimfarmNotification],
+        create_title: Callable[..., Title],
+        create_collection: Callable[..., Collection],
+        create_warehouse: Callable[..., Warehouse],
+    ):
+        """
+        Test that book goes to prod even though it's language code is invalid
+        but supported
+        """
+
+        title = create_title(name="test_en_all")
+        title.maturity = "stable"
+
+        prod = create_warehouse(
+            name="prod", warehouse_id=UUID("00000000-0000-0000-0000-000000000003")
+        )
+        collection = create_collection(warehouse=prod)
+
+        ct = CollectionTitle(path=Path("wikipedia"))
+        ct.title = title
+        ct.collection = collection
+        dbsession.add(ct)
+        dbsession.flush()
+
+        content = VALID_NOTIFICATION_CONTENT.copy()
+        content["folder_name"] = ""
+        content["metadata"]["Language"] = "xyz"
+        monkeypatch.setattr(
+            "cms_backend.context.Context.custom_language_codes", ["xyz"]
+        )
+        update_language_codes()
+
+        notification = create_zimfarm_notification(content=content)
+        dbsession.flush()
+
+        process_notification(dbsession, notification)
+
+        assert notification.status == "processed"
+
+        book = dbsession.query(Book).filter_by(id=notification.id).first()
+        assert book is not None
+        assert book.title_id == title.id
+        assert book.location_kind == "prod"
+        assert len(book.issues) == 0
+        assert book.has_error is False
+        assert book.needs_file_operation is True
+        assert book.needs_processing is False
+
+    def test_moves_book_to_staging_due_to_valid_language_code_being_disallowed(
+        self,
+        dbsession: OrmSession,
+        warehouse: Warehouse,  # noqa: ARG002
+        monkeypatch: MonkeyPatch,
+        create_zimfarm_notification: Callable[..., ZimfarmNotification],
+        create_title: Callable[..., Title],
+        create_collection: Callable[..., Collection],
+        create_warehouse: Callable[..., Warehouse],
+    ):
+        """
+        Test that book goes to staging because there it's language code is disallowed
+        even though it's valid
+        """
+
+        title = create_title(name="test_en_all")
+        title.maturity = "stable"
+
+        prod = create_warehouse(
+            name="prod", warehouse_id=UUID("00000000-0000-0000-0000-000000000003")
+        )
+        collection = create_collection(warehouse=prod)
+
+        ct = CollectionTitle(path=Path("wikipedia"))
+        ct.title = title
+        ct.collection = collection
+        dbsession.add(ct)
+        dbsession.flush()
+
+        content = VALID_NOTIFICATION_CONTENT.copy()
+        content["folder_name"] = ""
+        content["metadata"]["Language"] = "fra"
+        monkeypatch.setattr(
+            "cms_backend.context.Context.disallowed_language_codes", ["fra"]
+        )
+        update_language_codes()
+
+        notification = create_zimfarm_notification(content=content)
+        dbsession.flush()
+
+        process_notification(dbsession, notification)
+
+        assert notification.status == "processed"
+
+        book = dbsession.query(Book).filter_by(id=notification.id).first()
+        assert book is not None
+        assert book.title_id == title.id
+        assert book.location_kind == "staging"
+        assert len(book.issues) == 1
+        assert set(book.issues) == {"invalid language code"}
         assert book.has_error is False
         assert book.needs_file_operation is True
         assert book.needs_processing is False

--- a/frontend/src/components/TitleForm.vue
+++ b/frontend/src/components/TitleForm.vue
@@ -78,7 +78,7 @@
             :color="!inDialog && isFieldDifferent('title') ? 'warning' : undefined"
             :base-color="!inDialog && isFieldDifferent('title') ? 'warning' : undefined"
           />
-          <div v-if="!inDialog && isFieldDifferent('title')" class="text-body-2 mt-n2 mb-2">
+          <div v-if="!inDialog && isFieldDifferent('title')" class="text-body-2 mb-2">
             <div class="mb-1 text-warning font-weight-medium">
               Different from latest book which has:
             </div>
@@ -106,7 +106,7 @@
             :color="!inDialog && isFieldDifferent('creator') ? 'warning' : undefined"
             :base-color="!inDialog && isFieldDifferent('creator') ? 'warning' : undefined"
           />
-          <div v-if="!inDialog && isFieldDifferent('creator')" class="text-body-2 mt-n2 mb-2">
+          <div v-if="!inDialog && isFieldDifferent('creator')" class="text-body-2 mb-2">
             <div class="mb-1 text-warning font-weight-medium">
               Different from latest book which has:
             </div>
@@ -137,7 +137,7 @@
             :color="!inDialog && isFieldDifferent('publisher') ? 'warning' : undefined"
             :base-color="!inDialog && isFieldDifferent('publisher') ? 'warning' : undefined"
           />
-          <div v-if="!inDialog && isFieldDifferent('publisher')" class="text-body-2 mt-n2 mb-2">
+          <div v-if="!inDialog && isFieldDifferent('publisher')" class="text-body-2 mb-2">
             <div class="mb-1 text-warning font-weight-medium">
               Different from latest book which has:
             </div>
@@ -161,11 +161,12 @@
             label="Language"
             variant="outlined"
             density="comfortable"
+            :rules="[rules.langCode]"
             clearable
             :color="!inDialog && isFieldDifferent('language') ? 'warning' : undefined"
             :base-color="!inDialog && isFieldDifferent('language') ? 'warning' : undefined"
           />
-          <div v-if="!inDialog && isFieldDifferent('language')" class="text-body-2 mt-n2 mb-2">
+          <div v-if="!inDialog && isFieldDifferent('language')" class="text-body-2 mb-2">
             <div class="mb-1 text-warning font-weight-medium">
               Different from latest book which has:
             </div>
@@ -196,7 +197,7 @@
             :color="!inDialog && isFieldDifferent('license') ? 'warning' : undefined"
             :base-color="!inDialog && isFieldDifferent('license') ? 'warning' : undefined"
           />
-          <div v-if="!inDialog && isFieldDifferent('license')" class="text-body-2 mt-n2 mb-2">
+          <div v-if="!inDialog && isFieldDifferent('license')" class="text-body-2 mb-2">
             <div class="mb-1 text-warning font-weight-medium">
               Different from latest book which has:
             </div>
@@ -284,7 +285,7 @@
             :color="!inDialog && isFieldDifferent('description') ? 'warning' : undefined"
             :base-color="!inDialog && isFieldDifferent('description') ? 'warning' : undefined"
           />
-          <div v-if="!inDialog && isFieldDifferent('description')" class="text-body-2 mt-n2 mb-2">
+          <div v-if="!inDialog && isFieldDifferent('description')" class="text-body-2 mb-2">
             <div class="mb-1 text-warning font-weight-medium">
               Different from latest book which has:
             </div>
@@ -316,7 +317,7 @@
             :color="isFieldDifferent('long_description') ? 'warning' : undefined"
             :base-color="isFieldDifferent('long_description') ? 'warning' : undefined"
           />
-          <div v-if="isFieldDifferent('long_description')" class="text-body-2 mt-n2 mb-2">
+          <div v-if="isFieldDifferent('long_description')" class="text-body-2 mb-2">
             <div class="mb-1 text-warning font-weight-medium">
               Different from latest book which has:
             </div>
@@ -663,6 +664,13 @@ const hasChanges = computed(() => {
 
 const rules = {
   required: (value: string) => !!value || 'This field is required',
+  langCode: (value: string) => {
+    if (!value) return true // optional
+    const parts = value.split(',')
+    return parts.every((part) => part.trim().length === 3)
+      ? true
+      : 'Language code(s) must be 3 characters long'
+  },
 }
 
 watch(formValid, (value) => {

--- a/frontend/src/components/TitleFormDialog.vue
+++ b/frontend/src/components/TitleFormDialog.vue
@@ -13,10 +13,6 @@
           @update:valid="formValid = $event"
           @update:has-changes="hasChanges = $event"
         />
-
-        <v-alert v-if="error" type="error" class="mt-4" density="compact">
-          {{ error }}
-        </v-alert>
       </v-card-text>
 
       <v-card-actions class="pa-4">
@@ -41,6 +37,7 @@ import TitleForm from '@/components/TitleForm.vue'
 import { useTitleStore } from '@/stores/title'
 import type { Title, TitleCreate } from '@/types/title'
 import { computed, ref, watch } from 'vue'
+import { useNotificationStore } from '@/stores/notification'
 
 interface Props {
   modelValue: boolean
@@ -58,12 +55,12 @@ const emit = defineEmits<{
 }>()
 
 const titleStore = useTitleStore()
+const notificationStore = useNotificationStore()
 
 const titleFormRef = ref<InstanceType<typeof TitleForm>>()
 const formValid = ref(false)
 const hasChanges = ref(false)
 const loading = ref(false)
-const error = ref('')
 
 const isOpen = computed({
   get: () => props.modelValue,
@@ -74,7 +71,6 @@ watch(isOpen, async (newValue) => {
   if (newValue) {
     await titleFormRef.value?.fetchCollections()
     await titleFormRef.value?.fetchFlavours()
-    error.value = ''
   }
 })
 
@@ -82,21 +78,21 @@ async function handleSubmit() {
   if (!formValid.value || !titleFormRef.value) return
 
   loading.value = true
-  error.value = ''
 
   try {
     const formData = titleFormRef.value.getFormData() as TitleCreate
     const response = await titleStore.createTitle(formData)
     if (!response) {
-      error.value = titleStore.errors.join(', ') || `Failed to create title`
+      notificationStore.showError('Failed to create title')
+      notificationStore.showErrors(titleStore.errors)
       return
     }
     emit('created')
     titleFormRef.value.resetForm()
     isOpen.value = false
   } catch (err) {
+    notificationStore.showError('Failed to create title')
     console.error(`Failed to create title`, err)
-    error.value = titleStore.errors.join(', ') || `Failed to create title`
   } finally {
     loading.value = false
   }
@@ -104,7 +100,6 @@ async function handleSubmit() {
 
 function handleCancel() {
   titleFormRef.value?.resetForm()
-  error.value = ''
   isOpen.value = false
 }
 </script>

--- a/frontend/src/stores/notification.ts
+++ b/frontend/src/stores/notification.ts
@@ -70,6 +70,12 @@ export const useNotificationStore = defineStore('notification', () => {
     return addNotification(message, 'error', duration)
   }
 
+  const showErrors = (messages: string[], duration?: number) => {
+    for (const message of messages) {
+      addNotification(message, 'error', duration)
+    }
+  }
+
   const showWarning = (message: string, duration?: number) => {
     return addNotification(message, 'warning', duration)
   }
@@ -85,6 +91,7 @@ export const useNotificationStore = defineStore('notification', () => {
     clearAllNotifications,
     showSuccess,
     showError,
+    showErrors,
     showWarning,
     showInfo,
   }

--- a/frontend/src/views/TitleView.vue
+++ b/frontend/src/views/TitleView.vue
@@ -348,10 +348,6 @@
                   @update:valid="formValid = $event"
                   @update:has-changes="hasChanges = $event"
                 />
-
-                <v-alert v-if="updateError" type="error" class="mt-4" density="compact">
-                  {{ updateError }}
-                </v-alert>
               </v-card-text>
 
               <div class="d-flex flex-column flex-sm-row justify-end ga-2 px-4 pb-4">
@@ -481,7 +477,6 @@ const titleFormRef = ref<InstanceType<typeof TitleForm>>()
 const formValid = ref(false)
 const hasChanges = ref(false)
 const updating = ref(false)
-const updateError = ref('')
 
 // Confirmation dialog state
 const showConfirmDialog = ref(false)
@@ -620,9 +615,7 @@ const loadData = async (
     dataLoaded.value = true
   } else {
     error.value = 'Failed to load title'
-    for (const err of titleStore.errors) {
-      notificationStore.showError(err)
-    }
+    notificationStore.showErrors(titleStore.errors)
   }
 
   if (loadingStore.isLoading) {
@@ -644,9 +637,7 @@ const loadZimUrls = async () => {
   if (response?.urls) {
     zimUrls.value = response.urls
   } else {
-    for (const err of bookStore.errors) {
-      notificationStore.showError(err)
-    }
+    notificationStore.showErrors(bookStore.errors)
   }
 
   loadingUrls.value = false
@@ -661,9 +652,7 @@ const archiveTitle = async () => {
     // Switch to info tab after archiving
     currentTab.value = 'details'
   } else {
-    for (const error of titleStore.errors) {
-      notificationStore.showError(error)
-    }
+    notificationStore.showErrors(titleStore.errors)
   }
 }
 
@@ -676,16 +665,12 @@ const restoreTitle = async () => {
     // Switch to info tab after restoring
     currentTab.value = 'details'
   } else {
-    for (const error of titleStore.errors) {
-      notificationStore.showError(error)
-    }
+    notificationStore.showErrors(titleStore.errors)
   }
 }
 
 const handleUpdate = async () => {
   if (!formValid.value || !title.value) return
-
-  updateError.value = ''
 
   try {
     const updatePayload = titleFormRef.value?.getUpdatePayload()
@@ -708,7 +693,7 @@ const handleUpdate = async () => {
     showConfirmDialog.value = true
   } catch (err) {
     console.error('Failed to prepare update', err)
-    updateError.value = 'Failed to prepare update'
+    notificationStore.showError('Failed to prepare update')
   }
 }
 
@@ -716,7 +701,6 @@ const handleConfirmUpdate = async () => {
   if (!title.value || !pendingUpdatePayload.value) return
 
   updating.value = true
-  updateError.value = ''
 
   try {
     // Add comment to the payload if provided
@@ -727,7 +711,7 @@ const handleConfirmUpdate = async () => {
 
     const response = await titleStore.updateTitle(title.value.id, payloadWithComment)
     if (!response) {
-      updateError.value = titleStore.errors.join(', ') || 'Failed to update title'
+      notificationStore.showErrors(titleStore.errors)
       showConfirmDialog.value = false
       return
     }
@@ -747,7 +731,7 @@ const handleConfirmUpdate = async () => {
     currentTab.value = 'details'
   } catch (err) {
     console.error('Failed to update title', err)
-    updateError.value = titleStore.errors.join(', ') || 'Failed to update title'
+    notificationStore.showError('Failed to update title')
     showConfirmDialog.value = false
   } finally {
     updating.value = false


### PR DESCRIPTION
# Rationale
This PR enhances the mill to ensure that a book's language metadata is a valid ISO639-3 language code. Additionally, it provides ability to extend the list of language codes and also disallow some that might be valid

## Changes
- add env vars `DISALLOWED_LANGUAGE_CODES` and `CUSTOM_LANGUAGE_CODES` to support removal and adding of language codes respectively
- update language code database at mill startup
- mark books with unknown language codes as errored and refuse to add book to title for further processing


This closes #101 