### PR TITLE
remove book backup

### DIFF
--- a/backend/src/cms_backend/api/routes/books.py
+++ b/backend/src/cms_backend/api/routes/books.py
@@ -19,6 +19,7 @@ from cms_backend.db.book import get_book_history as db_get_book_history
 from cms_backend.db.book import get_book_history_entry as db_get_book_history_entry
 from cms_backend.db.book import move_book as db_move_book
 from cms_backend.db.book import recover_book as db_recover_book
+from cms_backend.db.book import remove_book_backup as db_remove_book_backup
 from cms_backend.db.book import revert_book as db_revert_book
 from cms_backend.db.book import update_book as db_update_book
 from cms_backend.db.books import get_book_flavours as db_get_book_flavours
@@ -270,3 +271,14 @@ def revert_book(
         content={"message": f"book '{book_id}' has been restored"},
         status_code=HTTPStatus.OK,
     )
+
+
+@router.patch(
+    "/{book_id}/backup/remove",
+    dependencies=[Depends(require_permission(namespace="book", name="update"))],
+)
+def remove_book_backup(
+    book_id: Annotated[UUID, Path()],
+    session: Annotated[OrmSession, Depends(gen_dbsession)],
+) -> BookFullSchema:
+    return create_book_full_schema(db_remove_book_backup(session, book_id=book_id))

--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -642,20 +642,82 @@ def backup_book(
             Context.backup_warehouse_id,
             Context.backup_base_path,
             current_location.filename,
+            is_backup=True,
         )
     )
-    existing_filename = current_location.filename
     create_book_target_locations(
         session=session,
         book=book,
         target_locations=target_locations,
-        is_backup=True,
     )
     book.events.append(
         f"{getnow()}: Book scheduled to be copied from '{book.location_kind}' to "
         f"'backup'"
     )
 
+    session.add(book)
+    session.flush()
+    return book
+
+
+def remove_book_backup(
+    session: OrmSession,
+    *,
+    book_id: UUID,
+) -> Book:
+    """Create a backup of a book."""
+    book = get_book_or_none(
+        session,
+        book_id=book_id,
+        has_error=False,
+        needs_processing=False,
+        needs_file_operation=False,
+        locations=["staging", "quarantine", "prod", "deleted"],
+    )
+
+    if book is None:
+        raise RecordDoesNotExistError(
+            f"Book {book_id} does not meet criteria for it's backup to be removed."
+        )
+
+    if book.title is None:
+        raise ValueError("Book has no associated title.")
+
+    if book.title.archived:
+        raise ValueError(f"Book title {book.title_id} is currently archived")
+
+    existing_backups = [
+        loc for loc in book.locations if loc.status == "current" and loc.is_backup
+    ]
+    if not existing_backups:
+        raise ValueError("Book does not have a backup.")
+
+    target_locations = [
+        FileLocation(loc.warehouse_id, loc.path, loc.filename)
+        for loc in book.locations
+        if loc.status == "current" and not loc.is_backup
+    ]
+
+    for backup in existing_backups:
+        backup.is_backup = False
+        session.add(backup)
+
+    if book.location_kind == "deleted":
+        # book has no target locations and only backups exist
+        book.location_kind = "to_delete"
+        book.needs_file_operation = True
+        book.deletion_date = getnow()
+        session.add(book)
+        session.flush()
+        return book
+
+    create_book_target_locations(
+        session=session,
+        book=book,
+        target_locations=target_locations,
+    )
+
+    book.events.append(f"{getnow()}: Book backup scheduled to be removed")
     session.add(book)
     session.flush()
     return book

--- a/backend/src/cms_backend/db/book_location.py
+++ b/backend/src/cms_backend/db/book_location.py
@@ -89,8 +89,6 @@ def create_book_target_locations(
     session: OrmSession,
     book: Book,
     target_locations: list[FileLocation],
-    *,
-    is_backup: bool = False,
 ) -> None:
     """Create target locations for a book if not already at expected locations.
 
@@ -136,7 +134,7 @@ def create_book_target_locations(
             path=target_location.path,
             filename=target_location.filename,
             status="target",
-            is_backup=is_backup,
+            is_backup=target_location.is_backup,
         )
 
     book.needs_file_operation = True

--- a/backend/src/cms_backend/schemas/models.py
+++ b/backend/src/cms_backend/schemas/models.py
@@ -32,6 +32,7 @@ class FileLocation:
     warehouse_id: UUID
     path: Path
     filename: str
+    is_backup: bool = False
 
 
 class AccountUpdateSchema(BaseModel):

--- a/backend/tests/api/routes/test_books.py
+++ b/backend/tests/api/routes/test_books.py
@@ -11,7 +11,14 @@ from sqlalchemy.orm import Session as OrmSession
 from cms_backend.api.token import generate_access_token
 from cms_backend.context import Context
 from cms_backend.db.book import update_book
-from cms_backend.db.models import Account, Book, BookLocation, Title, Warehouse
+from cms_backend.db.models import (
+    Account,
+    Book,
+    BookLocation,
+    Collection,
+    Title,
+    Warehouse,
+)
 from cms_backend.roles import RoleEnum
 from cms_backend.schemas.models import BookUpdateSchema
 from cms_backend.utils.datetime import getnow
@@ -620,6 +627,72 @@ def test_backup_book_required_permissions(
 
     response = client.patch(
         f"/v1/books/{book.id}/backup",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "permission,expected_status_code",
+    [
+        pytest.param(RoleEnum.EDITOR, HTTPStatus.OK, id="editor"),
+        pytest.param(RoleEnum.VIEWER, HTTPStatus.UNAUTHORIZED, id="viewer"),
+    ],
+)
+def test_remove_book_backup_required_permissions(
+    dbsession: OrmSession,
+    client: TestClient,
+    create_account: Callable[..., Account],
+    create_book: Callable[..., Book],
+    create_title: Callable[..., Title],
+    create_book_location: Callable[..., BookLocation],
+    create_collection: Callable[..., Collection],
+    create_warehouse: Callable[..., Warehouse],
+    permission: RoleEnum,
+    expected_status_code: HTTPStatus,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test backing up a book with different roles"""
+
+    account = create_account(permission=permission)
+    access_token = generate_access_token(
+        account_id=str(account.id), issue_time=getnow()
+    )
+
+    backup_warehouse = create_warehouse()
+    monkeypatch.setattr(Context, "backup_warehouse_id", backup_warehouse.id)
+    monkeypatch.setattr(Context, "backup_base_path", Path("/backup"))
+
+    warehouse = create_warehouse()
+    title = create_title()
+    create_collection(warehouse=warehouse, title_ids_with_paths=[(title.id, "zim")])
+    book = create_book(name="test_en_all", date="2024-01")
+    book.title = title
+    book.location_kind = "staging"
+    book.has_error = False
+    book.needs_processing = False
+    book.needs_file_operation = False
+
+    create_book_location(
+        book=book,
+        warehouse_id=warehouse.id,
+        path=Path("zim"),
+        filename="test_en_all_2024-01.zim",
+        status="current",
+    )
+
+    create_book_location(
+        book=book,
+        warehouse_id=warehouse.id,
+        path=Path("backup"),
+        filename="test_en_all_2024-01.zim",
+        status="current",
+        is_backup=True,
+    )
+    dbsession.flush()
+
+    response = client.patch(
+        f"/v1/books/{book.id}/backup/remove",
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert response.status_code == expected_status_code

--- a/backend/tests/db/test_book.py
+++ b/backend/tests/db/test_book.py
@@ -11,6 +11,7 @@ from cms_backend.db.book import (
     get_book_history,
     get_book_history_entry_or_none,
     get_differing_metadata_keys,
+    remove_book_backup,
     revert_book,
     update_book,
 )
@@ -20,6 +21,7 @@ from cms_backend.db.models import (
     Account,
     Book,
     BookLocation,
+    Collection,
     Title,
     Warehouse,
     ZimfarmNotification,
@@ -511,3 +513,128 @@ def test_backup_book_no_current_location_raises_error(
 
     with pytest.raises(ValueError, match=f"Book {book.id} has no current location"):
         backup_book(dbsession, book_id=book.id)
+
+
+def test_remove_book_backup_no_existing_backup_raises_error(
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+    create_title: Callable[..., Title],
+    create_book_location: Callable[..., BookLocation],
+    create_warehouse: Callable[..., Warehouse],
+):
+    """Test that removing backup for a book with no existing backups raises error"""
+    warehouse = create_warehouse()
+    title = create_title()
+    book = create_book(name="test_en_all", date="2024-01")
+    book.title = title
+    book.location_kind = "staging"
+    book.has_error = False
+    book.needs_processing = False
+    book.needs_file_operation = False
+
+    create_book_location(
+        book=book,
+        warehouse_id=warehouse.id,
+        path=Path("zim"),
+        filename="test_en_all_2024-01.zim",
+        status="current",
+    )
+    dbsession.flush()
+
+    with pytest.raises(ValueError, match="Book does not have a backup"):
+        remove_book_backup(dbsession, book_id=book.id)
+
+
+def test_backup_locations_is_backup_property_removed(
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+    create_title: Callable[..., Title],
+    create_book_location: Callable[..., BookLocation],
+    create_collection: Callable[..., Collection],
+    create_warehouse: Callable[..., Warehouse],
+):
+    """Test that removing backups for a book removes the is_backup property for existing
+    backups
+    """
+    warehouse = create_warehouse()
+    title = create_title()
+    create_collection(warehouse=warehouse, title_ids_with_paths=[(title.id, "zim")])
+    book = create_book(name="test_en_all", date="2024-01")
+    book.title = title
+    book.location_kind = "staging"
+    book.has_error = False
+    book.needs_processing = False
+    book.needs_file_operation = False
+
+    # Create two current locations, one as backup and one a normal location
+    create_book_location(
+        book=book,
+        warehouse_id=warehouse.id,
+        path=Path("zim"),
+        filename="test_en_all_2024-01.zim",
+        status="current",
+    )
+
+    create_book_location(
+        book=book,
+        warehouse_id=warehouse.id,
+        path=Path("backup"),
+        filename="test_en_all_2024-01.zim",
+        status="current",
+        is_backup=True,
+    )
+    dbsession.flush()
+
+    book = remove_book_backup(dbsession, book_id=book.id)
+    assert book.needs_file_operation is True
+    # no more locations have backup property and one new target
+    assert (
+        len(
+            [loc for loc in book.locations if loc.is_backup and loc.status == "current"]
+        )
+        == 0
+    )
+    assert len([loc for loc in book.locations if loc.status == "target"]) == 1
+
+
+def test_remove_backup_for_deleted_book_moves_book_to_deleted(
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+    create_title: Callable[..., Title],
+    create_book_location: Callable[..., BookLocation],
+    create_collection: Callable[..., Collection],
+    create_warehouse: Callable[..., Warehouse],
+):
+    """Test that removing backups for a deleted book moves the book to to_delete"""
+    warehouse = create_warehouse()
+    title = create_title()
+    create_collection(warehouse=warehouse, title_ids_with_paths=[(title.id, "zim")])
+    book = create_book(name="test_en_all", date="2024-01")
+    book.title = title
+    book.location_kind = "deleted"
+    book.has_error = False
+    book.needs_processing = False
+    book.needs_file_operation = False
+
+    create_book_location(
+        book=book,
+        warehouse_id=warehouse.id,
+        path=Path("backup"),
+        filename="test_en_all_2024-01.zim",
+        status="current",
+        is_backup=True,
+    )
+    dbsession.flush()
+
+    book = remove_book_backup(dbsession, book_id=book.id)
+    assert book.needs_file_operation is True
+    assert book.location_kind == "to_delete"
+    # no more backup locations and backup is now the current location
+    assert (
+        len(
+            [loc for loc in book.locations if loc.is_backup and loc.status == "current"]
+        )
+        == 0
+    )
+    assert len([loc for loc in book.locations if loc.status == "target"]) == 0
+    assert len([loc for loc in book.locations if loc.status == "current"]) == 1

--- a/frontend/src/stores/book.ts
+++ b/frontend/src/stores/book.ts
@@ -202,6 +202,20 @@ export const useBookStore = defineStore('book', () => {
     }
   }
 
+  const removeBookBackup = async (bookId: string) => {
+    const service = await authStore.getApiService('books')
+    try {
+      const response = await service.patch<null, Book>(`/${bookId}/backup/remove`)
+      errors.value = []
+      book.value = response
+      return response
+    } catch (_error) {
+      console.error('Failed to remove book backup', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
   const moveBook = async (bookId: string, destination: 'staging' | 'prod') => {
     const service = await authStore.getApiService('books')
     try {
@@ -265,6 +279,7 @@ export const useBookStore = defineStore('book', () => {
     fetchZimUrls,
     deleteBook,
     recoverBook,
+    removeBookBackup,
     moveBook,
     fetchBookFlavours,
     updateBook,

--- a/frontend/src/views/BookView.vue
+++ b/frontend/src/views/BookView.vue
@@ -17,7 +17,8 @@
           canRecoverBook ||
           canAddBookToTitle ||
           canCreateTitleFromBook ||
-          canBackupBook
+          canBackupBook ||
+          canRemoveBookBackup
         "
       >
         <v-btn v-if="canMoveBook" color="primary" prepend-icon="mdi-truck" @click="openMoveDialog">
@@ -62,6 +63,14 @@
           @click="openBackupDialog"
         >
           Backup Book
+        </v-btn>
+        <v-btn
+          v-if="canRemoveBookBackup"
+          color="error"
+          prepend-icon="mdi-delete-sweep"
+          @click="openRemoveBackupDialog"
+        >
+          Remove Backup
         </v-btn>
       </div>
 
@@ -503,6 +512,25 @@
     </ConfirmDialog>
 
     <ConfirmDialog
+      v-model="removeBackupDialogOpen"
+      title="Confirm Remove Book Backup"
+      confirm-text="Remove Backup"
+      cancel-text="Abort"
+      confirm-color="error"
+      icon="mdi-delete-sweep"
+      icon-color="error"
+      :max-width="600"
+      :loading="removingBackup"
+      @confirm="handleRemoveBookBackup"
+    >
+      <template #content>
+        <p class="text-body-1">
+          Are you sure you want to remove the backup for this book? This action cannot be undone.
+        </p>
+      </template>
+    </ConfirmDialog>
+
+    <ConfirmDialog
       v-model="showConfirmDialog"
       title="Confirm Book Update"
       confirm-text="Save Changes"
@@ -591,6 +619,8 @@ const deleteDialogOpen = ref(false)
 const addToTitleDialogOpen = ref(false)
 const createTitleDialogOpen = ref(false)
 const backupDialogOpen = ref(false)
+const removeBackupDialogOpen = ref(false)
+const removingBackup = ref(false)
 const backingUpBook = ref(false)
 const updatingBook = ref(false)
 const updateError = ref('')
@@ -726,6 +756,19 @@ const canBackupBook = computed(() => {
     !!book.value.title_id &&
     !book.value.title_archived &&
     !book.value.has_backup
+  )
+})
+
+const canRemoveBookBackup = computed(() => {
+  if (!book.value) return false
+  return (
+    ['quarantine', 'prod', 'staging', 'deleted'].includes(book.value.location_kind) &&
+    book.value.has_backup &&
+    authStore.hasPermission('book', 'update') &&
+    !book.value.needs_file_operation &&
+    !book.value.needs_processing &&
+    !!book.value.title_id &&
+    !book.value.title_archived
   )
 })
 
@@ -919,6 +962,32 @@ const handleBackupBook = async () => {
   }
 }
 
+const openRemoveBackupDialog = () => {
+  removeBackupDialogOpen.value = true
+}
+
+const handleRemoveBookBackup = async () => {
+  if (!book.value) return
+
+  removingBackup.value = true
+  try {
+    const response = await bookStore.removeBookBackup(book.value.id)
+    if (response) {
+      book.value = response
+      notificationStore.showSuccess('Book backup removed successfully!')
+    } else {
+      for (const error of bookStore.errors) {
+        notificationStore.showError(error)
+      }
+    }
+  } catch {
+    notificationStore.showError('An error occurred while removing the book backup')
+  } finally {
+    removingBackup.value = false
+    removeBackupDialogOpen.value = false
+  }
+}
+
 const handleTitleSelected = async (titleName: string) => {
   if (!book.value || !book.value.name) return
 
@@ -1043,7 +1112,7 @@ watch(
   async (newTab) => {
     currentTab.value = newTab
 
-    await loadData(newTab == 'edit', newTab === 'history', newTab === 'info')
+    await loadData(newTab != 'history', newTab === 'history', newTab === 'info')
 
     if (newTab === 'edit' && book.value && flavours.value.length == 0) {
       loadingFlavours.value = true


### PR DESCRIPTION
## Rationale
This PR introduces a way to remove existing book backups by resetting the existing backups `is_backup` property to False and creating new target locations. This way, the `move_files` function deletes the extra current locations.

<img width="1117" height="403" alt="Screenshot_20260609_100117" src="https://github.com/user-attachments/assets/8841c108-9d31-4bf1-819c-9314300ac742" />
<img width="1146" height="593" alt="Screenshot_20260609_100108" src="https://github.com/user-attachments/assets/6a47665c-8496-4e67-ac0b-d3b34e3d0b67" />
<img width="1122" height="563" alt="Screenshot_20260609_100056" src="https://github.com/user-attachments/assets/5ade6795-ee9b-4a3f-b3e4-bbf89e54ebb1" />
<img width="1144" height="662" alt="Screenshot_20260609_100049" src="https://github.com/user-attachments/assets/83e32d55-4003-4d34-b144-599a588c0776" />


## Changes
- scope `is_backup` property to indivdiual `FileLocation` object instead of function to create book target locations as that applies it to all
- add function to remove book backup

This closes #328 