### PR TITLE
check book Name metadata meets constraints

### DIFF
--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 from typing import Any, Literal
 from uuid import UUID
 
@@ -27,7 +28,7 @@ from cms_backend.schemas.orms import (
     ListResult,
 )
 from cms_backend.utils.datetime import getnow
-from cms_backend.utils.zim import get_missing_metadata_keys
+from cms_backend.utils.zim import ZIM_TITLE_NAME_REGEX, get_missing_metadata_keys
 
 
 def get_book_or_none(
@@ -554,6 +555,13 @@ def book_has_bad_metadata(book: Book, *, update_events: bool = False) -> bool:
 
     Assumes book has all mandatory metadata
     """
+    name = book.zim_metadata["Name"]
+    if not re.match(ZIM_TITLE_NAME_REGEX, name):
+        if update_events:
+            book.events.append(
+                f"{getnow()}: book Name metadata contains unwanted characters"
+            )
+        return True
     title_length = len(regex.findall(r"\X", book.zim_metadata["Title"]))
 
     if title_length > Context.zim_title_max_length:

--- a/backend/src/cms_backend/mill/processors/title.py
+++ b/backend/src/cms_backend/mill/processors/title.py
@@ -49,7 +49,7 @@ def add_book_to_title(session: OrmSession, book: Book, title: Title):
         # Compute target filename once for this book
         book.filename = compute_target_filename(
             session,
-            name=book.name,
+            name=title.name,
             flavour=book.flavour,
             date=book.date,
             book_id=book.id,

--- a/backend/src/cms_backend/schemas/models.py
+++ b/backend/src/cms_backend/schemas/models.py
@@ -16,6 +16,7 @@ from cms_backend.context import Context
 from cms_backend.roles import RoleEnum
 from cms_backend.schemas import BaseModel
 from cms_backend.schemas.orms import BaseTitleCollectionSchema
+from cms_backend.utils.zim import ZIM_TITLE_NAME_REGEX
 
 
 class ZimUrlSchema(BaseModel):
@@ -105,12 +106,12 @@ class BaseTitleCreateUpdateSchema(BaseModel):
 
 
 class TitleCreateSchema(BaseTitleCreateUpdateSchema):
-    name: NotEmptyString
+    name: NotEmptyString = Field(pattern=ZIM_TITLE_NAME_REGEX)
     maturity: Literal["unstable", "stable"] = "unstable"
 
 
 class TitleUpdateSchema(BaseTitleCreateUpdateSchema):
-    name: NotEmptyString | None = None
+    name: NotEmptyString | None = Field(pattern=ZIM_TITLE_NAME_REGEX, default=None)
     maturity: Literal["unstable", "stable"] | None = None
     comment: NotEmptyString | None = None
 

--- a/backend/src/cms_backend/utils/zim.py
+++ b/backend/src/cms_backend/utils/zim.py
@@ -1,4 +1,9 @@
+import re
 from typing import Any
+
+ZIM_TITLE_NAME_REGEX = re.compile(
+    r"^[a-z0-9\-\.]+?_[a-z]{2}(?:-[a-z]{2,10})?_[a-z0-9\-\.]+?$"
+)
 
 
 def get_missing_keys(payload: dict[str, Any], *keys: str) -> list[str]:

--- a/backend/tests/api/routes/test_titles.py
+++ b/backend/tests/api/routes/test_titles.py
@@ -456,7 +456,7 @@ def test_update_title(
 
     update_data = {
         "maturity": "stable",
-        "name": "wikipedia_en",
+        "name": "wikipedia_en_all",
     }
 
     response = client.patch(
@@ -468,7 +468,7 @@ def test_update_title(
     data = response.json()
 
     assert data["id"] == str(title.id)
-    assert data["name"] == "wikipedia_en"
+    assert data["name"] == "wikipedia_en_all"
     assert data["maturity"] == "stable"
 
     events = dbsession.scalars(
@@ -476,7 +476,7 @@ def test_update_title(
     ).all()
     assert len(events) == 1
     assert events[0].payload["action"] == "updated"
-    assert events[0].payload["name"] == "wikipedia_en"
+    assert events[0].payload["name"] == "wikipedia_en_all"
     assert events[0].payload["id"] == str(title.id)
 
 

--- a/backend/tests/db/test_book.py
+++ b/backend/tests/db/test_book.py
@@ -878,12 +878,13 @@ def test_update_book_issues_item_count_issues(
 
 
 @pytest.mark.parametrize(
-    "title,description,flavour,event_regex,expected",
+    "title,description,flavour,name,event_regex,expected",
     [
         pytest.param(
             "é" * 31,
             "é" * 40,
             "",
+            "test_en_all",
             r"book Title metadata is \d+ characters long",
             True,
             id="title-too-long",
@@ -892,6 +893,7 @@ def test_update_book_issues_item_count_issues(
             "é" * 30,
             "é" * 90,
             "",
+            "test_en_all",
             r"book Description metadata is \d+ characters long",
             True,
             id="description-too-long",
@@ -900,6 +902,7 @@ def test_update_book_issues_item_count_issues(
             "é" * 30,
             "é" * 80,
             "_maxi",
+            "test_en_all",
             "book Flavour metadata contains non-alphabetic characters",
             True,
             id="invalid-flavour",
@@ -908,6 +911,7 @@ def test_update_book_issues_item_count_issues(
             "é" * 30,
             "é" * 80,
             "maxi",
+            "test_en_all",
             "",
             False,
             id="all-good",
@@ -919,12 +923,18 @@ def test_book_has_bad_metadata(
     title: str,
     description: str,
     flavour: str | None,
+    name: str,
     event_regex: str,
     *,
     expected: bool,
 ):
     book = create_book(
-        zim_metadata={"Title": title, "Description": description, "Flavour": flavour}
+        zim_metadata={
+            "Name": name,
+            "Title": title,
+            "Description": description,
+            "Flavour": flavour,
+        }
     )
     assert book_has_bad_metadata(book, update_events=True) is expected
     if expected:

--- a/backend/tests/db/test_title.py
+++ b/backend/tests/db/test_title.py
@@ -127,18 +127,18 @@ def test_update_title_name(
         dbsession,
         title_identifier=str(title.id),
         author_id=account.id,
-        payload=TitleUpdateSchema(name="wikipedia_en"),
+        payload=TitleUpdateSchema(name="wikipedia_en_all"),
     )
 
     dbsession.refresh(title)
-    assert title.name == "wikipedia_en"
+    assert title.name == "wikipedia_en_all"
 
     events = dbsession.scalars(
         select(Event).where(Event.topic == "title_modified")
     ).all()
     assert len(events) == 1
     assert events[0].payload["action"] == "updated"
-    assert events[0].payload["name"] == "wikipedia_en"
+    assert events[0].payload["name"] == "wikipedia_en_all"
     assert events[0].payload["id"] == str(title.id)
 
 

--- a/frontend/src/components/TitleForm.vue
+++ b/frontend/src/components/TitleForm.vue
@@ -78,14 +78,14 @@
             :rules="[rules.title]"
             clearable
             :color="
-              titleOverLimit || (!inDialog && isFieldDifferent('title')) ? 'warning' : undefined
+              titleInvalid || (!inDialog && isFieldDifferent('title')) ? 'warning' : undefined
             "
             :base-color="
-              titleOverLimit || (!inDialog && isFieldDifferent('title')) ? 'warning' : undefined
+              titleInvalid || (!inDialog && isFieldDifferent('title')) ? 'warning' : undefined
             "
           >
             <template #counter> {{ titleGraphemeCount }}/{{ titleMaxLength }} </template>
-            <template v-if="titleOverLimit" #append-inner>
+            <template v-if="titleInvalid" #append-inner>
               <v-icon color="warning" icon="mdi-alert-circle" />
             </template>
           </v-text-field>
@@ -473,6 +473,8 @@ interface Props {
   latestBook?: Book | null
 }
 
+const TITLE_NAME_PATTERN = '^[a-z0-9\-\.]+?_[a-z]{2}(?:-[a-z]{2,10})?_[a-z0-9\-\.]+?$'
+
 const props = withDefaults(defineProps<Props>(), {
   title: null,
   inDialog: false,
@@ -712,7 +714,12 @@ const descriptionGraphemeCount = computed(() => {
   if (!formData.value.description) return 0
   return formData.value.description.split(byGrapheme).length
 })
-const titleOverLimit = computed(() => titleGraphemeCount.value > titleMaxLength)
+const titleInvalid = computed(() => {
+  if (!formData.value.title) return true
+  const isValid = rules.title(formData.value.title)
+  if (typeof isValid === 'string') return false
+  return isValid
+})
 const descriptionOverLimit = computed(() => descriptionGraphemeCount.value > descriptionMaxLength)
 const languageInvalid = computed(() => {
   const value = formData.value.language
@@ -734,6 +741,10 @@ const rules = {
     if (!value) return true
     if (titleGraphemeCount.value > titleMaxLength) {
       return `Maximum length is ${titleMaxLength} characters.`
+    }
+    const regex = new RegExp(TITLE_NAME_PATTERN)
+    if (!regex.test(value)) {
+      return `Value does not meet pattern: ${TITLE_NAME_PATTERN}`
     }
     return true
   },


### PR DESCRIPTION
## Rationale
This PR adds a check for the book's Title metadata and passes the title name to the logic to compute book filename insead of the book name.

## Changes
- define regex for valid title names
- mark books whose `Name` metadata fails to match regex with `bad metadata`
- extend UI rules in TitleForm to validate input with regex
- use title name in computing book filename instead of book name

This closes #9