### PR TITLE
show book issues in UI

### DIFF
--- a/backend/src/cms_backend/api/routes/books.py
+++ b/backend/src/cms_backend/api/routes/books.py
@@ -12,11 +12,16 @@ from cms_backend.api.routes.fields import LimitFieldMax200, NotEmptyString, Skip
 from cms_backend.api.routes.models import ListResponse, calculate_pagination_metadata
 from cms_backend.db import gen_dbsession
 from cms_backend.db.book import backup_book as db_backup_book
-from cms_backend.db.book import create_book_full_schema, create_book_history_schema
+from cms_backend.db.book import (
+    can_compute_book_issues,
+    create_book_full_schema,
+    create_book_history_schema,
+)
 from cms_backend.db.book import delete_book as db_delete_book
 from cms_backend.db.book import get_book as db_get_book
 from cms_backend.db.book import get_book_history as db_get_book_history
 from cms_backend.db.book import get_book_history_entry as db_get_book_history_entry
+from cms_backend.db.book import get_book_issues as db_get_book_issues
 from cms_backend.db.book import move_book as db_move_book
 from cms_backend.db.book import recover_book as db_recover_book
 from cms_backend.db.book import remove_book_backup as db_remove_book_backup
@@ -209,6 +214,23 @@ def backup_book(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> BookFullSchema:
     return create_book_full_schema(db_backup_book(session, book_id=book_id))
+
+
+@router.get("/{book_id}/issues")
+def get_book_issues(
+    book_id: Annotated[UUID, Path()],
+    session: OrmSession = Depends(gen_dbsession),
+) -> JSONResponse:
+    book = db_get_book(session, book_id)
+    if not can_compute_book_issues(book):
+        issues = {}
+    else:
+        issues = db_get_book_issues(session, book)
+
+    return JSONResponse(
+        content=issues,
+        status_code=HTTPStatus.OK,
+    )
 
 
 @router.get(

--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -561,102 +561,71 @@ def revert_book(
     return book
 
 
-def book_has_bad_metadata(book: Book, *, update_events: bool = False) -> bool:
-    """Determine if a book has bad metadata.
-
-    Assumes book has all mandatory metadata
-    """
+def get_book_metadata_issues(book: Book) -> list[str]:
+    issues: list[str] = []
     name = book.zim_metadata["Name"]
+
     if not re.match(ZIM_TITLE_NAME_REGEX, name):
-        if update_events:
-            book.events.append(
-                f"{getnow()}: book Name metadata contains unwanted characters"
-            )
-        return True
+        issues.append(f"book Name metadata ({name}) does not meet naming conventions")
+
     title_length = len(regex.findall(r"\X", book.zim_metadata["Title"]))
 
     if title_length > Context.zim_title_max_length:
-        if update_events:
-            book.events.append(
-                f"{getnow()}: book Title metadata is {title_length} characters long"
-            )
-        return True
+        issues.append(
+            f"book Title metadata is {title_length} characters long, "
+            f"maximum length: {Context.zim_title_max_length}"
+        )
 
     description_length = len(regex.findall(r"\X", book.zim_metadata["Description"]))
     if description_length > Context.zim_description_max_length:
-        if update_events:
-            book.events.append(
-                f"{getnow()}: book Description metadata is {description_length} "
-                "characters long"
-            )
-        return True
+        issues.append(
+            f"book Description metadata is {description_length} characters long, "
+            f"maximum length: {Context.zim_description_max_length}"
+        )
     flavour = book.zim_metadata.get("Flavour")
     if flavour and not flavour.isalpha():
-        if update_events:
-            book.events.append(
-                f"{getnow()}: book Flavour metadata contains non-alphabetic characters"
-            )
+        issues.append(
+            f"book Flavour metadata ({flavour}) contains non-alphabetic characters"
+        )
 
-        return True
-    return False
+    return issues
 
 
-def update_book_issues(
-    session: OrmSession,
-    book: Book,
-    *,
-    update_events: bool = False,
-    raise_exceptions: bool = False,
-):
+def get_book_issues(
+    session: OrmSession, book: Book, *, raise_exceptions: bool = False
+) -> dict[str, list[str]]:
     """
-    Update book issues based on it's associated title and optionally update book events.
+    Compute book issues based on it's associated title
 
-    A book's issues will not be updated if:
-    - it has no associated title
-    - it is missing mandatory metadata keys
-    - it's associated title is missing mandatory metadata
-    - it's location kind is to_delete or deleted
+    Makes the same assumptions as the update_book_issues function
     """
-    if (
-        not book.title
-        or get_missing_metadata_keys(book.zim_metadata)
-        or title_is_missing_mandatory_metadata(book.title)
-        or book.location_kind in ["deleted", "to_delete"]
-    ):
-        return
-
-    issues: list[str] = []
-
+    issues: dict[str, list[str]] = {}
     unknown_languages: list[str] = []
     for language_code in book.zim_metadata["Language"].split(","):
         if pycountry.languages.get(alpha_3=language_code) is None:  # pyright: ignore[reportUnknownMemberType]
             unknown_languages.append(language_code)
 
     if unknown_languages:
-        issues.append("invalid language code")
-        if update_events:
-            book.events.append(
-                f"{getnow()}: book has unknown language code(s) {unknown_languages}"
-            )
+        issues["invalid language code"] = [
+            f"book has unknown language code(s) {','.join(unknown_languages)}"
+        ]
 
     different_metadata_keys = get_differing_metadata_keys(book)
     if different_metadata_keys:
-        issues.append("metadata mismatch")
-        if update_events:
-            book.events.append(
-                f"{getnow()}: book metadata is different from title metadata: "
-                f"{','.join(different_metadata_keys)}"
-            )
+        issues["metadata mismatch"] = [
+            "book metadata is different from title metadata: "
+            f"{','.join(different_metadata_keys)}"
+        ]
 
-    if has_flavour_mismatch(book.flavour, book.title.flavours):
-        issues.append("flavour mismatch")
-        if update_events:
-            book.events.append(
-                f"{getnow()}: book flavour is not in list of title flavours"
-            )
+    if has_flavour_mismatch(book.flavour, book.title.flavours):  # pyright: ignore[reportOptionalMemberAccess]
+        issues["flavour mismatch"] = [
+            f"book flavour {book.flavour} is not in list of "
+            f"title flavours: {','.join(book.title.flavours)}"  # pyright: ignore[reportOptionalMemberAccess]
+        ]
 
-    if book_has_bad_metadata(book, update_events=update_events):
-        issues.append("bad metadata")
+    metadata_issues = get_book_metadata_issues(book)
+    if metadata_issues:
+        issues["bad metadata"] = metadata_issues
 
     # Get the latest prod book that isn't the current book
     latest_book = session.scalars(
@@ -677,7 +646,7 @@ def update_book_issues(
             Context.media_count_change_threshold
             if tc.collection.media_count_change_threshold is None
             else tc.collection.media_count_change_threshold
-            for tc in book.title.collections
+            for tc in book.title.collections  # pyright: ignore[reportOptionalMemberAccess]
         ],
         default=Context.media_count_change_threshold,
     )
@@ -686,7 +655,7 @@ def update_book_issues(
             Context.article_count_change_threshold
             if tc.collection.article_count_change_threshold is None
             else tc.collection.article_count_change_threshold
-            for tc in book.title.collections
+            for tc in book.title.collections  # pyright: ignore[reportOptionalMemberAccess]
         ],
         default=Context.article_count_change_threshold,
     )
@@ -696,42 +665,95 @@ def update_book_issues(
     ) / latest_book.media_count
 
     if media_count_diff > collection_media_count_change_threshold:
-        issues.append("media count")
-        if update_events:
-            book.events.append(
-                f"{getnow()}: book media count exceeds collection median threshold by "
-                f"{media_count_diff * 100}%"
-            )
+        issues["media count"] = [
+            f"book media count ({book.media_count}) exceeds latest book "
+            f"(id={latest_book.id}) media count ({latest_book.media_count}) "
+            f"by {media_count_diff * 100}%"
+        ]
 
     article_count_diff = (
         abs(book.article_count - latest_book.article_count)
     ) / latest_book.article_count
     if article_count_diff > collection_article_count_change_threshold:
-        issues.append("article count")
-        if update_events:
-            book.events.append(
-                f"{getnow()}: book article count exceeds collection median threshold "
-                f"by {article_count_diff * 100}%"
-            )
+        issues["article count"] = [
+            f"book article count ({book.article_count}) exceeds latest book "
+            f"(id={latest_book.id}) article count ({latest_book.article_count}) "
+            f"by {article_count_diff * 100}%"
+        ]
 
-    if not check_zimcheck_quality(
-        book, raise_exceptions=raise_exceptions, update_events=update_events
+    zimcheck_errors = get_zimcheck_errors(book, raise_exceptions=raise_exceptions)
+    if zimcheck_errors:
+        issues["zimcheck error"] = zimcheck_errors
+
+    return issues
+
+
+def can_compute_book_issues(book: Book) -> bool:
+    """Deterimine if a book's issues can be computed.
+
+    A book's issues cannot be computed if:
+    - it has no associated title
+    - it is missing mandatory metadata keys
+    - it's associated title is missing mandatory metadata
+    - it's location kind is to_delete or deleted
+    """
+    if (
+        not book.title
+        or get_missing_metadata_keys(book.zim_metadata)
+        or title_is_missing_mandatory_metadata(book.title)
+        or book.location_kind in ["deleted", "to_delete"]
     ):
-        issues.append("zimcheck error")
+        return False
+    return True
 
+
+def book_is_whitelisted_from_zimcheck(book: Book) -> bool:
+    scraper = book.zim_metadata.get("Scraper", "")
+    if Context.zimcheck_scrapers_whitelist_regex is not None and re.search(
+        Context.zimcheck_scrapers_whitelist_regex, scraper
+    ):
+        return True
+    return False
+
+
+def update_book_issues(
+    session: OrmSession,
+    book: Book,
+    *,
+    update_events: bool = False,
+    raise_exceptions: bool = False,
+):
+    """
+    Update book issues based on it's associated title and optionally update book events.
+
+    Book's issues will be updated it it meets the requirements of the
+    can_compute_book_issues function
+    """
+
+    if not can_compute_book_issues(book):
+        return
+
+    issues = list(
+        get_book_issues(session, book, raise_exceptions=raise_exceptions).keys()
+    )
     book.issues = issues
+    if update_events and book_is_whitelisted_from_zimcheck(book):
+        book.events.append(f"{getnow()}: book is whitelisted for zimcheck quality")
+    if update_events and issues:
+        book.events.append(
+            f"{getnow()}: book has the following issues: {','.join(issues)}"
+        )
+
     session.add(book)
     session.flush()
 
 
-def check_zimcheck_quality(
-    book: Book, *, update_events: bool = False, raise_exceptions: bool = False
-) -> bool:
+def get_zimcheck_errors(book: Book, *, raise_exceptions: bool = False) -> list[str]:
     """Run checks for zimcheck quality if scraper is not whitelisted.
 
     If book is missing zimcheck summary, results will be downloaded from URL and set.
-    Returns true if it is impossible to run checks or there are no errors.
     """
+    issues: list[str] = []
     # Determine whether we need to fetch zimcheck results or not
     missing_summary_keys = get_missing_keys(
         book.zimcheck_summary,
@@ -745,21 +767,17 @@ def check_zimcheck_quality(
     zimcheck_summary: ZimcheckSummarySchema
     if missing_summary_keys:
         if not book.zimcheck_result_url:
-            if update_events:
-                book.events.append(f"{getnow()}: book has no zimcheck url")
-
-            return False
+            issues.append("book has no zimcheck url")
+            return issues
 
         zimcheck_response = query_api(book.zimcheck_result_url)
         if zimcheck_response.success:
             zimcheck_summary = parse_zimcheck_result(zimcheck_response.json)
             book.zimcheck_summary = zimcheck_summary.model_dump(mode="json")
         else:
-            if update_events:
-                book.events.append(
-                    f"{getnow()}: unable to retrieve zimcheck results "
-                    f"from {book.zimcheck_result_url}"
-                )
+            issues.append(
+                f"unable to retrieve zimcheck results from {book.zimcheck_result_url}"
+            )
             message = (
                 "Unable to retrieve zimcheck results from "
                 f"{book.zimcheck_result_url}: {zimcheck_response.json}"
@@ -767,26 +785,18 @@ def check_zimcheck_quality(
             logger.debug(message)
             if raise_exceptions:
                 raise ValueError(message)
-            return False
+            return issues
     else:
         zimcheck_summary = ZimcheckSummarySchema.model_validate(book.zimcheck_summary)
 
-    scraper = book.zim_metadata.get("Scraper", "")
-    if Context.zimcheck_scrapers_whitelist_regex is not None and re.search(
-        Context.zimcheck_scrapers_whitelist_regex, scraper
-    ):
-        if update_events:
-            book.events.append(f"{getnow()}: book is whitelisted for zimcheck quality")
-        return True
+    if book_is_whitelisted_from_zimcheck(book):
+        return []
 
     if zimcheck_summary.error_count is not None and zimcheck_summary.error_count > 0:
-        if update_events:
-            book.events.append(
-                f"{getnow()}: book has {zimcheck_summary.error_count} error(s) in "
-                "zimcheck"
-            )
-        return False
-    return True
+        issues.append(
+            f"{getnow()}: book has {zimcheck_summary.error_count} error(s) in zimcheck"
+        )
+    return issues
 
 
 def backup_book(

--- a/backend/tests/api/routes/test_books.py
+++ b/backend/tests/api/routes/test_books.py
@@ -696,3 +696,78 @@ def test_remove_book_backup_required_permissions(
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert response.status_code == expected_status_code
+
+
+def test_get_book_issues(
+    client: TestClient,
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+    create_title: Callable[..., Title],
+    create_collection: Callable[..., Collection],
+    create_book_location: Callable[..., BookLocation],
+    create_warehouse: Callable[..., Warehouse],
+):
+    warehouse = create_warehouse()
+    content = {
+        "Name": "test_en_all",
+        "Title": "Test Article",
+        "Creator": "Test Creator",
+        "Publisher": "Test Publisher",
+        "Date": "2025-01-01",
+        "Description": "Test description",
+        "Language": "eng",
+        "Illustration_48x48@1": (
+            "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAOklEQVR4nO3OwQkAIAwA"
+            "wfRf2u1gB4kfQeYKCHcNAAAAAAAAAAAAgL96bPf7EgAAAAAAAIC/egF5uwED0gQ8ugAAAA"
+            "BJRU5ErkJggg=="
+        ),
+    }
+    title = create_title(
+        name="test_en_all",
+        flavours=["maxi", "mini"],
+        title=content["Title"],
+        creator=content["Creator"],
+        publisher=content["Publisher"],
+        description=content["Description"],
+        language=content["Language"],
+        illustration_48x48_at_1=content["Illustration_48x48@1"],
+    )
+    # create a collection that tolerates only 10% increase in media and article count
+    create_collection(
+        warehouse=warehouse,
+        title_ids_with_paths=[(title.id, "zim")],
+        media_count_change_threshold=0.1,
+        article_count_change_threshold=0.1,
+    )
+
+    # create the latest book with media_count of 100 and article count of 105
+    latest_book = create_book(
+        article_count=105,
+        media_count=100,
+        flavour="maxi",
+        title_id=title.id,
+        zim_metadata=content,
+        location_kind="prod",
+    )
+
+    create_book_location(
+        book=latest_book,
+        warehouse_id=warehouse.id,
+        path=Path("zim"),
+        filename="test_en_all_2024-01.zim",
+        status="current",
+    )
+
+    book = create_book(
+        article_count=100,
+        media_count=100,
+        flavour="maxi",
+        title_id=title.id,
+        zim_metadata=content,
+    )
+    dbsession.flush()
+
+    response = client.get(
+        f"/v1/books/{book.id}/issues",
+    )
+    assert response.status_code == HTTPStatus.OK

--- a/backend/tests/db/test_book.py
+++ b/backend/tests/db/test_book.py
@@ -11,11 +11,11 @@ from sqlalchemy.orm import Session as OrmSession
 from cms_backend.context import Context
 from cms_backend.db.book import (
     backup_book,
-    book_has_bad_metadata,
-    check_zimcheck_quality,
     get_book_history,
     get_book_history_entry_or_none,
+    get_book_metadata_issues,
     get_differing_metadata_keys,
+    get_zimcheck_errors,
     recover_book,
     remove_book_backup,
     revert_book,
@@ -292,9 +292,9 @@ def test_revert_book(
     assert reverted_book.flavour == "mini"
 
 
-@patch("cms_backend.db.book.check_zimcheck_quality")
+@patch("cms_backend.db.book.get_zimcheck_errors")
 def test_update_book_flavour_mismatch_issues(
-    mock_check_zimcheck_quaity: MagicMock,
+    mock_get_zimcheck_errors: MagicMock,
     dbsession: OrmSession,
     account: Account,
     create_title: Callable[..., Title],
@@ -304,7 +304,7 @@ def test_update_book_flavour_mismatch_issues(
     Test that book with  a flavour mismatch between it and it's title has
     it's issues reset when it's flavour is updated to the same as the title
     """
-    mock_check_zimcheck_quaity.return_value = True
+    mock_get_zimcheck_errors.return_value = []
     content = {
         "Name": "test_en_all",
         "Title": "Test Article",
@@ -805,9 +805,9 @@ def test_recover_deleted_book_with_no_backup(
         ),
     ],
 )
-@patch("cms_backend.db.book.check_zimcheck_quality")
+@patch("cms_backend.db.book.get_zimcheck_errors")
 def test_update_book_issues_item_count_issues(
-    mock_check_zimcheck_quaity: MagicMock,
+    mock_get_zimcheck_errors: MagicMock,
     dbsession: OrmSession,
     create_book: Callable[..., Book],
     create_title: Callable[..., Title],
@@ -821,7 +821,7 @@ def test_update_book_issues_item_count_issues(
     expected_issues: set[str],
 ):
     """Test that update_book_issues correctly flags issues with book item count"""
-    mock_check_zimcheck_quaity.return_value = True
+    mock_get_zimcheck_errors.return_value = []
     warehouse = create_warehouse()
     content = {
         "Name": "test_en_all",
@@ -911,7 +911,7 @@ def test_update_book_issues_item_count_issues(
             "é" * 80,
             "_maxi",
             "test_en_all",
-            "book Flavour metadata contains non-alphabetic characters",
+            "book Flavour metadata .* contains non-alphabetic characters",
             True,
             id="invalid-flavour",
         ),
@@ -944,9 +944,10 @@ def test_book_has_bad_metadata(
             "Flavour": flavour,
         }
     )
-    assert book_has_bad_metadata(book, update_events=True) is expected
+    issues = get_book_metadata_issues(book)
+    assert bool(issues) is expected
     if expected:
-        assert any(re.search(event_regex, event) for event in book.events)
+        assert any(re.search(event_regex, issue) for issue in issues)
 
 
 @pytest.mark.parametrize(
@@ -956,7 +957,7 @@ def test_book_has_bad_metadata(
         (False, False),
     ],
 )
-def test_check_zimcheck_quality_ignore_scraper(
+def test_get_zimcheck_errors_ignore_scraper(
     dbsession: OrmSession,
     create_book: Callable[..., Book],
     monkeypatch: pytest.MonkeyPatch,
@@ -982,4 +983,8 @@ def test_check_zimcheck_quality_ignore_scraper(
             "cms_backend.context.Context.zimcheck_scrapers_whitelist_regex",
             re.compile(r"mwoffliner.*|sotoki"),
         )
-    assert check_zimcheck_quality(book) is passes_quality_check
+    errors = get_zimcheck_errors(book)
+    if passes_quality_check:
+        assert len(errors) == 0
+    else:
+        assert len(errors) > 0

--- a/backend/tests/mill/processors/test_zimfarm_notification.py
+++ b/backend/tests/mill/processors/test_zimfarm_notification.py
@@ -279,10 +279,10 @@ class TestValidNotificationWithMatchingTitleUnstableMaturity:
     Unstable maturity titles should have their books moved to staging.
     """
 
-    @patch("cms_backend.db.book.check_zimcheck_quality")
+    @patch("cms_backend.db.book.get_zimcheck_errors")
     def test_set_missing_title_metadata_from_book(
         self,
-        mock_check_zimcheck_quaity: MagicMock,
+        mock_get_zimcheck_errors: MagicMock,
         dbsession: OrmSession,
         warehouse: Warehouse,  # noqa: ARG002
         create_zimfarm_notification: Callable[..., ZimfarmNotification],
@@ -291,7 +291,7 @@ class TestValidNotificationWithMatchingTitleUnstableMaturity:
         """
         Set title metadata from book because title has no metadata set
         """
-        mock_check_zimcheck_quaity.return_value = True
+        mock_get_zimcheck_errors.return_value = []
         # Create title that matches book name
         title = create_title(name="test_en_all")
         title.maturity = "unstable"
@@ -316,10 +316,10 @@ class TestValidNotificationWithMatchingTitleUnstableMaturity:
         assert title.description == book.zim_metadata["Description"]
         assert title.language == book.zim_metadata["Language"]
 
-    @patch("cms_backend.db.book.check_zimcheck_quality")
+    @patch("cms_backend.db.book.get_zimcheck_errors")
     def test_preserve_title_metadata(
         self,
-        mock_check_zimcheck_quaity: MagicMock,
+        mock_get_zimcheck_errors: MagicMock,
         dbsession: OrmSession,
         warehouse: Warehouse,  # noqa: ARG002
         create_zimfarm_notification: Callable[..., ZimfarmNotification],
@@ -329,7 +329,7 @@ class TestValidNotificationWithMatchingTitleUnstableMaturity:
         """
         Preserve existing title metadata even though book has different metadata
         """
-        mock_check_zimcheck_quaity.return_value = True
+        mock_get_zimcheck_errors.return_value = []
         # Create title that matches book name with all metadata matching with book
         # except for language
         title = create_title(
@@ -360,10 +360,10 @@ class TestValidNotificationWithMatchingTitleUnstableMaturity:
         dbsession.refresh(title)
         assert title.language != book.zim_metadata["Language"]
 
-    @patch("cms_backend.db.book.check_zimcheck_quality")
+    @patch("cms_backend.db.book.get_zimcheck_errors")
     def test_moves_book_to_staging(
         self,
-        mock_check_zimcheck_quaity: MagicMock,
+        mock_get_zimcheck_errors: MagicMock,
         dbsession: OrmSession,
         warehouse: Warehouse,  # noqa: ARG002
         create_zimfarm_notification: Callable[..., ZimfarmNotification],
@@ -372,7 +372,7 @@ class TestValidNotificationWithMatchingTitleUnstableMaturity:
         """
         Valid notification + matching unstable maturity title → book moves to staging.
         """
-        mock_check_zimcheck_quaity.return_value = True
+        mock_get_zimcheck_errors.return_value = []
         # Create title that matches book name
         title = create_title(name="test_en_all")
         title.maturity = "unstable"
@@ -406,16 +406,16 @@ class TestValidNotificationWithMatchingTitleUnstableMaturity:
         assert book.needs_file_operation is True
         assert book.needs_processing is False
 
-    @patch("cms_backend.db.book.check_zimcheck_quality")
+    @patch("cms_backend.db.book.get_zimcheck_errors")
     def test_moves_book_to_staging_with_empty_folder_name(
         self,
-        mock_check_zimcheck_quaity: MagicMock,
+        mock_get_zimcheck_errors: MagicMock,
         dbsession: OrmSession,
         warehouse: Warehouse,  # noqa: ARG002
         create_zimfarm_notification: Callable[..., ZimfarmNotification],
         create_title: Callable[..., Title],
     ):
-        mock_check_zimcheck_quaity.return_value = True
+        mock_get_zimcheck_errors.return_value = []
         """
         Valid notification with empty folder_name + unstable maturity title → book
         moves to staging.
@@ -461,10 +461,10 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
     Stable maturity titles have their books moved directly to production collections.
     """
 
-    @patch("cms_backend.db.book.check_zimcheck_quality")
+    @patch("cms_backend.db.book.get_zimcheck_errors")
     def test_moves_book_to_collection_warehouses(
         self,
-        mock_check_zimcheck_quaity: MagicMock,
+        mock_get_zimcheck_errors: MagicMock,
         dbsession: OrmSession,
         warehouse: Warehouse,  # noqa: ARG002
         create_zimfarm_notification: Callable[..., ZimfarmNotification],
@@ -473,7 +473,7 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         create_warehouse: Callable[..., Warehouse],
     ):
         """Valid notification + stable title → book has collection warehouse targets."""
-        mock_check_zimcheck_quaity.return_value = True
+        mock_get_zimcheck_errors.return_value = []
 
         title = create_title(name="test_en_all")
         title.maturity = "stable"
@@ -517,10 +517,10 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         assert book.needs_file_operation is True
         assert book.needs_processing is False
 
-    @patch("cms_backend.db.book.check_zimcheck_quality")
+    @patch("cms_backend.db.book.get_zimcheck_errors")
     def test_moves_book_to_collection_warehouses_with_empty_folder_name(
         self,
-        mock_check_zimcheck_quaity: MagicMock,
+        mock_get_zimcheck_errors: MagicMock,
         dbsession: OrmSession,
         warehouse: Warehouse,  # noqa: ARG002
         create_zimfarm_notification: Callable[..., ZimfarmNotification],
@@ -532,7 +532,7 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         Valid notification with empty folder_name + stable title → book has collection
         warehouse targets.
         """
-        mock_check_zimcheck_quaity.return_value = True
+        mock_get_zimcheck_errors.return_value = []
 
         title = create_title(name="test_en_all")
         title.maturity = "stable"
@@ -577,10 +577,10 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         assert book.needs_file_operation is True
         assert book.needs_processing is False
 
-    @patch("cms_backend.db.book.check_zimcheck_quality")
+    @patch("cms_backend.db.book.get_zimcheck_errors")
     def test_moves_book_to_staging_due_to_diffrent_metadata_from_title(
         self,
-        mock_check_zimcheck_quaity: MagicMock,
+        mock_get_zimcheck_errors: MagicMock,
         dbsession: OrmSession,
         warehouse: Warehouse,  # noqa: ARG002
         create_zimfarm_notification: Callable[..., ZimfarmNotification],
@@ -593,7 +593,7 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         Test that book goes to staging because there is a metadata mismatch between
         it and it's title
         """
-        mock_check_zimcheck_quaity.return_value = True
+        mock_get_zimcheck_errors.return_value = []
 
         # Create title that matches book name with all metadata matching with book
         # except for language
@@ -639,10 +639,10 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         assert book.needs_file_operation is True
         assert book.needs_processing is False
 
-    @patch("cms_backend.db.book.check_zimcheck_quality")
+    @patch("cms_backend.db.book.get_zimcheck_errors")
     def test_moves_book_to_staging_due_to_diffrent_flavour_from_title(
         self,
-        mock_check_zimcheck_quaity: MagicMock,
+        mock_get_zimcheck_errors: MagicMock,
         dbsession: OrmSession,
         warehouse: Warehouse,  # noqa: ARG002
         create_zimfarm_notification: Callable[..., ZimfarmNotification],
@@ -654,7 +654,7 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         Test that book goes to staging because there is a flavour mismatch between
         it and it's title
         """
-        mock_check_zimcheck_quaity.return_value = True
+        mock_get_zimcheck_errors.return_value = []
 
         title = create_title(name="test_en_all", flavours=["maxi", "mini"])
         title.maturity = "stable"
@@ -690,10 +690,10 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         assert book.needs_file_operation is True
         assert book.needs_processing is False
 
-    @patch("cms_backend.db.book.check_zimcheck_quality")
+    @patch("cms_backend.db.book.get_zimcheck_errors")
     def test_moves_book_to_staging_due_to_invalid_language(
         self,
-        mock_check_zimcheck_quaity: MagicMock,
+        mock_get_zimcheck_errors: MagicMock,
         dbsession: OrmSession,
         warehouse: Warehouse,  # noqa: ARG002
         create_zimfarm_notification: Callable[..., ZimfarmNotification],
@@ -704,7 +704,7 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         """
         Test that book goes to staging because it has an invalid language code
         """
-        mock_check_zimcheck_quaity.return_value = True
+        mock_get_zimcheck_errors.return_value = []
 
         title = create_title(name="test_en_all")
         title.maturity = "stable"
@@ -741,10 +741,10 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         assert book.needs_file_operation is True
         assert book.needs_processing is False
 
-    @patch("cms_backend.db.book.check_zimcheck_quality")
+    @patch("cms_backend.db.book.get_zimcheck_errors")
     def test_moves_book_to_prod_due_to_invalid_language_code_being_supported(
         self,
-        mock_check_zimcheck_quaity: MagicMock,
+        mock_get_zimcheck_errors: MagicMock,
         dbsession: OrmSession,
         warehouse: Warehouse,  # noqa: ARG002
         monkeypatch: MonkeyPatch,
@@ -757,7 +757,7 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         Test that book goes to prod even though it's language code is invalid
         but supported
         """
-        mock_check_zimcheck_quaity.return_value = True
+        mock_get_zimcheck_errors.return_value = []
 
         title = create_title(name="test_en_all")
         title.maturity = "stable"
@@ -797,10 +797,10 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         assert book.needs_file_operation is True
         assert book.needs_processing is False
 
-    @patch("cms_backend.db.book.check_zimcheck_quality")
+    @patch("cms_backend.db.book.get_zimcheck_errors")
     def test_moves_book_to_staging_due_to_valid_language_code_being_disallowed(
         self,
-        mock_check_zimcheck_quaity: MagicMock,
+        mock_get_zimcheck_errors: MagicMock,
         dbsession: OrmSession,
         warehouse: Warehouse,  # noqa: ARG002
         monkeypatch: MonkeyPatch,
@@ -813,7 +813,7 @@ class TestValidNotificationWithMatchingTitleStableMaturity:
         Test that book goes to staging because there it's language code is disallowed
         even though it's valid
         """
-        mock_check_zimcheck_quaity.return_value = True
+        mock_get_zimcheck_errors.return_value = []
 
         title = create_title(name="test_en_all")
         title.maturity = "stable"

--- a/frontend/src/components/BookIssues.vue
+++ b/frontend/src/components/BookIssues.vue
@@ -1,0 +1,118 @@
+<template>
+  <div>
+    <div v-if="loading" class="text-center pa-4">
+      <v-progress-circular indeterminate size="32" />
+      <div class="mt-2 text-body-2 text-medium-emphasis">Loading issues...</div>
+    </div>
+
+    <div
+      v-else-if="!issues || Object.keys(issues).length === 0"
+      class="text-center pa-4 text-medium-emphasis"
+    >
+      No issues found for this book.
+    </div>
+
+    <v-expansion-panels v-else variant="accordion">
+      <v-expansion-panel v-for="(reasons, issueKey) in issues" :key="issueKey" :title="issueKey">
+        <template #text>
+          <v-list
+            v-if="issueKey !== 'metadata mismatch'"
+            density="compact"
+            class="py-0 overflow-y-auto striped-list"
+            border
+            style="max-height: 300px"
+          >
+            <v-list-item v-for="(reason, index) in reasons" :key="index" class="px-3 py-1">
+              <v-list-item-title class="text-body-2 text-wrap">{{ reason }}</v-list-item-title>
+            </v-list-item>
+          </v-list>
+
+          <div
+            v-if="issueKey === 'metadata mismatch' && metadataDifferences"
+            class="border pa-2 rounded mt-0"
+          >
+            <div class="text-subtitle-2 mb-2">Book Metadata vs Title Metadata:</div>
+            <DiffViewer :differences="metadataDifferences" />
+          </div>
+        </template>
+
+        <template #title>
+          <div class="d-flex align-center">
+            <v-icon color="warning" size="small" class="mr-2">mdi-alert-circle</v-icon>
+            <span class="text-capitalize">{{ issueKey }}</span>
+            <v-chip size="x-small" class="ml-2" variant="flat" color="warning">
+              {{ reasons.length }}
+            </v-chip>
+          </div>
+        </template>
+      </v-expansion-panel>
+    </v-expansion-panels>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { diff } from 'deep-diff'
+import type { Book } from '@/types/book'
+import type { Title } from '@/types/title'
+import type { EnhancedDiff } from '@/utils/diff'
+import DiffViewer from '@/components/DiffViewer.vue'
+
+interface Props {
+  issues: Record<string, string[]> | null
+  loading: boolean
+  book: Book | null
+  title: Title | null
+}
+
+const props = defineProps<Props>()
+
+const METADATA_KEYS = [
+  'Title',
+  'Creator',
+  'Publisher',
+  'Description',
+  'Language',
+  'Illustration_48x48@1',
+] as const
+
+type MetadataKey = (typeof METADATA_KEYS)[number]
+
+const metadataDifferences = computed(() => {
+  if (!props.book || !props.title) return undefined
+
+  const metadata = props.book.zim_metadata as Record<string, unknown>
+
+  const bookMetadata: Record<MetadataKey, unknown> = {} as Record<MetadataKey, unknown>
+  for (const key of METADATA_KEYS) {
+    bookMetadata[key] = metadata[key] ?? null
+  }
+
+  const titleMetadata: Record<MetadataKey, unknown> = {
+    Title: props.title.title,
+    Creator: props.title.creator,
+    Publisher: props.title.publisher,
+    Description: props.title.description,
+    Language: props.title.language,
+    'Illustration_48x48@1': props.title.illustration_48x48_at_1,
+  }
+
+  const differences = diff(bookMetadata, titleMetadata)
+  if (!differences) return undefined
+
+  // Enhance differences with blob metadata
+  return differences.map((d) => {
+    const enhanced: EnhancedDiff = { ...d }
+    if (d.path?.includes('Illustration_48x48@1')) {
+      enhanced.isBlob = true
+    }
+    return enhanced
+  }) as EnhancedDiff[]
+})
+</script>
+
+<style scoped>
+.striped-list :deep(.v-list-item:nth-child(even)) {
+  background-color: rgba(var(--v-theme-on-surface), 0.05);
+}
+</style>

--- a/frontend/src/components/BookStatus.vue
+++ b/frontend/src/components/BookStatus.vue
@@ -50,7 +50,7 @@
     </v-chip>
 
     <!-- Issues indicator -->
-    <v-menu v-if="hasIssues" :close-on-content-click="false">
+    <v-menu v-if="hasIssues" :close-on-content-click="false" v-model="menuOpen">
       <template #activator="{ props: menuProps }">
         <v-chip
           v-bind="menuProps"
@@ -65,21 +65,46 @@
         </v-chip>
       </template>
 
-      <v-list class="pa-2">
-        <v-list-item v-for="(warning, index) in book.issues" :key="index">
+      <v-list class="pa-2 pt-0" density="compact">
+        <v-list-item
+          v-for="(warning, index) in book.issues"
+          :key="index"
+          class="py-0"
+          style="min-height: unset"
+        >
           <template #prepend>
             <span class="mr-2">•</span>
           </template>
           <v-list-item-title class="text-wrap">{{ warning }}</v-list-item-title>
         </v-list-item>
+
+        <div>
+          <v-divider class="my-0" />
+          <v-btn
+            color="primary"
+            variant="elevated"
+            size="small"
+            block
+            :to="{
+              name: 'book-detail-tab',
+              params: { id: book.id, selectedTab: 'issues' },
+            }"
+            @click="menuOpen = false"
+          >
+            <v-icon size="small" class="mr-1">mdi-alert-circle</v-icon>
+            View Issues
+          </v-btn>
+        </div>
       </v-list>
     </v-menu>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { Book, BookLight } from '@/types/book'
+
+const menuOpen = ref(false)
 
 const props = withDefaults(
   defineProps<{

--- a/frontend/src/stores/book.ts
+++ b/frontend/src/stores/book.ts
@@ -265,6 +265,19 @@ export const useBookStore = defineStore('book', () => {
     }
   }
 
+  const fetchBookIssues = async (bookId: string) => {
+    const service = await authStore.getApiService('books')
+    try {
+      errors.value = []
+      const response = await service.get<null, Record<string, string[]>>(`/${bookId}/issues`)
+      return response
+    } catch (_error) {
+      console.error('Failed to load book', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
   return {
     // State
     defaultLimit,
@@ -285,5 +298,6 @@ export const useBookStore = defineStore('book', () => {
     updateBook,
     backupBook,
     countBooks,
+    fetchBookIssues,
   }
 })

--- a/frontend/src/views/BookView.vue
+++ b/frontend/src/views/BookView.vue
@@ -174,6 +174,18 @@
           <v-icon class="mr-2">mdi-pencil</v-icon>
           Edit
         </v-tab>
+
+        <v-tab
+          base-color="primary"
+          value="issues"
+          :to="{
+            name: 'book-detail-tab',
+            params: { id: book.id, selectedTab: 'issues' },
+          }"
+        >
+          <v-icon class="mr-2">mdi-alert-circle</v-icon>
+          Issues
+        </v-tab>
       </v-tabs>
 
       <v-window v-model="currentTab">
@@ -476,6 +488,11 @@
           </div>
         </v-window-item>
 
+        <!-- Issues Tab -->
+        <v-window-item value="issues">
+          <BookIssues :issues="issues" :loading="loadingIssues" :book="book" :title="title" />
+        </v-window-item>
+
         <!-- History Tab -->
         <v-window-item value="history">
           <BookHistory
@@ -600,6 +617,7 @@ import TitleSelectDialog from '@/components/TitleSelectDialog.vue'
 import TitleFormDialog from '@/components/TitleFormDialog.vue'
 import ZimUrlButtons from '@/components/ZimUrlButtons.vue'
 import BookHistory from '@/components/BookHistory.vue'
+import BookIssues from '@/components/BookIssues.vue'
 import { useAuthStore } from '@/stores/auth'
 import { useLoadingStore } from '@/stores/loading'
 import { useNotificationStore } from '@/stores/notification'
@@ -643,6 +661,8 @@ const updateError = ref('')
 const flavours = ref<string[]>([])
 const loadingFlavours = ref(false)
 const loadingHistory = ref(false)
+const loadingIssues = ref(false)
+const issues = ref<Record<string, string[]> | null>(null)
 
 const showConfirmDialog = ref(false)
 const pendingComment = ref('')
@@ -851,6 +871,7 @@ const loadData = async (
   forceReload: boolean = false,
   fetchHistory: boolean = false,
   fetchZimUrls: boolean = false,
+  fetchIssues: boolean = false,
 ) => {
   loadingStore.startLoading('Fetching book...')
 
@@ -880,6 +901,22 @@ const loadData = async (
   if (fetchZimUrls && book.value) {
     loadZimUrls()
   }
+
+  if (fetchIssues) {
+    await loadIssues()
+  }
+}
+
+const loadIssues = async () => {
+  loadingIssues.value = true
+  if (!book.value) return
+  const data = await bookStore.fetchBookIssues(book.value.id)
+  if (data) {
+    issues.value = data
+  } else {
+    notificationStore.showErrors(bookStore.errors)
+  }
+  loadingIssues.value = false
 }
 
 const loadZimUrls = async () => {
@@ -900,7 +937,7 @@ const loadZimUrls = async () => {
 }
 
 onMounted(async () => {
-  await loadData(true, props.selectedTab === 'history', true)
+  await loadData(true, props.selectedTab === 'history', true, props.selectedTab === 'issues')
 })
 
 const copyToClipboard = async (text: string) => {
@@ -1133,7 +1170,12 @@ watch(
   async (newTab) => {
     currentTab.value = newTab
 
-    await loadData(newTab != 'history', newTab === 'history', newTab === 'info')
+    await loadData(
+      ['info', 'edit'].includes(newTab),
+      newTab === 'history',
+      newTab === 'info',
+      newTab === 'issues',
+    )
 
     if (newTab === 'edit' && book.value && flavours.value.length == 0) {
       loadingFlavours.value = true


### PR DESCRIPTION
## Rationale
This PR enhances the API to be able to view the list of book issues in the book detail view
<img width="1009" height="260" alt="Screenshot_20260624_155912" src="https://github.com/user-attachments/assets/22daa28e-f47f-4d1c-aa01-0a59b9996f32" />
<img width="1144" height="450" alt="Screenshot_20260624_154542" src="https://github.com/user-attachments/assets/b15a6b06-f3f9-42dd-8a91-35419af4b0e9" />
<img width="1071" height="373" alt="Screenshot_20260624_154447" src="https://github.com/user-attachments/assets/8509583e-7b9c-4af4-b115-80f343566067" />
<img width="1085" height="541" alt="Screenshot_20260625_130150" src="https://github.com/user-attachments/assets/1abe6977-9a04-4b9b-86f9-3f5f02430e69" />



## Changes
- refactor the logic to update book issues to use the results of new function `get_book_issues` which computes the issues
- add issues tab in UI
- add API to retrieve book issues

This closes #358 