### PR TITLE
expicitly commit db operations in shuttle

### DIFF
--- a/backend/src/cms_backend/mill/main.py
+++ b/backend/src/cms_backend/mill/main.py
@@ -71,7 +71,7 @@ def main():
         for task_config in tasks:
             if task_config.should_run(now):
                 try:
-                    with Session.begin() as session:
+                    with Session() as session:
                         logger.debug(f"Executing task: {task_config.task_name}")
                         task_config.execute(session)
                 except Exception:

--- a/backend/src/cms_backend/mill/mark_staging_books_for_deletion.py
+++ b/backend/src/cms_backend/mill/mark_staging_books_for_deletion.py
@@ -26,17 +26,17 @@ def mark_staging_books_for_deletion(session: OrmSession):
             break
 
         for book in results.records:
-            with session.begin_nested():
-                try:
-                    delete_book(
-                        session,
-                        book_id=book.id,
-                        deletion_delay=MillContext.staging_books_deletion_grace_period,
-                    )
-                except Exception:
-                    logger.exception(f"error while marking book {book.id} for deletion")
-                else:
-                    nb_books_marked += 1
+            try:
+                delete_book(
+                    session,
+                    book_id=book.id,
+                    deletion_delay=MillContext.staging_books_deletion_grace_period,
+                )
+            except Exception:
+                logger.exception(f"error while marking book {book.id} for deletion")
+            else:
+                session.commit()
+                nb_books_marked += 1
         skip += limit
 
     logger.info(f"Done marking {nb_books_marked} staging book(s) for deletion")

--- a/backend/src/cms_backend/mill/process_retention_rules.py
+++ b/backend/src/cms_backend/mill/process_retention_rules.py
@@ -13,14 +13,14 @@ def process_retention_rules(session: OrmSession):
     titles = session.scalars(select(Title)).all()
 
     for title in titles:
-        with session.begin_nested():
-            try:
-                apply_retention_rules(session, title)
-            except Exception:
-                logger.exception(
-                    f"Error while applying retention rules to title {title.id}"
-                )
-            else:
-                nb_titles_processed += 1
+        try:
+            apply_retention_rules(session, title)
+        except Exception:
+            logger.exception(
+                f"Error while applying retention rules to title {title.id}"
+            )
+        else:
+            nb_titles_processed += 1
+            session.commit()
 
     logger.info(f"Done applying retention rules to {nb_titles_processed} titles.")

--- a/backend/src/cms_backend/mill/process_title_modifications.py
+++ b/backend/src/cms_backend/mill/process_title_modifications.py
@@ -27,17 +27,20 @@ def process_title_modifications(session: OrmSession):
                 f"{','.join(missing_keys)}"
             )
             delete_event(session, event_id=event.id)
+            session.commit()
             continue
 
         title = get_title_by_id_or_none(session, title_id=UUID(event.payload["id"]))
         if not title:
             logger.warning(f"Title with ID {event.payload['id']} does not exist.")
             delete_event(session, event_id=event.id)
+            session.commit()
             continue
 
         if title.archived:
             logger.warning(f"Title {title.id} is archived.")
             delete_event(session, event_id=event.id)
+            session.commit()
             continue
 
         title_name = event.payload["name"]
@@ -55,6 +58,7 @@ def process_title_modifications(session: OrmSession):
         if not books_without_title:
             logger.info(f"No books without title matching title '{title_name}'")
             delete_event(session, event_id=event.id)
+            session.commit()
             continue
 
         logger.info(
@@ -62,13 +66,13 @@ def process_title_modifications(session: OrmSession):
         )
 
         for book in books_without_title:
-            with session.begin_nested():
-                try:
-                    process_book(session, book)
-                except Exception:
-                    logger.exception("error while processing book")
-                else:
-                    delete_event(session, event.id)
-                    nb_events_processed += 1
+            try:
+                process_book(session, book)
+            except Exception:
+                logger.exception("error while processing book")
+            else:
+                delete_event(session, event.id)
+                nb_events_processed += 1
+            session.commit()
 
     logger.info(f"Done processing {nb_events_processed} title modification events.")

--- a/backend/src/cms_backend/mill/process_zimfarm_notifications.py
+++ b/backend/src/cms_backend/mill/process_zimfarm_notifications.py
@@ -9,12 +9,12 @@ def process_zimfarm_notifications(session: OrmSession):
     logger.info("Processing Zimfarm notifications")
     nb_notifications_processed = 0
     while True:
-        with session.begin_nested():
-            notification = get_next_notification_to_process_or_none(session)
-            if not notification:
-                break
-            logger.debug(f"Processing Zimfarm notification {notification.id}")
-            process_notification(session, notification)
-            nb_notifications_processed += 1
+        notification = get_next_notification_to_process_or_none(session)
+        if not notification:
+            break
+        logger.debug(f"Processing Zimfarm notification {notification.id}")
+        process_notification(session, notification)
+        session.commit()
+        nb_notifications_processed += 1
 
     logger.info(f"Done processing {nb_notifications_processed} Zimfarm notifications")

--- a/backend/src/cms_backend/shuttle/delete_files.py
+++ b/backend/src/cms_backend/shuttle/delete_files.py
@@ -19,22 +19,22 @@ def delete_files(session: OrmSession):
     nb_zim_files_deleted = 0
 
     while True:
-        with session.begin_nested():
-            book = get_next_book_to_delete(session, now)
-            if not book:
-                break
+        book = get_next_book_to_delete(session, now)
+        if not book:
+            break
 
-            try:
-                logger.info(f"Deleting files for book {book.id}")
-                delete_book_files(session, book)
-                nb_zim_files_deleted += 1
-            except Exception as exc:
-                book.events.append(
-                    f"{getnow()}: error encountered while deleting files\n{exc}"
-                )
-                logger.exception(f"Failed to delete files for book {book.id}")
-                book.needs_file_operation = False
-                book.has_error = True
+        try:
+            logger.info(f"Deleting files for book {book.id}")
+            delete_book_files(session, book)
+            nb_zim_files_deleted += 1
+        except Exception as exc:
+            book.events.append(
+                f"{getnow()}: error encountered while deleting files\n{exc}"
+            )
+            logger.exception(f"Failed to delete files for book {book.id}")
+            book.needs_file_operation = False
+            book.has_error = True
+        session.commit()
 
     if nb_zim_files_deleted:
         logger.info(f"Done deleting {nb_zim_files_deleted} ZIM files")

--- a/backend/src/cms_backend/shuttle/main.py
+++ b/backend/src/cms_backend/shuttle/main.py
@@ -58,7 +58,7 @@ def main():
         for task_config in tasks:
             if task_config.should_run(now):
                 try:
-                    with Session.begin() as session:
+                    with Session() as session:
                         logger.debug(f"Executing task: {task_config.task_name}")
                         task_config.execute(session)
                 except Exception:

--- a/backend/src/cms_backend/shuttle/move_files.py
+++ b/backend/src/cms_backend/shuttle/move_files.py
@@ -12,21 +12,21 @@ from cms_backend.utils.datetime import getnow
 def move_files(session: OrmSession):
     nb_zim_files_moved = 0
     while True:
-        with session.begin_nested():
-            book = get_next_book_to_move_files_or_none(session)
-            if not book:
-                break
+        book = get_next_book_to_move_files_or_none(session)
+        if not book:
+            break
 
-            try:
-                logger.info(f"Moving ZIM file(s) of book {book.id}")
-                move_book_files(session, book)
-                nb_zim_files_moved += 1
-            except Exception as exc:
-                book.events.append(
-                    f"{getnow()}: error encountered while moving file\n{exc}"
-                )
-                logger.exception(f"Failed to move file for {book.id}")
-                book.has_error = True
+        try:
+            logger.info(f"Moving ZIM file(s) of book {book.id}")
+            move_book_files(session, book)
+            nb_zim_files_moved += 1
+        except Exception as exc:
+            book.events.append(
+                f"{getnow()}: error encountered while moving file\n{exc}"
+            )
+            logger.exception(f"Failed to move file for {book.id}")
+            book.has_error = True
+        session.commit()
 
     if nb_zim_files_moved:
         logger.info(f"Done moving {nb_zim_files_moved} ZIM files")


### PR DESCRIPTION
## Changes
- use manual session instead of a transaction within shuttle and call `commit` after every operation

This fixes #350 