### PR TITLE
create title from book or add title to book

### DIFF
--- a/backend/maint-scripts/update_titles_from_latest_books.py
+++ b/backend/maint-scripts/update_titles_from_latest_books.py
@@ -9,7 +9,8 @@ from sqlalchemy.orm import Session as OrmSession
 from cms_backend import logger
 from cms_backend.db import Session
 from cms_backend.db.models import Book, Title
-from cms_backend.db.title import get_title_by_id, title_is_missing_mandatory_metadata
+from cms_backend.db.rules import title_is_missing_mandatory_metadata
+from cms_backend.db.title import get_title_by_id
 
 
 def get_latest_book_for_title(session: OrmSession, title: Title) -> Book | None:

--- a/backend/src/cms_backend/db/title.py
+++ b/backend/src/cms_backend/db/title.py
@@ -289,8 +289,6 @@ def create_title(
     title.flavours = [] if payload.flavours is None else payload.flavours
     title.events.append(f"{getnow()}: title created")
 
-    session.add(title)
-
     if payload.collection_titles:
         # Create the collection titles for the title
         for entry in payload.collection_titles:
@@ -307,6 +305,9 @@ def create_title(
     create_title_history_entry(
         session, title, author_id, comment="Create initial history"
     )
+
+    session.add(title)
+
     try:
         session.flush()
     except IntegrityError as exc:

--- a/backend/src/cms_backend/mill/process_retention_rules.py
+++ b/backend/src/cms_backend/mill/process_retention_rules.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend import logger
 from cms_backend.db.models import Title
-from cms_backend.mill.processors.title import apply_retention_rules
+from cms_backend.db.rules import apply_retention_rules
 
 
 def process_retention_rules(session: OrmSession):

--- a/backend/src/cms_backend/mill/process_title_modifications.py
+++ b/backend/src/cms_backend/mill/process_title_modifications.py
@@ -35,6 +35,11 @@ def process_title_modifications(session: OrmSession):
             delete_event(session, event_id=event.id)
             continue
 
+        if title.archived:
+            logger.warning(f"Title {title.id} is archived.")
+            delete_event(session, event_id=event.id)
+            continue
+
         title_name = event.payload["name"]
         books_without_title = session.scalars(
             select(Book)

--- a/backend/tests/mill/processors/test_title.py
+++ b/backend/tests/mill/processors/test_title.py
@@ -8,9 +8,9 @@ import pytest
 from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend.db.models import Book, BookLocation, Title
-from cms_backend.db.rules import sort_books_by_filename_period
-from cms_backend.mill.processors.title import (
+from cms_backend.db.rules import (
     apply_retention_rules,
+    sort_books_by_filename_period,
 )
 from cms_backend.utils.datetime import getnow
 

--- a/frontend/src/components/TitleForm.vue
+++ b/frontend/src/components/TitleForm.vue
@@ -473,7 +473,7 @@ const formData = ref<TitleUpdate>({
 
 const originalCollections = ref<BaseTitleCollection[]>([])
 
-const isEditMode = computed(() => props.title !== null)
+const isEditMode = computed(() => props.title !== null && props.title.id !== '')
 
 const maturityHint = computed(() => {
   if (formData.value.maturity === 'unstable') {

--- a/frontend/src/components/TitleSelectDialog.vue
+++ b/frontend/src/components/TitleSelectDialog.vue
@@ -1,0 +1,232 @@
+<template>
+  <v-dialog v-model="dialogModel" max-width="800" persistent>
+    <v-card>
+      <v-card-title class="d-flex justify-space-between align-center">
+        <span class="text-h5">Select Title</span>
+        <v-btn icon="mdi-close" variant="text" @click="closeDialog" />
+      </v-card-title>
+
+      <v-card-text class="pa-4">
+        <TitlesFilter
+          v-if="!loading"
+          :filters="filters"
+          :collections="collectionNames"
+          @filters-changed="handleFiltersChange"
+          @clear-filters="clearFilters"
+        />
+
+        <div v-if="titles.length > 0" class="d-flex justify-end gap-2">
+          <v-btn variant="text" @click="closeDialog"> Cancel </v-btn>
+          <v-btn
+            color="primary"
+            variant="elevated"
+            :disabled="!selectedTitleData"
+            @click="confirmSelection"
+          >
+            Update Title Name
+          </v-btn>
+        </div>
+        <v-alert v-if="selectedTitleData" type="info" variant="tonal" class="mt-4">
+          <div class="font-weight-bold mb-1">Selected Title</div>
+          <div>{{ selectedTitleData.name }}</div>
+          <div class="mt-2 text-caption">
+            This will update the title name to: <strong>{{ bookName }}</strong>
+          </div>
+        </v-alert>
+
+        <TitlesTable
+          v-if="!loading"
+          :headers="headers"
+          :titles="titles"
+          :paginator="paginator"
+          :loading="loadingStore.isLoading"
+          :loading-text="loadingStore.loadingText"
+          :errors="errors"
+          :filters="filters"
+          :selected-titles="selectedTitle"
+          :show-selection="false"
+          disable-navigation
+          @limit-changed="handleLimitChange"
+          @load-data="loadData"
+          @selection-changed="handleSelectionChange"
+          @row-clicked="handleRowClick"
+        />
+
+        <v-alert v-if="selectedTitleData" type="info" variant="tonal" class="mt-4">
+          <div class="font-weight-bold mb-1">Selected Title</div>
+          <div>{{ selectedTitleData.name }}</div>
+          <div class="mt-2 text-caption">
+            This will update the title name to: <strong>{{ bookName }}</strong>
+          </div>
+        </v-alert>
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions class="pa-4" v-if="titles.length > 0">
+        <v-spacer />
+        <v-btn variant="text" @click="closeDialog"> Cancel </v-btn>
+        <v-btn
+          color="primary"
+          variant="elevated"
+          :disabled="!selectedTitleData"
+          @click="confirmSelection"
+        >
+          Update Title Name
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import TitlesFilter from '@/components/TitlesFilters.vue'
+import TitlesTable from '@/components/TitlesTable.vue'
+import { useLoadingStore } from '@/stores/loading'
+import { useNotificationStore } from '@/stores/notification'
+import { useTitleStore } from '@/stores/title'
+import { useCollectionsStore } from '@/stores/collections'
+import type { TitleLight } from '@/types/title'
+import type { Paginator } from '@/types/base'
+import { computed, onMounted, ref, watch } from 'vue'
+
+interface Props {
+  modelValue: boolean
+  bookName: string
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  titleSelected: [titleName: string]
+}>()
+
+const headers = [
+  { title: 'Name', value: 'name' },
+  {
+    title: 'Maturity',
+    value: 'maturity',
+  },
+]
+
+const titles = ref<TitleLight[]>([])
+const loading = ref<boolean>(true)
+const errors = ref<string[]>([])
+const filters = ref({
+  name: '',
+  collection_name: '',
+})
+const selectedTitle = ref<string[]>([])
+
+const titleStore = useTitleStore()
+const collectionsStore = useCollectionsStore()
+const loadingStore = useLoadingStore()
+const notificationStore = useNotificationStore()
+
+const collectionNames = computed(() => collectionsStore.collections.map((c) => c.name))
+
+const paginator = ref<Paginator>({
+  page: 1,
+  page_size: titleStore.defaultLimit,
+  skip: 0,
+  limit: titleStore.defaultLimit,
+  count: 0,
+})
+
+const dialogModel = computed({
+  get: () => props.modelValue,
+  set: (value: boolean) => emit('update:modelValue', value),
+})
+
+const selectedTitleData = computed(() => {
+  if (selectedTitle.value.length === 0) return null
+  return titles.value.find((t) => t.name === selectedTitle.value[0])
+})
+
+async function loadData(limit: number, skip: number, hideLoading: boolean = false) {
+  if (!hideLoading) {
+    loadingStore.startLoading('Fetching titles...')
+  }
+
+  await titleStore.fetchTitles(
+    limit,
+    skip,
+    filters.value.name || undefined,
+    filters.value.collection_name || undefined,
+    false,
+  )
+
+  titles.value = titleStore.titles
+  paginator.value = titleStore.paginator
+  errors.value = titleStore.errors
+
+  for (const error of errors.value) {
+    notificationStore.showError(error)
+  }
+
+  if (loadingStore.isLoading) {
+    loadingStore.stopLoading()
+  }
+}
+
+async function handleFiltersChange(newFilters: typeof filters.value) {
+  filters.value = newFilters
+  selectedTitle.value = []
+  await loadData(paginator.value.limit, 0)
+}
+
+async function handleLimitChange(newLimit: number) {
+  await loadData(newLimit, 0)
+}
+
+async function clearFilters() {
+  filters.value = {
+    name: '',
+    collection_name: '',
+  }
+  selectedTitle.value = []
+  await loadData(paginator.value.limit, 0)
+}
+
+function handleSelectionChange(selection: string[]) {
+  selectedTitle.value = selection
+}
+
+function handleRowClick(item: TitleLight) {
+  if (selectedTitle.value.includes(item.name)) {
+    selectedTitle.value = []
+  } else {
+    selectedTitle.value = [item.name]
+  }
+}
+
+function closeDialog() {
+  dialogModel.value = false
+  selectedTitle.value = []
+}
+
+function confirmSelection() {
+  if (selectedTitleData.value) {
+    emit('titleSelected', selectedTitleData.value.name)
+    closeDialog()
+  }
+}
+
+onMounted(async () => {
+  await collectionsStore.fetchCollections(20)
+  loading.value = false
+})
+
+// Watch for dialog open to load and reset state
+watch(dialogModel, async (newValue) => {
+  if (newValue) {
+    selectedTitle.value = []
+    filters.value = {
+      name: '',
+      collection_name: '',
+    }
+    await loadData(paginator.value.limit, 0)
+  }
+})
+</script>

--- a/frontend/src/components/TitlesBaseView.vue
+++ b/frontend/src/components/TitlesBaseView.vue
@@ -142,10 +142,6 @@ const headers = [
 const titles = ref<TitleLight[]>([])
 const ready = ref<boolean>(false)
 const errors = ref<string[]>([])
-const filters = ref({
-  name: '',
-  collection_name: '',
-})
 const intervalId = ref<number | null>(null)
 const selectedTitles = ref<string[]>([])
 const showCreateDialog = ref(false)
@@ -313,8 +309,7 @@ function handleArchiveCancel() {
 }
 
 async function handleFiltersChange(newFilters: typeof filters.value) {
-  filters.value = newFilters
-  updateUrl()
+  updateUrl(newFilters)
   if (!props.archived) {
     fetchArchivedCount(newFilters)
   }
@@ -335,11 +330,11 @@ async function handleLimitChange(newLimit: number) {
 }
 
 async function clearFilters() {
-  filters.value = {
+  const emptyFilters = {
     name: '',
     collection_name: '',
   }
-  updateUrl()
+  updateUrl(emptyFilters)
 }
 
 function handleSelectionChanged(newSelection: string[]) {
@@ -351,14 +346,14 @@ async function handleTitleCreated() {
   await loadData(paginator.value.limit, paginator.value.skip)
 }
 
-function updateUrl() {
+function updateUrl(sourceFilters: typeof filters.value) {
   const query: Record<string, string | string[]> = {}
 
-  if (filters.value.name) {
-    query.name = filters.value.name
+  if (sourceFilters.name) {
+    query.name = sourceFilters.name
   }
-  if (filters.value.collection_name) {
-    query.collection_name = filters.value.collection_name
+  if (sourceFilters.collection_name) {
+    query.collection_name = sourceFilters.collection_name
   }
 
   router.push({
@@ -367,16 +362,19 @@ function updateUrl() {
   })
 }
 
-function loadFiltersFromUrl() {
+const filters = computed(() => {
   const query = router.currentRoute.value.query
+  const derived = { name: '', collection_name: '' }
 
   if (query.name && typeof query.name === 'string') {
-    filters.value.name = query.name
+    derived.name = query.name
   }
   if (query.collection_name && typeof query.collection_name === 'string') {
-    filters.value.collection_name = query.collection_name
+    derived.collection_name = query.collection_name
   }
-}
+
+  return derived
+})
 
 function navigateToArchives() {
   const query: Record<string, string | string[]> = {}
@@ -396,15 +394,9 @@ function navigateToArchives() {
 // Lifecycle
 onMounted(async () => {
   await collectionsStore.fetchCollections(100)
-  loadFiltersFromUrl()
   intervalId.value = window.setInterval(async () => {
     await loadData(paginator.value.limit, paginator.value.skip, true)
   }, 60000)
-
-  // Fetch archived count on mount for regular titles view
-  if (!props.archived) {
-    fetchArchivedCount(filters.value)
-  }
 
   // Mark as ready to show content - the table will handle initial load via updateOptions
   ready.value = true
@@ -415,15 +407,6 @@ onBeforeUnmount(() => {
     clearInterval(intervalId.value)
   }
 })
-
-// Watch for route changes to update filters
-watch(
-  () => router.currentRoute.value.query,
-  () => {
-    loadFiltersFromUrl()
-  },
-  { deep: true, immediate: true },
-)
 
 watch(
   () => router.currentRoute.value.query,

--- a/frontend/src/components/TitlesTable.vue
+++ b/frontend/src/components/TitlesTable.vue
@@ -36,13 +36,17 @@
         :headers="headers"
         :items="titles"
         :loading="loading"
-        :items-per-page="selectedLimit"
-        :items-length="paginator.count"
+        :items-per-page="props.paginator.limit"
+        :items-length="props.paginator.count"
+        :page="props.paginator.page"
         :items-per-page-options="limits"
         class="elevation-1 cursor-pointer-table"
+        :mobile="smAndDown"
+        :density="smAndDown ? 'compact' : 'comfortable'"
         item-value="name"
         :model-value="selectedTitles"
         :show-select="showSelection"
+        :row-props="getRowProps"
         hover
         @update:model-value="handleSelectionChange"
         @update:options="onUpdateOptions"
@@ -58,7 +62,7 @@
         </template>
 
         <template #[`header.maturity`]="{ column }">
-          <div class="d-flex align-center">
+          <div>
             <span>{{ column.title }}</span>
             <v-tooltip location="top">
               <template #activator="{ props: tooltipProps }">
@@ -78,9 +82,18 @@
         </template>
 
         <template #[`item.name`]="{ item }">
-          <span class="d-flex align-center">
+          <div class="d-flex align-center ga-2">
+            <v-icon
+              v-if="!showSelection"
+              size="small"
+              :color="selectedTitles.includes(item.name) ? 'primary' : undefined"
+              :style="{ opacity: selectedTitles.includes(item.name) ? 1 : 0 }"
+              aria-hidden="true"
+            >
+              mdi-check-circle
+            </v-icon>
             {{ item.name }}
-          </span>
+          </div>
         </template>
 
         <template #no-data>
@@ -99,6 +112,7 @@ import type { Paginator } from '@/types/base'
 import type { TitleLight } from '@/types/title'
 import { computed, ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { useDisplay } from 'vuetify'
 
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
 
@@ -116,25 +130,29 @@ interface Props {
   }
   selectedTitles?: string[]
   showSelection?: boolean
+  disableNavigation?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   filters: () => ({ name: '', collection_name: '' }),
   selectedTitles: () => [],
   showSelection: false,
+  disableNavigation: false,
 })
+
+const { smAndDown } = useDisplay()
 
 // Define emits
 const emit = defineEmits<{
   limitChanged: [limit: number]
   loadData: [limit: number, skip: number]
   selectionChanged: [selectedTitles: string[]]
+  rowClicked: [item: TitleLight]
 }>()
 
 const router = useRouter()
 const route = useRoute()
 const limits = [10, 20, 50, 100]
-const selectedLimit = ref(props.paginator.limit)
 
 const selectedTitles = computed(() => props.selectedTitles)
 const showClearConfirm = ref(false)
@@ -147,7 +165,15 @@ function onUpdateOptions(options: { page: number; itemsPerPage: number }) {
     delete query.page
   }
 
-  router.push({ query })
+  if (!props.disableNavigation) {
+    router.push({ query })
+  } else {
+    // When navigation is disabled, emit loadData directly
+    if (options.itemsPerPage === props.paginator.limit) {
+      const skip = (options.page - 1) * options.itemsPerPage
+      emit('loadData', options.itemsPerPage, skip)
+    }
+  }
 
   // Emit limit change when it actually changes as the query would be the
   // same and we need to reload the data.
@@ -169,18 +195,41 @@ function clearSelections() {
   showClearConfirm.value = false
 }
 
+function getRowProps({ item }: { item: TitleLight }) {
+  return {
+    class: props.selectedTitles?.includes(item.name) ? 'selected-row' : '',
+  }
+}
+
 function onRowClick(event: Event, { item }: { item: TitleLight }) {
   // Don't navigate if clicking on checkbox column
   const target = event.target as HTMLElement
   if (target.closest('.v-selection-control') || target.closest('td.v-data-table__td--select')) {
     return
   }
-  router.push({ name: 'title-detail', params: { id: item.name } })
+
+  emit('rowClicked', item)
+
+  if (!props.disableNavigation) {
+    router.push({ name: 'title-detail', params: { id: item.name } })
+  }
 }
 </script>
 
 <style scoped>
 :deep(.cursor-pointer-table tbody tr) {
   cursor: pointer;
+}
+
+:deep(.selected-row td) {
+  background-color: rgba(var(--v-theme-primary), 0.1) !important;
+}
+
+:deep(.selected-row td:first-child) {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-primary));
+}
+
+:deep(.selected-row:hover td) {
+  background-color: rgba(var(--v-theme-primary), 0.16) !important;
 }
 </style>

--- a/frontend/src/views/BookView.vue
+++ b/frontend/src/views/BookView.vue
@@ -9,14 +9,17 @@
     </div>
 
     <div v-if="dataLoaded && book">
-      <div class="d-flex justify-end mb-4" v-if="canMoveBook || canDeleteBook || canRecoverBook">
-        <v-btn
-          v-if="canMoveBook"
-          color="primary"
-          prepend-icon="mdi-truck"
-          @click="openMoveDialog"
-          class="mr-2"
-        >
+      <div
+        class="d-flex flex-md-row flex-column justify-md-end ga-2"
+        v-if="
+          canMoveBook ||
+          canDeleteBook ||
+          canRecoverBook ||
+          canAddBookToTitle ||
+          canCreateTitleFromBook
+        "
+      >
+        <v-btn v-if="canMoveBook" color="primary" prepend-icon="mdi-truck" @click="openMoveDialog">
           Move Book
         </v-btn>
         <v-btn
@@ -24,7 +27,6 @@
           color="success"
           prepend-icon="mdi-restore"
           @click="openRecoverDialog"
-          class="mr-2"
         >
           Recover Book
         </v-btn>
@@ -35,6 +37,22 @@
           @click="openDeleteDialog"
         >
           Delete Book
+        </v-btn>
+        <v-btn
+          v-if="canCreateTitleFromBook"
+          color="primary"
+          prepend-icon="mdi-plus-circle"
+          @click="openCreateTitleDialog"
+        >
+          Create New Title
+        </v-btn>
+        <v-btn
+          v-if="canAddBookToTitle"
+          color="warning"
+          prepend-icon="mdi-link-plus"
+          @click="openAddToTitleDialog"
+        >
+          Add to Title
         </v-btn>
       </div>
 
@@ -403,6 +421,17 @@
     <MoveBookDialog v-model="moveDialogOpen" :book="book" @moved="handleBookMoved" />
     <RecoverBookDialog v-model="recoverDialogOpen" :book="book" @recovered="handleBookRecovered" />
     <DeleteBookDialog v-model="deleteDialogOpen" :book="book" @deleted="handleBookDeleted" />
+    <TitleSelectDialog
+      v-if="book && book.name"
+      v-model="addToTitleDialogOpen"
+      :book-name="book.name"
+      @title-selected="handleTitleSelected"
+    />
+    <TitleFormDialog
+      v-model="createTitleDialogOpen"
+      :title="titleDataFromBook"
+      @created="handleTitleCreated"
+    />
 
     <ConfirmDialog
       v-model="showConfirmDialog"
@@ -454,6 +483,8 @@ import EditBookForm from '@/components/EditBookForm.vue'
 import EventsList from '@/components/EventsList.vue'
 import MoveBookDialog from '@/components/MoveBookDialog.vue'
 import RecoverBookDialog from '@/components/RecoverBookDialog.vue'
+import TitleSelectDialog from '@/components/TitleSelectDialog.vue'
+import TitleFormDialog from '@/components/TitleFormDialog.vue'
 import ZimUrlButtons from '@/components/ZimUrlButtons.vue'
 import BookHistory from '@/components/BookHistory.vue'
 import { useAuthStore } from '@/stores/auth'
@@ -488,6 +519,8 @@ const zimUrls = ref<ZimUrl[]>([])
 const moveDialogOpen = ref(false)
 const recoverDialogOpen = ref(false)
 const deleteDialogOpen = ref(false)
+const addToTitleDialogOpen = ref(false)
+const createTitleDialogOpen = ref(false)
 const updatingBook = ref(false)
 const updateError = ref('')
 const flavours = ref<string[]>([])
@@ -535,7 +568,11 @@ const locationHeaders = [
 
 const canEditBook = computed(() => {
   if (!book.value) return false
-  return authStore.hasPermission('book', 'update') && !book.value.title_archived
+  return (
+    authStore.hasPermission('book', 'update') &&
+    !book.value.title_archived &&
+    book.value.location_kind != 'deleted'
+  )
 })
 
 const canMoveBook = computed(() => {
@@ -585,6 +622,56 @@ const canRecoverBook = computed(() => {
     hasFutureDeletionDate &&
     !book.value.title_archived
   )
+})
+
+const canAddBookToTitle = computed(() => {
+  if (!book.value) return false
+  return (
+    authStore.hasPermission('book', 'update') &&
+    book.value.location_kind == 'quarantine' &&
+    book.value.title_id === null &&
+    !!book.value.name
+  )
+})
+
+const canCreateTitleFromBook = computed(() => {
+  if (!book.value) return false
+  return (
+    authStore.hasPermission('title', 'create') &&
+    book.value.location_kind == 'quarantine' &&
+    book.value.title_id === null &&
+    !!book.value.name
+  )
+})
+
+const titleDataFromBook = computed<Title | null>(() => {
+  if (!book.value) return null
+
+  const metadata = book.value.zim_metadata as Record<string, unknown>
+
+  // Create a Title object with data from the book
+  return {
+    id: '', // Will be assigned on creation
+    name: book.value.name || '',
+    maturity: 'unstable',
+    archived: false,
+    collection_titles: [],
+    title: (metadata.Title as string | null | undefined) || null,
+    creator: (metadata.Creator as string | null | undefined) || null,
+    publisher: (metadata.Publisher as string | null | undefined) || null,
+    description: (metadata.Description as string | null | undefined) || null,
+    language: (metadata.Language as string | null | undefined) || null,
+    illustration_48x48_at_1:
+      (metadata['Illustration_48x48@1'] as string | null | undefined) || null,
+    long_description: (metadata.LongDescription as string | null | undefined) || null,
+    license: (metadata.License as string | null | undefined) || null,
+    relation: (metadata.Relation as string | null | undefined) || null,
+    source: (metadata.Source as string | null | undefined) || null,
+    flavours: book.value.flavour ? [book.value.flavour] : [],
+    events: [],
+    books: [],
+    collections: [],
+  }
 })
 
 const canLoadMoreHistory = computed(() => {
@@ -705,7 +792,42 @@ const openDeleteDialog = () => {
 
 const handleBookDeleted = async () => {
   notificationStore.showSuccess('Book deleted successfully!')
-  await loadData()
+  await loadData(true)
+}
+
+const openAddToTitleDialog = () => {
+  addToTitleDialogOpen.value = true
+}
+
+const openCreateTitleDialog = () => {
+  createTitleDialogOpen.value = true
+}
+
+const handleTitleSelected = async (titleName: string) => {
+  if (!book.value || !book.value.name) return
+
+  loadingStore.startLoading('Updating title name...')
+
+  const response = await titleStore.updateTitle(titleName, {
+    name: book.value.name,
+    comment: `Updated title name to "${book.value.name}" from book`,
+  })
+
+  loadingStore.stopLoading()
+
+  if (response) {
+    notificationStore.showSuccess(`Title name updated to "${book.value.name}" successfully`)
+    await loadData(true, currentTab.value == 'history', currentTab.value == 'info')
+  } else {
+    for (const error of titleStore.errors) {
+      notificationStore.showError(error)
+    }
+  }
+}
+
+const handleTitleCreated = async () => {
+  notificationStore.showSuccess('Title created successfully!')
+  await loadData(true, currentTab.value == 'history', currentTab.value == 'info')
 }
 
 const handleUpdateBook = async (bookData: { flavour: string }) => {


### PR DESCRIPTION
## Rationale
This PR improves the UI to create a title from book details or associate a book with an existing title. This way, pending books can easily be associated with books as title modification/creation register events which lead to re-processing of pending books
<img width="1072" height="523" alt="Screenshot_20260605_072022" src="https://github.com/user-attachments/assets/5d1f38d1-4deb-4bd4-ad21-d810fc8f46d1" />
<img width="1014" height="815" alt="Screenshot_20260605_070807" src="https://github.com/user-attachments/assets/ae22443d-e379-43c4-b5e0-74f6cd9e7f5e" />
<img width="1060" height="795" alt="Screenshot_20260605_065336" src="https://github.com/user-attachments/assets/692767dd-fef5-4e9d-88e1-89a4e3d755a6" />
<img width="1078" height="803" alt="Screenshot_20260605_065321" src="https://github.com/user-attachments/assets/77b81183-3e04-4922-80ae-972a45a33940" />


## Changes
- make TitleTable reusable and optionally disable update of routes when table limit is changed or filters are updated. used in title selection dialog when updating tilte name with book name
- sync title table page with paginator and fix issues with reloading from page query parameter
- restrict title modification events from working on archived titles

This closes #311 