### PR TITLE
copy to temporary location before move

### DIFF
--- a/backend/src/cms_backend/shuttle/move_files.py
+++ b/backend/src/cms_backend/shuttle/move_files.py
@@ -111,7 +111,11 @@ def move_book_files(session: OrmSession, book: Book):
             ShuttleContext.local_warehouse_paths
         )
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(source_path, target_path)
+        # First copy the file to temporary location before moving. This avoids creating
+        # partially complete ZIM files: https://github.com/openzim/cms/issues/368
+        tmp_path = target_path.with_suffix(target_path.suffix + ".tmp")
+        shutil.copy(source_path, tmp_path)
+        shutil.move(tmp_path, target_path)
         logger.debug(f"Copied book {book.id} from {source_path} to {target_path}")
         book.events.append(
             f"{getnow()}: copied book from {source_location.full_str} to "

--- a/backend/tests/shuttle/test_move_files.py
+++ b/backend/tests/shuttle/test_move_files.py
@@ -129,6 +129,7 @@ def test_move_book_files_copy_operation(
             patch("cms_backend.shuttle.move_files.ShuttleContext")
         )
         mock_copy = stack.enter_context(patch("shutil.copy"))
+        mock_move = stack.enter_context(patch("shutil.move"))
         mock_unlink = stack.enter_context(patch("pathlib.Path.unlink"))
         stack.enter_context(patch("pathlib.Path.mkdir"))
 
@@ -136,6 +137,7 @@ def test_move_book_files_copy_operation(
         move_book_files(dbsession, book)
 
         assert mock_copy.call_count == 2
+        assert mock_move.call_count == 2
         assert mock_unlink.call_count == 1
 
     assert book.needs_processing is False
@@ -174,6 +176,7 @@ def test_move_book_files_move_operation(
             patch("cms_backend.shuttle.move_files.ShuttleContext")
         )
         mock_copy = stack.enter_context(patch("shutil.copy"))
+        mock_move = stack.enter_context(patch("shutil.move"))
         mock_unlink = stack.enter_context(patch("pathlib.Path.unlink"))
         stack.enter_context(patch("pathlib.Path.mkdir"))
 
@@ -182,6 +185,7 @@ def test_move_book_files_move_operation(
 
         # Should have copied once and unlinked once
         assert mock_copy.call_count == 1
+        assert mock_move.call_count == 1
         assert mock_unlink.call_count == 1
 
     assert book.needs_processing is False
@@ -224,6 +228,7 @@ def test_move_book_files_delete_operation(
             patch("cms_backend.shuttle.move_files.ShuttleContext")
         )
         mock_copy = stack.enter_context(patch("shutil.copy"))
+        mock_move = stack.enter_context(patch("shutil.move"))
         stack.enter_context(patch("pathlib.Path.mkdir"))
         mock_unlink = stack.enter_context(patch("pathlib.Path.unlink"))
 
@@ -232,6 +237,7 @@ def test_move_book_files_delete_operation(
 
         # Should have copied once and deleted two extra locations
         assert mock_copy.call_count == 1
+        assert mock_move.call_count == 1
         assert mock_unlink.call_count == 2
 
     assert book.needs_processing is False
@@ -277,6 +283,7 @@ def test_move_book_files_identical_source_and_target_paths(
             patch("cms_backend.shuttle.move_files.ShuttleContext")
         )
         mock_copy = stack.enter_context(patch("shutil.copy"))
+        mock_move = stack.enter_context(patch("shutil.move"))
         mock_unlink = stack.enter_context(patch("pathlib.Path.unlink"))
         stack.enter_context(patch("pathlib.Path.mkdir"))
 
@@ -285,6 +292,7 @@ def test_move_book_files_identical_source_and_target_paths(
 
         # Should only copy once (to "new_path") because "same_path" is identical
         assert mock_copy.call_count == 1
+        assert mock_move.call_count == 1
         # Should NOT unlink "same_path" because it's in the target paths
         assert mock_unlink.call_count == 0
 
@@ -324,6 +332,7 @@ def test_move_book_files_updates_book_locations(
             patch("cms_backend.shuttle.move_files.ShuttleContext")
         )
         stack.enter_context(patch("shutil.copy"))
+        stack.enter_context(patch("shutil.move"))
         stack.enter_context(patch("pathlib.Path.unlink"))
         stack.enter_context(patch("pathlib.Path.mkdir"))
 
@@ -385,6 +394,7 @@ def test_move_book_files_does_not_delete_backup_locations(
             patch("cms_backend.shuttle.move_files.ShuttleContext")
         )
         mock_copy = stack.enter_context(patch("shutil.copy"))
+        mock_move = stack.enter_context(patch("shutil.move"))
         mock_unlink = stack.enter_context(patch("pathlib.Path.unlink"))
         stack.enter_context(patch("pathlib.Path.mkdir"))
 
@@ -396,6 +406,7 @@ def test_move_book_files_does_not_delete_backup_locations(
 
         # Should have copied once and deleted once
         assert mock_copy.call_count == 1
+        assert mock_move.call_count == 1
         assert mock_unlink.call_count == 1
 
     assert book.needs_processing is False
@@ -456,6 +467,7 @@ def test_backup_book_files_does_not_delete_existing_current_locations(
             patch("cms_backend.shuttle.move_files.ShuttleContext")
         )
         mock_copy = stack.enter_context(patch("shutil.copy"))
+        mock_move = stack.enter_context(patch("shutil.move"))
         mock_unlink = stack.enter_context(patch("pathlib.Path.unlink"))
         stack.enter_context(patch("pathlib.Path.mkdir"))
 
@@ -466,6 +478,7 @@ def test_backup_book_files_does_not_delete_existing_current_locations(
         move_book_files(dbsession, book)
 
         assert mock_copy.call_count == 1
+        assert mock_move.call_count == 1
         assert mock_unlink.call_count == 0
 
     assert book.needs_processing is False


### PR DESCRIPTION
## Changes
- during move operation, copy ZIM files to temporary location before making move

This fixes #368 