### PR TITLE
reuse existing current locations in backup operation

### DIFF
--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -631,11 +631,10 @@ def backup_book(
     if existing_backup:
         raise ValueError("Book already has a backup.")
 
-    # Create a current and tagret location for the backup using the book's details
-    existing_filename = current_location.filename
     target_locations = [
-        FileLocation(tc.collection.warehouse_id, tc.path, existing_filename)
-        for tc in book.title.collections
+        FileLocation(loc.warehouse_id, loc.path, loc.filename)
+        for loc in book.locations
+        if loc.status == "current"
     ]
     target_locations.append(
         FileLocation(

--- a/backend/tests/db/test_book.py
+++ b/backend/tests/db/test_book.py
@@ -396,11 +396,14 @@ def test_backup_book_success(
     # Verify backup has a current location (source) and target location
     current_locations = [loc for loc in book.locations if loc.status == "current"]
     target_locations = [loc for loc in book.locations if loc.status == "target"]
+    backup_target_locations = [
+        loc for loc in book.locations if loc.status == "target" and loc.is_backup
+    ]
     assert len(current_locations) == 1
-    assert len(target_locations) == 1
-    assert target_locations[0].is_backup
+    assert len(target_locations) == 2
+    assert len(backup_target_locations) == 1
     assert current_locations[0].warehouse_id == warehouse.id
-    assert target_locations[0].warehouse_id == backup_warehouse.id
+    assert backup_target_locations[0].warehouse_id == backup_warehouse.id
     assert book.needs_file_operation is True
 
 


### PR DESCRIPTION
## Changes
- reuse existing current locations to build up list of target locations during backup instead of collection titles path

This fixes #334 