### PR TITLE
fix flavour mismatch comparison during book move

### DIFF
--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -12,6 +12,7 @@ from cms_backend.db.exceptions import RecordDoesNotExistError
 from cms_backend.db.models import Book, BookHistory, ZimfarmNotification
 from cms_backend.db.rules import (
     apply_retention_rules,
+    has_flavour_mismatch,
     title_is_missing_mandatory_metadata,
 )
 from cms_backend.schemas.models import BookUpdateSchema, FileLocation
@@ -110,8 +111,8 @@ def create_book_full_schema(book: Book) -> BookFullSchema:
         current_locations=current_locations,
         target_locations=target_locations,
         title_archived=book.title.archived if book.title else False,
-        has_flavour_mismatch=book.flavour not in book.title.flavours
-        if book.title and book.title.flavours
+        has_flavour_mismatch=has_flavour_mismatch(book.flavour, book.title.flavours)
+        if book.title
         else False,
     )
 
@@ -269,7 +270,9 @@ def move_book(
     if not book.title:
         raise ValueError(f"Book {book_id} has no associated title.")
 
-    if destination == "prod" and book.flavour not in book.title.flavours:
+    if destination == "prod" and has_flavour_mismatch(
+        book.flavour, book.title.flavours
+    ):
         raise ValueError(
             f"Book flavour '{book.flavour}' is not in title expected flavours "
             f"{book.title.flavours}"
@@ -548,7 +551,7 @@ def update_book_issues(session: OrmSession, book: Book, *, update_events: bool =
                 f"{','.join(different_metadata_keys)}"
             )
 
-    if book.title and book.title.flavours and book.flavour not in book.title.flavours:
+    if has_flavour_mismatch(book.flavour, book.title.flavours):
         issues.append("flavour mismatch")
         if update_events:
             book.events.append(

--- a/backend/src/cms_backend/db/books.py
+++ b/backend/src/cms_backend/db/books.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session as OrmSession
 from cms_backend.context import Context
 from cms_backend.db import count_from_stmt
 from cms_backend.db.models import Book, BookLocation, Collection, CollectionTitle, Title
+from cms_backend.db.rules import has_flavour_mismatch
 from cms_backend.schemas.models import BookLanguagesSchema, ZimUrlSchema, ZimUrlsSchema
 from cms_backend.schemas.orms import BookLightSchema, ListResult
 from cms_backend.utils.filename import construct_download_url
@@ -119,8 +120,8 @@ def get_books(
                 date=date,
                 flavour=flavour,
                 issues=book_issues,
-                has_flavour_mismatch=flavour not in title_flavours
-                if title_flavours
+                has_flavour_mismatch=has_flavour_mismatch(flavour, title_flavours)
+                if title_flavours is not None
                 else False,
             )
             for (

--- a/backend/src/cms_backend/db/rules.py
+++ b/backend/src/cms_backend/db/rules.py
@@ -119,3 +119,15 @@ def title_is_missing_mandatory_metadata(title: Title) -> bool:
             title.illustration_48x48_at_1,
         ]
     )
+
+
+def has_flavour_mismatch(book_flavour: str | None, title_flavours: list[str]) -> bool:
+    # Title has flavours but book has no flavour or flavour not in book flavours
+    if title_flavours and book_flavour not in title_flavours:
+        return True
+
+    # Book has flavour but title has no flavours
+    if book_flavour and not title_flavours:
+        return True
+
+    return False

--- a/backend/src/cms_backend/db/title.py
+++ b/backend/src/cms_backend/db/title.py
@@ -22,6 +22,7 @@ from cms_backend.db.models import (
     Title,
     TitleHistory,
 )
+from cms_backend.db.rules import has_flavour_mismatch
 from cms_backend.schemas.models import (
     FileLocation,
     TitleCreateSchema,
@@ -72,9 +73,7 @@ def create_title_full_schema(title: Title) -> TitleFullSchema:
                 date=book.date,
                 flavour=book.flavour,
                 issues=book.issues,
-                has_flavour_mismatch=book.flavour not in title.flavours
-                if title.flavours
-                else False,
+                has_flavour_mismatch=has_flavour_mismatch(book.flavour, title.flavours),
             )
             for book in sorted(
                 title.books,

--- a/backend/tests/db/test_book.py
+++ b/backend/tests/db/test_book.py
@@ -14,6 +14,7 @@ from cms_backend.db.book import (
 )
 from cms_backend.db.exceptions import RecordDoesNotExistError
 from cms_backend.db.models import Account, Book, Title, ZimfarmNotification
+from cms_backend.db.rules import has_flavour_mismatch
 from cms_backend.schemas.models import BookUpdateSchema
 
 
@@ -327,3 +328,21 @@ def test_update_book_flavour_mismatch_issues(
         payload=BookUpdateSchema(flavour="maxi"),
     )
     assert len(book.issues) == 0
+
+
+@pytest.mark.parametrize(
+    "book_flavour, title_flavours, expected",
+    [
+        pytest.param(None, ["maxi"], True),
+        pytest.param("maxi", ["maxi", "mini"], False),
+        pytest.param("maxi", ["mini", "nopic"], True),
+        pytest.param(None, [], False),
+        pytest.param("maxi", [], True),
+        pytest.param("", [], False),
+        pytest.param("", ["maxi"], True),
+    ],
+)
+def test_has_flavour_mismatch(
+    book_flavour: str, title_flavours: list[str], *, expected: bool
+):
+    assert has_flavour_mismatch(book_flavour, title_flavours) is expected


### PR DESCRIPTION
## Changes
- refuse to move book to prod only if title has flavours and book flavour not in list of flavours

This fixes #323 