### PR TITLE
remove id and needs_attention from book filters

### DIFF
--- a/backend/src/cms_backend/db/books.py
+++ b/backend/src/cms_backend/db/books.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from uuid import UUID
 
 from pydantic import AnyUrl
-from sqlalchemy import String, and_, or_, select
+from sqlalchemy import String, and_, case, or_, select
 from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend.context import Context
@@ -110,11 +110,12 @@ def get_books(
         )
 
     if has_backup:
-        stmt = (
-            stmt.join(BookLocation, Book.id == BookLocation.book_id, isouter=True)
+        backup_books = (
+            select(BookLocation.book_id)
             .where(BookLocation.status == "current", BookLocation.is_backup.is_(True))
             .distinct()
         )
+        stmt = stmt.where(Book.id.in_(backup_books))
 
     if needs_attention is True:
         order_clauses = [
@@ -128,9 +129,16 @@ def get_books(
     else:
         order_clauses = [
             Book.has_error,
-            Book.location_kind,
-            Book.needs_file_operation,
+            case(
+                (Book.location_kind == "quarantine", 0),
+                (Book.location_kind == "staging", 1),
+                (Book.location_kind == "prod", 2),
+                (Book.location_kind == "to_delete", 3),
+                (Book.location_kind == "deleted", 4),
+                else_=5,
+            ),
             Book.created_at.desc(),
+            Book.needs_file_operation,
             Book.id,
         ]
 

--- a/frontend/src/components/BooksBaseView.vue
+++ b/frontend/src/components/BooksBaseView.vue
@@ -94,14 +94,9 @@ const errors = ref<string[]>([])
 const bookFilters = computed(() => {
   const query = router.currentRoute.value.query
   const derived = {
-    id: '',
     name: '',
     flavour: '',
-    needs_attention: 'no',
     location_kind: '',
-  }
-  if (query.id && typeof query.id === 'string') {
-    derived.id = query.id
   }
 
   if (query.name && typeof query.name === 'string') {
@@ -110,10 +105,6 @@ const bookFilters = computed(() => {
 
   if (query.flavour && typeof query.flavour === 'string') {
     derived.flavour = query.flavour
-  }
-
-  if (query.needs_attention && typeof query.needs_attention === 'string') {
-    derived.needs_attention = query.needs_attention
   }
 
   if (query.location_kind && typeof query.location_kind === 'string') {
@@ -146,21 +137,12 @@ async function loadData(limit: number, skip: number, hideLoading: boolean = fals
     books.value = []
   }
 
-  // Convert needs_attention filter to boolean or undefined
-  let needsAttention: boolean | undefined = undefined
-  if (bookFilters.value.needs_attention === 'yes') {
-    needsAttention = true
-  } else if (bookFilters.value.needs_attention === 'no') {
-    needsAttention = false
-  }
-  // 'all' or empty string maps to undefined
-
   // Fetch books with the selected filters
   await bookStore.fetchBooks(
     limit,
     skip,
-    needsAttention,
-    bookFilters.value.id || undefined,
+    undefined,
+    undefined,
     bookFilters.value.location_kind ? [bookFilters.value.location_kind] : undefined,
     undefined, // flag not used in this view
     bookFilters.value.name || undefined,
@@ -197,20 +179,12 @@ function updateUrlFilters(sourceFilters: typeof bookFilters.value) {
   // create query object from selected filters
   const query: Record<string, string | string[]> = {}
 
-  if (sourceFilters.id) {
-    query.id = sourceFilters.id
-  }
-
   if (sourceFilters.name) {
     query.name = sourceFilters.name
   }
 
   if (sourceFilters.flavour) {
     query.flavour = sourceFilters.flavour
-  }
-
-  if (sourceFilters.needs_attention) {
-    query.needs_attention = sourceFilters.needs_attention
   }
 
   if (sourceFilters.location_kind) {
@@ -224,7 +198,7 @@ function updateUrlFilters(sourceFilters: typeof bookFilters.value) {
 }
 
 async function clearFilters() {
-  updateUrlFilters({ id: '', name: '', flavour: '', needs_attention: '', location_kind: '' })
+  updateUrlFilters({ name: '', flavour: '', location_kind: '' })
 }
 
 async function handleBookFiltersChange(newFilters: typeof bookFilters.value) {
@@ -239,7 +213,7 @@ async function fetchBackupCount() {
     const currentFilters = bookFilters.value
     backupCount.value = await bookStore.countBooks(
       undefined,
-      currentFilters.id || undefined,
+      undefined,
       currentFilters.location_kind ? [currentFilters.location_kind] : undefined,
       undefined,
       currentFilters.name || undefined,
@@ -258,7 +232,6 @@ function navigateToBackups() {
   const currentFilters = bookFilters.value
   const query: Record<string, string> = { needs_attention: 'all' }
 
-  if (currentFilters.id) query.id = currentFilters.id
   if (currentFilters.name) query.name = currentFilters.name
   if (currentFilters.flavour) query.flavour = currentFilters.flavour
   if (currentFilters.location_kind) query.location_kind = currentFilters.location_kind

--- a/frontend/src/components/BooksViewFilters.vue
+++ b/frontend/src/components/BooksViewFilters.vue
@@ -4,17 +4,6 @@
       <v-row>
         <v-col cols="12" sm="6" md="3">
           <v-text-field
-            v-model="localFilters.id"
-            label="ID"
-            placeholder="Search by ID..."
-            variant="outlined"
-            density="compact"
-            hide-details
-            @change="emitFilters"
-          />
-        </v-col>
-        <v-col cols="12" sm="6" md="3">
-          <v-text-field
             v-model="localFilters.name"
             label="Name"
             placeholder="Search by name..."
@@ -35,19 +24,6 @@
             hide-details
             clearable
             :loading="loadingFlavours"
-            @update:model-value="emitFilters"
-          />
-        </v-col>
-        <v-col cols="12" sm="6" md="3">
-          <v-select
-            v-model="localFilters.needs_attention"
-            label="Needs Attention"
-            :items="needsAttentionOptions"
-            placeholder="Select needs attention"
-            variant="outlined"
-            density="compact"
-            hide-details
-            clearable
             @update:model-value="emitFilters"
           />
         </v-col>
@@ -85,10 +61,8 @@ import { computed, ref, watch } from 'vue'
 // Props
 interface Props {
   filters: {
-    id: string
     name: string
     flavour: string
-    needs_attention: string
     location_kind: string
   }
   locationKindOptions?: string[]
@@ -106,10 +80,8 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   filtersChanged: [
     filters: {
-      id: string
       name: string
       flavour: string
-      needs_attention: string
       location_kind: string
     },
   ]
@@ -118,10 +90,8 @@ const emit = defineEmits<{
 
 // Local filters state
 const localFilters = ref({
-  id: props.filters.id,
   name: props.filters.name,
   flavour: props.filters.flavour,
-  needs_attention: props.filters.needs_attention,
   location_kind: props.filters.location_kind,
 })
 
@@ -130,10 +100,8 @@ watch(
   () => props.filters,
   (newFilters) => {
     localFilters.value = {
-      id: newFilters.id,
       name: newFilters.name,
       flavour: newFilters.flavour,
-      needs_attention: newFilters.needs_attention,
       location_kind: newFilters.location_kind,
     }
   },
@@ -153,18 +121,10 @@ const formattedFlavourOptions = computed(() => {
   }))
 })
 
-const needsAttentionOptions = [
-  { title: 'All', value: 'all' },
-  { title: 'Yes', value: 'yes' },
-  { title: 'No', value: 'no' },
-]
-
 const hasActiveFilters = computed(() => {
   return (
-    props.filters.id.length > 0 ||
     props.filters.name.length > 0 ||
     props.filters.flavour.length > 0 ||
-    props.filters.needs_attention.length > 0 ||
     props.filters.location_kind.length > 0
   )
 })
@@ -172,10 +132,8 @@ const hasActiveFilters = computed(() => {
 // Emit filters when they change
 function emitFilters() {
   emit('filtersChanged', {
-    id: localFilters.value.id,
     name: localFilters.value.name,
     flavour: localFilters.value.flavour,
-    needs_attention: localFilters.value.needs_attention,
     location_kind: localFilters.value.location_kind,
   })
 }


### PR DESCRIPTION
<img width="1046" height="497" alt="Screenshot_20260612_102942" src="https://github.com/user-attachments/assets/f5253c99-ab65-4a1e-b706-708d4ddfc7d7" />


## Changes
- remove id and needs_attention parameters from books view
- when needs_attention is not set, use custom ordering for book locations. `quarantine` < `staging` < `prod` < `to_delete` < `deleted`. This way, deleted books are shown last in the books view
- because of custom ordering, remove distinct clause on backup books

This closes #340 