### PR TITLE
add list_buckets to KiwixStorage check_credentials

### DIFF
--- a/backend/src/cms_backend/shuttle/delete_zimcheck_s3_results.py
+++ b/backend/src/cms_backend/shuttle/delete_zimcheck_s3_results.py
@@ -27,7 +27,7 @@ def get_kiwix_storage_client(upload_uri: urllib.parse.ParseResult):
         rebuild_uri(upload_uri, scheme=get_url_scheme(upload_uri)).geturl()
     )
     if not s3.check_credentials(  # pyright: ignore[reportUnknownMemberType]
-        delete=True
+        list_buckets=True, delete=True
     ):
         raise AuthenticationError("check_credentials failed")
 


### PR DESCRIPTION
## Changes
- add `list_buckets` parameter to check_credentials while verifying connection to KiwixStorage as library does the following check:
```py
        if not list_buckets and not bucket and not write and not read:
            raise ValueError("Nothing to test your credentials over.")
```

This fixes #371 