### PR TITLE
add task to automatically mark staging books for deletion

### DIFF
--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Any, Literal
 from uuid import UUID
 
@@ -203,6 +204,7 @@ def delete_book(
     *,
     book_id: UUID,
     force_delete: bool = False,
+    deletion_delay: datetime.timedelta = Context.book_deletion_delay,
 ) -> Book:
     """Mark a book as deleted.
 
@@ -223,7 +225,7 @@ def delete_book(
             f"Book {book_id} does not meet criteria to be marked as deleted."
         )
 
-    deletion_date = now if force_delete else now + Context.book_deletion_delay
+    deletion_date = now if force_delete else now + deletion_delay
 
     if book.location_kind in ("staging", "prod", "quarantine"):
         book.deletion_date = deletion_date

--- a/backend/src/cms_backend/db/books.py
+++ b/backend/src/cms_backend/db/books.py
@@ -32,6 +32,7 @@ def get_books(
     has_backup: bool | None = None,
     updated_before: datetime.datetime | None = None,
     updated_after: datetime.datetime | None = None,
+    created_before: datetime.datetime | None = None,
 ) -> ListResult[BookLightSchema]:
     """Get a list of books"""
 
@@ -84,6 +85,9 @@ def get_books(
     if updated_after is not None:
         stmt = stmt.where(Book.updated_at > updated_after)
 
+    if created_before is not None:
+        stmt = stmt.where(Book.created_at < created_before)
+
     if needs_attention is True:
         stmt = stmt.where(
             or_(
@@ -111,6 +115,24 @@ def get_books(
             .where(BookLocation.status == "current", BookLocation.is_backup.is_(True))
             .distinct()
         )
+
+    if needs_attention is True:
+        order_clauses = [
+            Book.has_error,
+            Book.location_kind.in_(["staging", "to_delete"]).desc(),
+            Book.location_kind,
+            Book.needs_file_operation,
+            Book.created_at.desc(),
+            Book.id,
+        ]
+    else:
+        order_clauses = [
+            Book.has_error,
+            Book.location_kind,
+            Book.needs_file_operation,
+            Book.created_at.desc(),
+            Book.id,
+        ]
 
     return ListResult[BookLightSchema](
         nb_records=count_from_stmt(session, stmt),
@@ -147,15 +169,7 @@ def get_books(
                 book_issues,
                 title_flavours,
             ) in session.execute(
-                stmt.offset(skip)
-                .limit(limit)
-                .order_by(
-                    Book.has_error,
-                    Book.location_kind,
-                    Book.needs_file_operation,
-                    Book.created_at.desc(),
-                    Book.id,
-                )
+                stmt.offset(skip).limit(limit).order_by(*order_clauses)
             ).all()
         ],
     )

--- a/backend/src/cms_backend/mill/context.py
+++ b/backend/src/cms_backend/mill/context.py
@@ -35,3 +35,19 @@ class Context:
             os.getenv("PROCESS_RETENTION_RULES_INTERVAL", default="1d")
         )
     )
+
+    mark_staging_books_for_deletion_interval: timedelta = timedelta(
+        seconds=parse_timespan(
+            os.getenv("MARK_STAGING_BOOKS_FOR_DELETION_INTERVAL", default="1d")
+        )
+    )
+
+    staging_books_lifespan: timedelta = timedelta(
+        seconds=parse_timespan(os.getenv("STAGING_BOOKS_LIFESPAN", default="30d"))
+    )
+
+    staging_books_deletion_grace_period: timedelta = timedelta(
+        seconds=parse_timespan(
+            os.getenv("STAGING_BOOKS_DELETION_GRACE_PERIOD", default="7d")
+        )
+    )

--- a/backend/src/cms_backend/mill/main.py
+++ b/backend/src/cms_backend/mill/main.py
@@ -12,6 +12,9 @@ from cms_backend.__about__ import __version__
 from cms_backend.context import Context
 from cms_backend.db import Session
 from cms_backend.mill.context import Context as MillContext
+from cms_backend.mill.mark_staging_books_for_deletion import (
+    mark_staging_books_for_deletion,
+)
 from cms_backend.mill.process_retention_rules import process_retention_rules
 from cms_backend.mill.process_title_modifications import process_title_modifications
 from cms_backend.mill.process_zimfarm_notifications import process_zimfarm_notifications
@@ -32,6 +35,10 @@ tasks: list[TaskConfig] = [
     TaskConfig(
         func=process_retention_rules,
         interval=MillContext.process_retention_rules_interval,
+    ),
+    TaskConfig(
+        func=mark_staging_books_for_deletion,
+        interval=MillContext.mark_staging_books_for_deletion_interval,
     ),
 ]
 

--- a/backend/src/cms_backend/mill/mark_staging_books_for_deletion.py
+++ b/backend/src/cms_backend/mill/mark_staging_books_for_deletion.py
@@ -1,0 +1,42 @@
+from sqlalchemy.orm import Session as OrmSession
+
+from cms_backend import logger
+from cms_backend.db.book import delete_book
+from cms_backend.db.books import get_books
+from cms_backend.mill.context import Context as MillContext
+from cms_backend.utils.datetime import getnow
+
+
+def mark_staging_books_for_deletion(session: OrmSession):
+    logger.info("Marking staging books that have exceeded lifespan for deletion")
+    nb_books_marked = 0
+    while True:
+        skip = 0
+        limit = 50
+        results = get_books(
+            session,
+            needs_file_operation=False,
+            needs_processing=False,
+            created_before=getnow() - MillContext.staging_books_lifespan,
+            skip=skip,
+            limit=limit,
+            location_kinds=["staging"],
+        )
+        if not results.records:
+            break
+
+        for book in results.records:
+            with session.begin_nested():
+                try:
+                    delete_book(
+                        session,
+                        book_id=book.id,
+                        deletion_delay=MillContext.staging_books_deletion_grace_period,
+                    )
+                except Exception:
+                    logger.exception(f"error while marking book {book.id} for deletion")
+                else:
+                    nb_books_marked += 1
+        skip += limit
+
+    logger.info(f"Done marking {nb_books_marked} staging book(s) for deletion")

--- a/backend/tests/db/test_books.py
+++ b/backend/tests/db/test_books.py
@@ -1166,3 +1166,46 @@ def test_get_books_time_filters(
     )
     assert results.nb_records == expected_count
     assert len(results.records) == expected_count
+
+
+@pytest.mark.parametrize(
+    "created_before_hours,expected_count",
+    [
+        pytest.param(None, 5, id="no-time-filters"),  # All 5 books match
+        pytest.param(6, 2, id="created-before-6h"),  # Last 2 (4h, 2h ago) - exclusive
+        pytest.param(
+            3, 4, id="created-before-3h"
+        ),  # First 4 (10h, 8h, 6h, 4h ago) - exclusive
+    ],
+)
+def test_get_books_created_before_filters(
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+    created_before_hours: int | None,
+    expected_count: int,
+):
+    """Test that get_books works correctly with created_before filters."""
+    now = getnow()
+    # Create 5 books with different times
+    create_book(created_at=now - datetime.timedelta(hours=10))
+    create_book(created_at=now - datetime.timedelta(hours=8))
+    create_book(created_at=now - datetime.timedelta(hours=6))
+    create_book(created_at=now - datetime.timedelta(hours=4))
+    create_book(created_at=now - datetime.timedelta(hours=2))
+
+    dbsession.flush()
+
+    created_before = (
+        now - datetime.timedelta(hours=created_before_hours)
+        if created_before_hours
+        else None
+    )
+
+    results = get_books(
+        dbsession,
+        skip=0,
+        limit=20,
+        created_before=created_before,
+    )
+    assert results.nb_records == expected_count
+    assert len(results.records) == expected_count


### PR DESCRIPTION
## Changes
- add background task to mark staging books for deletion
- change order clause of `get_books` function to prioritize books in `staging` and `to_delete` when `needs_attention` is True
- add new env vars for task to delete staging books created before a specific time

This closes #44 