### PR TITLE
accurately highlight correct navbar item

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -60,7 +60,7 @@ const navigationItems = computed<NavigationItem[]>(() => [
     show: true,
   },
   {
-    name: 'users-list',
+    name: 'users',
     label: 'Users',
     route: 'users',
     icon: 'mdi-account-group',

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -15,7 +15,7 @@
     <v-spacer class="d-flex"></v-spacer>
 
     <!-- Navigation Links -->
-    <v-tabs class="d-none d-md-flex" color="white" slider-color="white">
+    <v-tabs class="d-none d-md-flex" color="white" slider-color="white" :model-value="activeTab">
       <v-tab
         v-for="item in visibleNavigationItems"
         :key="item.name"
@@ -63,6 +63,7 @@
         :disabled="item.disabled"
         :prepend-icon="item.icon"
         :to="{ name: item.name }"
+        :active="activeTab == item.name"
       >
         <v-list-item-title>{{ item.label }}</v-list-item-title>
       </v-list-item>
@@ -84,7 +85,9 @@ import type { AuthProviderType } from '@/types/auth'
 import UserButton from '@/components/UserButton.vue'
 import Loading from '@/components/Loading.vue'
 import { ref, computed } from 'vue'
+import { useRoute } from 'vue-router'
 
+const route = useRoute()
 // Props
 export interface NavigationItem {
   name: string
@@ -114,6 +117,19 @@ const drawer = ref(false)
 
 const visibleNavigationItems = computed(() => {
   return props.navigationItems.filter((item) => item.show)
+})
+
+const activeTab = computed(() => {
+  let currentRouteName = route.name as string
+  if (route.meta?.parentNavigation) {
+    currentRouteName = route.meta.parentNavigation as string
+  }
+
+  const isInNavigation = visibleNavigationItems.value.some(
+    (item) => item.show && item.name == currentRouteName,
+  )
+
+  return isInNavigation ? currentRouteName : undefined
 })
 </script>
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -56,7 +56,7 @@ const routes = [
     path: '/books/backups',
     name: 'backup-books',
     component: BackupBooksView,
-    meta: { title: 'CMS | Backup Books' },
+    meta: { title: 'CMS | Backup Books', parentNavigation: 'books' },
   },
   {
     path: '/titles',
@@ -68,7 +68,7 @@ const routes = [
     path: '/titles/archives',
     name: 'archived-titles',
     component: ArchivedTitlesView,
-    meta: { title: 'CMS | Archived Titles' },
+    meta: { title: 'CMS | Archived Titles', parentNavigation: 'titles' },
   },
   {
     path: '/title/:id',
@@ -76,6 +76,7 @@ const routes = [
     component: TitleView,
     props: true,
     meta: {
+      parentNavigation: 'titles',
       title: (to: RouteLocationNormalized) => `CMS | Title • ${to.params.id}`,
     },
   },
@@ -85,6 +86,7 @@ const routes = [
     component: TitleView,
     props: true,
     meta: {
+      parentNavigation: 'titles',
       title: (to: RouteLocationNormalized) => `CMS | Title • ${to.params.id}`,
     },
   },
@@ -94,6 +96,7 @@ const routes = [
     component: BookView,
     props: true,
     meta: {
+      parentNavigation: 'books',
       title: (to: RouteLocationNormalized) => `CMS | Book • ${to.params.id}`,
     },
   },
@@ -103,6 +106,7 @@ const routes = [
     component: BookView,
     props: true,
     meta: {
+      parentNavigation: 'books',
       title: (to: RouteLocationNormalized) => `CMS | Book • ${to.params.id}`,
     },
   },
@@ -121,7 +125,8 @@ const routes = [
     component: UserView,
     props: true,
     meta: {
-      title: (to: RouteLocationNormalized) => `Zimfarm | User • ${to.params.userId}`,
+      parentNavigation: 'users',
+      title: (to: RouteLocationNormalized) => `CMS | User • ${to.params.userId}`,
     },
   },
   {
@@ -130,14 +135,15 @@ const routes = [
     component: UserView,
     props: true,
     meta: {
-      title: (to: RouteLocationNormalized) => `Zimfarm | User • ${to.params.userId}`,
+      parentNavigation: 'users',
+      title: (to: RouteLocationNormalized) => `CMS | User • ${to.params.userId}`,
     },
   },
   {
     path: '/users',
-    name: 'users-list',
+    name: 'users',
     component: UsersView,
-    meta: { title: 'Zimfarm | Users' },
+    meta: { title: 'CMS | Users' },
   },
   {
     path: '/collections',
@@ -151,6 +157,7 @@ const routes = [
     component: CollectionView,
     props: true,
     meta: {
+      parentNavigation: 'collections',
       title: (to: RouteLocationNormalized) => `CMS | Collection • ${to.params.id}`,
     },
   },
@@ -160,6 +167,7 @@ const routes = [
     component: CollectionView,
     props: true,
     meta: {
+      parentNavigation: 'collections',
       title: (to: RouteLocationNormalized) => `CMS | Collection • ${to.params.id}`,
     },
   },

--- a/frontend/src/views/UserView.vue
+++ b/frontend/src/views/UserView.vue
@@ -355,7 +355,7 @@ const deleteUser = async () => {
   const success = await userStore.deleteUser(props.userId)
   if (success) {
     notificationStore.showSuccess(`User account ${user.value?.display_name} has been deleted.`)
-    router.push({ name: 'users-list' })
+    router.push({ name: 'users' })
   } else {
     for (const error of userStore.errors) {
       notificationStore.showError(error)


### PR DESCRIPTION
<img width="1916" height="617" alt="Screenshot_20260615_105858" src="https://github.com/user-attachments/assets/a43ec690-7df7-416a-848d-ea35fd5241e5" />
<img width="1911" height="741" alt="Screenshot_20260615_105841" src="https://github.com/user-attachments/assets/9920dd45-45fb-41de-a792-b22496d99513" />
<img width="1920" height="561" alt="Screenshot_20260615_105820" src="https://github.com/user-attachments/assets/74059b00-f073-4da8-8961-9d1fea5a9d7a" />
<img width="1903" height="624" alt="Screenshot_20260615_105805" src="https://github.com/user-attachments/assets/3c4957a6-67da-4393-aca6-89e66ff9a529" />


## Changes
- add `parentNavigation` metadata to routes
- detect the correct navigation entry to highlight based on the parent navigation or the route name

This fixes #341 