### PR TITLE
dump update data in json mode

### DIFF
--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -416,7 +416,9 @@ def update_book(
         raise ValueError(f"Book title {book.title_id} is currently archived")
 
     # Return early if no update data
-    update_data = payload.model_dump(exclude_unset=True, exclude={"comment"})
+    update_data = payload.model_dump(
+        exclude_unset=True, exclude={"comment"}, mode="json"
+    )
     if not update_data:
         return book
 

--- a/backend/src/cms_backend/db/collection.py
+++ b/backend/src/cms_backend/db/collection.py
@@ -229,7 +229,7 @@ def update_collection(
     else:
         collection = get_collection_by_name(session, collection_id)
 
-    values = request.model_dump(exclude_unset=True)
+    values = request.model_dump(exclude_unset=True, mode="json")
     if not values:
         return collection
 

--- a/backend/src/cms_backend/db/title.py
+++ b/backend/src/cms_backend/db/title.py
@@ -374,7 +374,7 @@ def update_title(
     title = get_title(session, title_identifier)
 
     # Return early if no update data
-    if not payload.model_dump(exclude_unset=True):
+    if not payload.model_dump(exclude_unset=True, mode="json"):
         return title
 
     # Determine whether to permit update based on value of archived parameter
@@ -388,7 +388,7 @@ def update_title(
         raise RecordDoesNotExistError("Title is not archived.")
 
     update_data = payload.model_dump(
-        exclude_unset=True, exclude={"collection_titles", "comment"}
+        exclude_unset=True, exclude={"collection_titles", "comment"}, mode="json"
     )
     name_changed = payload.name is not None and payload.name != title.name
 


### PR DESCRIPTION
## Changes
- dump pydantic models in `json` mode before using in update statement

This fixes #316 