### PR TITLE
keep prod books in prod despite reprocessing

### DIFF
--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -796,6 +796,9 @@ def book_goes_to_staging(book: Book) -> bool:
     if not book.title:
         raise ValueError("Book must have a title.")
 
+    if book.location_kind == "prod":
+        return False
+
     return book.title.maturity != "stable" or len(book.issues) != 0
 
 


### PR DESCRIPTION
## Changes
- keep books in prod if they are already in prod despite issues being re-computed 

This fixes  #349