### PR TITLE
flag books with bad metadata

### DIFF
--- a/backend/src/cms_backend/api/routes/config.py
+++ b/backend/src/cms_backend/api/routes/config.py
@@ -15,6 +15,8 @@ def get_config() -> JSONResponse:
         content={
             "MEDIA_COUNT_CHANGE_THRESHOLD": Context.media_count_change_threshold,
             "ARTICLE_COUNT_CHANGE_THRESHOLD": Context.article_count_change_threshold,
+            "ZIM_TITLE_MAX_LENGTH": Context.zim_title_max_length,
+            "ZIM_DESCRIPTION_MAX_LENGTH": Context.zim_description_max_length,
         },
         status_code=HTTPStatus.OK,
     )

--- a/backend/src/cms_backend/api/routes/fields.py
+++ b/backend/src/cms_backend/api/routes/fields.py
@@ -1,7 +1,9 @@
 import base64
+from dataclasses import dataclass
 from typing import Annotated, Any
 
 import pycountry
+import regex
 from pydantic import (
     AfterValidator,
     Field,
@@ -9,6 +11,27 @@ from pydantic import (
     ValidatorFunctionWrapHandler,
     WrapValidator,
 )
+
+
+@dataclass(frozen=True)
+class GraphemeLength:
+    min: int | None = None
+    max: int | None = None
+
+    def __call__(self, v: str, info: ValidationInfo) -> str:
+        context = info.context
+        if context and context.get("skip_validation"):
+            return v
+        n = len(regex.findall(r"\X", v))
+        if self.min is not None and n < self.min:
+            raise ValueError(
+                f"String should have at least {self.min} grapheme clusters (got {n})"
+            )
+        if self.max is not None and n > self.max:
+            raise ValueError(
+                f"String should have at most {self.max} grapheme clusters (got {n})"
+            )
+        return v
 
 
 def no_null_char(value: str) -> str:
@@ -83,8 +106,25 @@ def validate_comma_separated_lang_code(
     return value
 
 
+def validate_zim_flavour(value: str, info: ValidationInfo):
+    if not value:
+        return value
+    context = info.context
+    if context and context.get("skip_validation"):
+        return value
+    if not value.isalpha():
+        raise ValueError("Flavour '{value}' must only contain alphabetic characters.")
+    return value
+
+
 LangCode = Annotated[
     str,
     WrapValidator(skip_validation),
     AfterValidator(validate_comma_separated_lang_code),
+]
+
+ZimFlavour = Annotated[
+    NotEmptyString,
+    WrapValidator(skip_validation),
+    AfterValidator(validate_zim_flavour),
 ]

--- a/backend/src/cms_backend/context.py
+++ b/backend/src/cms_backend/context.py
@@ -107,3 +107,9 @@ class Context:
     article_count_change_threshold: float = field(
         default=float(os.getenv("ARTICLE_COUNT_CHANGE_THRESHOLD", "0.1"))
     )
+    zim_title_max_length: int = field(
+        default=int(os.getenv("ZIM_TITLE_MAX_LENGTH", "30"))
+    )
+    zim_description_max_length: int = field(
+        default=int(os.getenv("ZIM_DESCRIPTION_MAX_LENGTH", "80"))
+    )

--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -3,6 +3,7 @@ from typing import Any, Literal
 from uuid import UUID
 
 import pycountry
+import regex
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session as OrmSession
 from sqlalchemy.orm import selectinload
@@ -548,6 +549,39 @@ def revert_book(
     return book
 
 
+def book_has_bad_metadata(book: Book, *, update_events: bool = False) -> bool:
+    """Determine if a book has bad metadata.
+
+    Assumes book has all mandatory metadata
+    """
+    title_length = len(regex.findall(r"\X", book.zim_metadata["Title"]))
+
+    if title_length > Context.zim_title_max_length:
+        if update_events:
+            book.events.append(
+                f"{getnow()}: book Title metadata is {title_length} characters long"
+            )
+        return True
+
+    description_length = len(regex.findall(r"\X", book.zim_metadata["Description"]))
+    if description_length > Context.zim_description_max_length:
+        if update_events:
+            book.events.append(
+                f"{getnow()}: book Description metadata is {description_length} "
+                "characters long"
+            )
+        return True
+    flavour = book.zim_metadata.get("Flavour")
+    if flavour and not flavour.isalpha():
+        if update_events:
+            book.events.append(
+                f"{getnow()}: book Flavour metadata contains non-alphabetic characters"
+            )
+
+        return True
+    return False
+
+
 def update_book_issues(session: OrmSession, book: Book, *, update_events: bool = False):
     """
     Update book issues based on it's associated title and optionally update book events.
@@ -596,6 +630,9 @@ def update_book_issues(session: OrmSession, book: Book, *, update_events: bool =
                 f"{getnow()}: book flavour is not in list of title flavours"
             )
 
+    if book_has_bad_metadata(book, update_events=update_events):
+        issues.append("bad metadata")
+
     # Get the latest prod book that isn't the current book
     latest_book = session.scalars(
         select(Book)
@@ -635,20 +672,22 @@ def update_book_issues(session: OrmSession, book: Book, *, update_events: bool =
 
     if media_count_diff > collection_media_count_change_threshold:
         issues.append("media count")
-        book.events.append(
-            f"{getnow()}: book media count exceeds collection median threshold by "
-            f"{media_count_diff * 100}%"
-        )
+        if update_events:
+            book.events.append(
+                f"{getnow()}: book media count exceeds collection median threshold by "
+                f"{media_count_diff * 100}%"
+            )
 
     article_count_diff = (
         abs(book.article_count - latest_book.article_count)
     ) / latest_book.article_count
     if article_count_diff > collection_article_count_change_threshold:
         issues.append("article count")
-        book.events.append(
-            f"{getnow()}: book article count exceeds collection median threshold by "
-            f"{article_count_diff * 100}%"
-        )
+        if update_events:
+            book.events.append(
+                f"{getnow()}: book article count exceeds collection median threshold "
+                f"by {article_count_diff * 100}%"
+            )
     book.issues = issues
     session.add(book)
     session.flush()

--- a/backend/src/cms_backend/mill/processors/title.py
+++ b/backend/src/cms_backend/mill/processors/title.py
@@ -1,9 +1,7 @@
 from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend import logger
-from cms_backend.db.book import (
-    process_book,
-)
+from cms_backend.db.book import process_book
 from cms_backend.db.models import Book, Title
 from cms_backend.db.rules import (
     apply_retention_rules,
@@ -11,6 +9,21 @@ from cms_backend.db.rules import (
 )
 from cms_backend.utils.datetime import getnow
 from cms_backend.utils.filename import compute_target_filename
+
+
+def update_title_metadata_from_book(title: Title, book: Book):
+    """Update a title's metadata from book"""
+
+    title.title = book.zim_metadata["Title"]
+    title.creator = book.zim_metadata["Creator"]
+    title.publisher = book.zim_metadata["Publisher"]
+    title.description = book.zim_metadata["Description"]
+    title.language = book.zim_metadata["Language"]
+    title.illustration_48x48_at_1 = book.zim_metadata["Illustration_48x48@1"]
+    title.long_description = book.zim_metadata.get("LongDescription")
+    title.license = book.zim_metadata.get("License")
+    title.relation = book.zim_metadata.get("Relation")
+    title.source = book.zim_metadata.get("Source")
 
 
 def add_book_to_title(session: OrmSession, book: Book, title: Title):
@@ -43,16 +56,7 @@ def add_book_to_title(session: OrmSession, book: Book, title: Title):
         )
 
         if title_is_missing_mandatory_metadata(title):
-            title.title = book.zim_metadata["Title"]
-            title.creator = book.zim_metadata["Creator"]
-            title.publisher = book.zim_metadata["Publisher"]
-            title.description = book.zim_metadata["Description"]
-            title.language = book.zim_metadata["Language"]
-            title.illustration_48x48_at_1 = book.zim_metadata["Illustration_48x48@1"]
-            title.long_description = book.zim_metadata.get("LongDescription")
-            title.license = book.zim_metadata.get("License")
-            title.relation = book.zim_metadata.get("Relation")
-            title.source = book.zim_metadata.get("Source")
+            update_title_metadata_from_book(title, book)
 
         process_book(session, book, update_events=True)
         if book.location_kind == "prod":

--- a/backend/src/cms_backend/schemas/models.py
+++ b/backend/src/cms_backend/schemas/models.py
@@ -1,11 +1,18 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 from uuid import UUID
 
-from pydantic import AnyUrl, Field, model_validator
+from pydantic import AfterValidator, AnyUrl, Field, model_validator
 
-from cms_backend.api.routes.fields import Base64Str, LangCode, NotEmptyString
+from cms_backend.api.routes.fields import (
+    Base64Str,
+    GraphemeLength,
+    LangCode,
+    NotEmptyString,
+    ZimFlavour,
+)
+from cms_backend.context import Context
 from cms_backend.roles import RoleEnum
 from cms_backend.schemas import BaseModel
 from cms_backend.schemas.orms import BaseTitleCollectionSchema
@@ -61,13 +68,25 @@ class BaseTitleCreateUpdateSchema(BaseModel):
     license: NotEmptyString | None = None
     relation: NotEmptyString | None = None
     source: NotEmptyString | None = None
-    title: NotEmptyString | None = None
+    title: (
+        Annotated[
+            NotEmptyString,
+            AfterValidator(GraphemeLength(max=Context.zim_title_max_length)),
+        ]
+        | None
+    ) = None
     creator: NotEmptyString | None = None
-    description: NotEmptyString | None = None
+    description: (
+        Annotated[
+            NotEmptyString,
+            AfterValidator(GraphemeLength(max=Context.zim_description_max_length)),
+        ]
+        | None
+    ) = None
     publisher: NotEmptyString | None = None
     language: LangCode | None = None
     illustration_48x48_at_1: Base64Str | None = None
-    flavours: list[str] | None = None
+    flavours: list[ZimFlavour] | None = None
     archived: bool | None = None
 
     @model_validator(mode="after")

--- a/backend/tests/db/test_book.py
+++ b/backend/tests/db/test_book.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 from collections.abc import Callable
 from pathlib import Path
 
@@ -9,6 +10,7 @@ from sqlalchemy.orm import Session as OrmSession
 from cms_backend.context import Context
 from cms_backend.db.book import (
     backup_book,
+    book_has_bad_metadata,
     get_book_history,
     get_book_history_entry_or_none,
     get_differing_metadata_keys,
@@ -873,3 +875,57 @@ def test_update_book_issues_item_count_issues(
     dbsession.flush()
     update_book_issues(dbsession, book)
     assert set(book.issues) == expected_issues
+
+
+@pytest.mark.parametrize(
+    "title,description,flavour,event_regex,expected",
+    [
+        pytest.param(
+            "é" * 31,
+            "é" * 40,
+            "",
+            r"book Title metadata is \d+ characters long",
+            True,
+            id="title-too-long",
+        ),
+        pytest.param(
+            "é" * 30,
+            "é" * 90,
+            "",
+            r"book Description metadata is \d+ characters long",
+            True,
+            id="description-too-long",
+        ),
+        pytest.param(
+            "é" * 30,
+            "é" * 80,
+            "_maxi",
+            "book Flavour metadata contains non-alphabetic characters",
+            True,
+            id="invalid-flavour",
+        ),
+        pytest.param(
+            "é" * 30,
+            "é" * 80,
+            "maxi",
+            "",
+            False,
+            id="all-good",
+        ),
+    ],
+)
+def test_book_has_bad_metadata(
+    create_book: Callable[..., Book],
+    title: str,
+    description: str,
+    flavour: str | None,
+    event_regex: str,
+    *,
+    expected: bool,
+):
+    book = create_book(
+        zim_metadata={"Title": title, "Description": description, "Flavour": flavour}
+    )
+    assert book_has_bad_metadata(book, update_events=True) is expected
+    if expected:
+        assert any(re.search(event_regex, event) for event in book.events)

--- a/frontend/src/components/TitleForm.vue
+++ b/frontend/src/components/TitleForm.vue
@@ -44,6 +44,7 @@
             persistent-hint
             :items="availableFlavours"
             :loading="loadingFlavours"
+            :rules="[rules.flavours]"
           />
         </v-col>
       </v-row>
@@ -74,10 +75,20 @@
             label="Title"
             variant="outlined"
             density="comfortable"
+            :rules="[rules.title]"
             clearable
-            :color="!inDialog && isFieldDifferent('title') ? 'warning' : undefined"
-            :base-color="!inDialog && isFieldDifferent('title') ? 'warning' : undefined"
-          />
+            :color="
+              titleOverLimit || (!inDialog && isFieldDifferent('title')) ? 'warning' : undefined
+            "
+            :base-color="
+              titleOverLimit || (!inDialog && isFieldDifferent('title')) ? 'warning' : undefined
+            "
+          >
+            <template #counter> {{ titleGraphemeCount }}/{{ titleMaxLength }} </template>
+            <template v-if="titleOverLimit" #append-inner>
+              <v-icon color="warning" icon="mdi-alert-circle" />
+            </template>
+          </v-text-field>
           <div v-if="!inDialog && isFieldDifferent('title')" class="text-body-2 mb-2">
             <div class="mb-1 text-warning font-weight-medium">
               Different from latest book which has:
@@ -163,9 +174,17 @@
             density="comfortable"
             :rules="[rules.langCode]"
             clearable
-            :color="!inDialog && isFieldDifferent('language') ? 'warning' : undefined"
-            :base-color="!inDialog && isFieldDifferent('language') ? 'warning' : undefined"
-          />
+            :color="
+              languageInvalid || (!inDialog && isFieldDifferent('language')) ? 'warning' : undefined
+            "
+            :base-color="
+              languageInvalid || (!inDialog && isFieldDifferent('language')) ? 'warning' : undefined
+            "
+          >
+            <template v-if="languageInvalid" #append-inner>
+              <v-icon color="warning" icon="mdi-alert-circle" />
+            </template>
+          </v-text-field>
           <div v-if="!inDialog && isFieldDifferent('language')" class="text-body-2 mb-2">
             <div class="mb-1 text-warning font-weight-medium">
               Different from latest book which has:
@@ -280,11 +299,27 @@
             label="Description"
             variant="outlined"
             density="comfortable"
+            :rules="[rules.description]"
             rows="3"
             clearable
-            :color="!inDialog && isFieldDifferent('description') ? 'warning' : undefined"
-            :base-color="!inDialog && isFieldDifferent('description') ? 'warning' : undefined"
-          />
+            :color="
+              descriptionOverLimit || (!inDialog && isFieldDifferent('description'))
+                ? 'warning'
+                : undefined
+            "
+            :base-color="
+              descriptionOverLimit || (!inDialog && isFieldDifferent('description'))
+                ? 'warning'
+                : undefined
+            "
+          >
+            <template #counter>
+              {{ descriptionGraphemeCount }}/{{ descriptionMaxLength }}
+            </template>
+            <template v-if="descriptionOverLimit" #append-inner>
+              <v-icon color="warning" icon="mdi-alert-circle" />
+            </template>
+          </v-textarea>
           <div v-if="!inDialog && isFieldDifferent('description')" class="text-body-2 mb-2">
             <div class="mb-1 text-warning font-weight-medium">
               Different from latest book which has:
@@ -427,7 +462,10 @@ import { useCollectionsStore } from '@/stores/collections'
 import { useBookStore } from '@/stores/book'
 import type { BaseTitleCollection, Title, TitleUpdate } from '@/types/title'
 import type { Book } from '@/types/book'
-import { computed, ref, watch } from 'vue'
+import { computed, inject, ref, watch } from 'vue'
+import { byGrapheme } from 'split-by-grapheme'
+import constants from '@/constants'
+import type { Config } from '@/config'
 
 interface Props {
   title?: Title | null
@@ -446,6 +484,7 @@ const emit = defineEmits<{
   'update:hasChanges': [value: boolean]
 }>()
 
+const config = inject<Config>(constants.config)!
 const collectionsStore = useCollectionsStore()
 const bookStore = useBookStore()
 
@@ -662,6 +701,26 @@ const hasChanges = computed(() => {
   )
 })
 
+const titleMaxLength = config.ZIM_TITLE_MAX_LENGTH ?? 30
+const descriptionMaxLength = config.ZIM_DESCRIPTION_MAX_LENGTH ?? 80
+
+const titleGraphemeCount = computed(() => {
+  if (!formData.value.title) return 0
+  return formData.value.title.split(byGrapheme).length
+})
+const descriptionGraphemeCount = computed(() => {
+  if (!formData.value.description) return 0
+  return formData.value.description.split(byGrapheme).length
+})
+const titleOverLimit = computed(() => titleGraphemeCount.value > titleMaxLength)
+const descriptionOverLimit = computed(() => descriptionGraphemeCount.value > descriptionMaxLength)
+const languageInvalid = computed(() => {
+  const value = formData.value.language
+  if (!value) return false
+  const parts = value.split(',')
+  return !parts.every((part) => part.trim().length === 3)
+})
+
 const rules = {
   required: (value: string) => !!value || 'This field is required',
   langCode: (value: string) => {
@@ -670,6 +729,29 @@ const rules = {
     return parts.every((part) => part.trim().length === 3)
       ? true
       : 'Language code(s) must be 3 characters long'
+  },
+  title: (value: string) => {
+    if (!value) return true
+    if (titleGraphemeCount.value > titleMaxLength) {
+      return `Maximum length is ${titleMaxLength} characters.`
+    }
+    return true
+  },
+  description: (value: string) => {
+    if (!value) return true
+    if (descriptionGraphemeCount.value > descriptionMaxLength) {
+      return `Maximum length is ${descriptionMaxLength} characters.`
+    }
+    return true
+  },
+  flavours: (value: string | string[]) => {
+    if (!value || (Array.isArray(value) && value.length === 0)) return true
+    const flavours = Array.isArray(value) ? value : [value]
+    const invalid = flavours.filter((f) => f && !/^[a-zA-Z]+$/.test(f))
+    if (invalid.length > 0) {
+      return `Flavours must contain only alphabetic characters. Invalid: ${invalid.join(', ')}`
+    }
+    return true
   },
 }
 

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -13,6 +13,8 @@ export interface Config {
   LOGIN_MODES: Array<string>
   MEDIA_COUNT_CHANGE_THRESHOLD: number | undefined
   ARTICLE_COUNT_CHANGE_THRESHOLD: number | undefined
+  ZIM_TITLE_MAX_LENGTH: number | undefined
+  ZIM_DESCRIPTION_MAX_LENGTH: number | undefined
 }
 
 export const ConfigService = {


### PR DESCRIPTION
## Rationale
This PR adds validation/rules for `Title`, `Flavour` and `Description` metadata. Books failing these checks are flagged with `bad metadata`

## Changes
- add function to check if book has bad metadata
- show alert icon near title fields that don't meet constraint

<img width="576" height="292" alt="Screenshot_20260622_155941" src="https://github.com/user-attachments/assets/afacfdc4-4e22-42ea-bc65-2ff8ae69fa02" />


This closes #99 