### PR TITLE
omit processed books in shuttle/mill actions

### DIFF
--- a/backend/src/cms_backend/db/books.py
+++ b/backend/src/cms_backend/db/books.py
@@ -33,6 +33,7 @@ def get_books(
     updated_before: datetime.datetime | None = None,
     updated_after: datetime.datetime | None = None,
     created_before: datetime.datetime | None = None,
+    omit_book_ids: list[UUID] | None = None,
 ) -> ListResult[BookLightSchema]:
     """Get a list of books"""
 
@@ -88,6 +89,9 @@ def get_books(
 
     if created_before is not None:
         stmt = stmt.where(Book.created_at < created_before)
+
+    if omit_book_ids is not None:
+        stmt.where(Book.id.not_in(omit_book_ids))
 
     if needs_attention is True:
         stmt = stmt.where(

--- a/backend/src/cms_backend/mill/mark_staging_books_for_deletion.py
+++ b/backend/src/cms_backend/mill/mark_staging_books_for_deletion.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend import logger
@@ -10,22 +12,23 @@ from cms_backend.utils.datetime import getnow
 def mark_staging_books_for_deletion(session: OrmSession):
     logger.info("Marking staging books that have exceeded lifespan for deletion")
     nb_books_marked = 0
-    skip = 0
-    limit = 50
+    omit_book_ids: list[UUID] = []
     while True:
         results = get_books(
             session,
             needs_file_operation=False,
             needs_processing=False,
             created_before=getnow() - MillContext.staging_books_lifespan,
-            skip=skip,
-            limit=limit,
+            skip=0,
+            limit=50,
             location_kinds=["staging"],
+            omit_book_ids=omit_book_ids,
         )
         if not results.records:
             break
 
         for book in results.records:
+            omit_book_ids.append(book.id)
             try:
                 delete_book(
                     session,
@@ -37,6 +40,5 @@ def mark_staging_books_for_deletion(session: OrmSession):
             else:
                 session.commit()
                 nb_books_marked += 1
-        skip += limit
 
     logger.info(f"Done marking {nb_books_marked} staging book(s) for deletion")

--- a/backend/src/cms_backend/shuttle/delete_zimcheck_s3_results.py
+++ b/backend/src/cms_backend/shuttle/delete_zimcheck_s3_results.py
@@ -1,5 +1,6 @@
 import pathlib
 import urllib.parse
+from uuid import UUID
 
 from kiwixstorage import (  # pyright: ignore[reportMissingTypeStubs]
     AuthenticationError,
@@ -57,8 +58,7 @@ def delete_zimcheck_s3_results(session: OrmSession):
     logger.info("Deleting zimcheck results from S3")
     nb_deleted, nb_failed = 0, 0
 
-    skip = 0
-    limit = 50
+    omit_book_ids: list[UUID] = []
     while True:
         books = session.scalars(
             select(Book)
@@ -66,9 +66,9 @@ def delete_zimcheck_s3_results(session: OrmSession):
                 Book.zimcheck_result_url.is_not(None),
                 Book.zimcheck_s3_deleted.is_(False),
                 Book.location_kind.in_(["prod", "deleted"]),
+                Book.id.not_in(omit_book_ids),
             )
-            .offset(skip)
-            .limit(limit)
+            .limit(50)
             .order_by(Book.created_at)
         ).all()
 
@@ -79,6 +79,7 @@ def delete_zimcheck_s3_results(session: OrmSession):
             break
 
         for book in books:
+            omit_book_ids.append(book.id)
             try:
                 s3.delete_object(
                     book.zimcheck_result_url.split("/")[-1],  # pyright: ignore[reportOptionalMemberAccess]
@@ -93,7 +94,6 @@ def delete_zimcheck_s3_results(session: OrmSession):
                 session.add(book)
                 session.commit()
                 nb_deleted += 1
-        skip += limit
 
     logger.info(f"Done deleting zimcheck files from S3: {nb_deleted=}, {nb_failed=}")
 


### PR DESCRIPTION
## Changes
- omit processed books as shuttle/mill loops around to find books to process instead of incrementing skip

This fixes #374 