### PR TITLE
display zimcheck summary in UI

### DIFF
--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -24,13 +24,13 @@ from cms_backend.schemas.models import (
     ZIM_TITLE_NAME_REGEX,
     BookUpdateSchema,
     FileLocation,
-    ZimcheckSummarySchema,
 )
 from cms_backend.schemas.orms import (
     BookFullSchema,
     BookHistorySchema,
     BookLocationSchema,
     ListResult,
+    ZimcheckSummarySchema,
 )
 from cms_backend.utils.datetime import getnow
 from cms_backend.utils.requests import query_api
@@ -135,6 +135,10 @@ def create_book_full_schema(book: Book) -> BookFullSchema:
         has_backup=any(
             current_location.is_backup for current_location in current_locations
         ),
+        zimcheck_s3_deleted=book.zimcheck_s3_deleted,
+        zimcheck_summary=ZimcheckSummarySchema.model_validate(book.zimcheck_summary)
+        if book.zimcheck_summary
+        else None,
     )
 
 

--- a/backend/src/cms_backend/schemas/models.py
+++ b/backend/src/cms_backend/schemas/models.py
@@ -123,12 +123,3 @@ class TitleUpdateSchema(BaseTitleCreateUpdateSchema):
 class BookUpdateSchema(BaseModel):
     comment: NotEmptyString | None = None
     flavour: NotEmptyString | None = None
-
-
-class ZimcheckSummarySchema(BaseModel):
-    zimcheck_version: str | None = None
-    status: bool | None = None
-    checks: list[str] | None = None
-    error_count: int | None = None
-    warning_count: int | None = None
-    retcode: int | None = None

--- a/backend/src/cms_backend/schemas/orms.py
+++ b/backend/src/cms_backend/schemas/orms.py
@@ -136,6 +136,15 @@ class BookLightSchema(BaseModel):
     has_flavour_mismatch: bool
 
 
+class ZimcheckSummarySchema(BaseModel):
+    zimcheck_version: str | None = None
+    status: bool | None = None
+    checks: list[str] | None = None
+    error_count: int | None = None
+    warning_count: int | None = None
+    retcode: int | None = None
+
+
 class BookFullSchema(BookLightSchema):
     article_count: int
     media_count: int
@@ -147,6 +156,8 @@ class BookFullSchema(BookLightSchema):
     target_locations: list[BookLocationSchema]
     title_archived: bool
     has_backup: bool
+    zimcheck_summary: ZimcheckSummarySchema | None
+    zimcheck_s3_deleted: bool
 
 
 class BookHistorySchema(BaseModel):

--- a/backend/src/cms_backend/utils/zim.py
+++ b/backend/src/cms_backend/utils/zim.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from cms_backend import logger
 from cms_backend.context import parse_bool
-from cms_backend.schemas.models import ZimcheckSummarySchema
+from cms_backend.schemas.orms import ZimcheckSummarySchema
 
 
 def get_missing_keys(payload: dict[str, Any], *keys: str) -> list[str]:

--- a/frontend/src/types/book.ts
+++ b/frontend/src/types/book.ts
@@ -14,6 +14,15 @@ export interface BookLocation {
   is_backup: boolean
 }
 
+export interface ZimcheckSummary {
+  zimcheck_version: string | null
+  status: boolean | null
+  checks: string[] | null
+  error_count: number | null
+  warning_count: number | null
+  retcode: number | null
+}
+
 export interface BookLight {
   id: string
   title_id?: string
@@ -42,6 +51,9 @@ export interface Book extends BookLight {
   target_locations: BookLocation[]
   title_archived: boolean
   has_backup: boolean
+  zimcheck_result_url: string | null
+  zimcheck_s3_deleted: boolean
+  zimcheck_summary: ZimcheckSummary | null
 }
 
 export interface ZimUrl {

--- a/frontend/src/views/BookView.vue
+++ b/frontend/src/views/BookView.vue
@@ -372,15 +372,17 @@
 
                 <v-row no-gutters class="py-2">
                   <v-col cols="12" md="3">
-                    <div class="text-subtitle-2">
-                      ZIM Metadata
+                    <div
+                      class="text-subtitle-2 d-flex flex-row flex-sm-column ga-2 pa-2 align-center align-sm-stretch"
+                    >
+                      <span> ZIM Metadata </span>
                       <v-btn
                         size="small"
                         variant="outlined"
-                        class="ml-2"
+                        class="align-self-start"
                         @click="copyToClipboard(JSON.stringify(book.zim_metadata, null, 2))"
                       >
-                        <v-icon size="small" class="mr-1">mdi-content-copy</v-icon>
+                        <v-icon size="small">mdi-content-copy</v-icon>
                         Copy
                       </v-btn>
                     </div>
@@ -393,25 +395,114 @@
                 </v-row>
                 <v-divider class="my-2"></v-divider>
 
-                <v-row no-gutters class="py-2">
+                <!-- Zimcheck Summary -->
+                <v-row v-if="book.zimcheck_summary" no-gutters class="py-2">
                   <v-col cols="12" md="3">
-                    <div class="text-subtitle-2">
-                      Zimcheck Result
+                    <div
+                      class="text-subtitle-2 d-flex flex-row flex-sm-column ga-2 pa-2 align-center align-sm-stretch"
+                    >
+                      <span> Zimcheck Summary </span>
                       <v-btn
                         size="small"
                         variant="outlined"
-                        class="ml-2"
-                        @click="copyToClipboard(JSON.stringify(book.zimcheck_result, null, 2))"
+                        class="align-self-start"
+                        @click="copyToClipboard(JSON.stringify(book.zimcheck_summary, null, 2))"
                       >
-                        <v-icon size="small" class="mr-1">mdi-content-copy</v-icon>
+                        <v-icon size="small">mdi-content-copy</v-icon>
                         Copy
                       </v-btn>
                     </div>
                   </v-col>
                   <v-col cols="12" md="9">
-                    <div class="overflow-y-auto overflow-x-auto" style="max-height: 400px">
-                      <pre>{{ JSON.stringify(book.zimcheck_result, null, 2) }}</pre>
+                    <div class="d-flex flex-wrap ga-2">
+                      <v-chip v-if="book.zimcheck_summary.zimcheck_version" size="small" label>
+                        <v-icon start size="small">mdi-tag</v-icon>
+                        v{{ book.zimcheck_summary.zimcheck_version }}
+                      </v-chip>
+                      <v-chip
+                        v-if="book.zimcheck_summary.status !== null"
+                        size="small"
+                        :color="book.zimcheck_summary.status ? 'success' : 'error'"
+                        label
+                      >
+                        <v-icon start size="small">
+                          {{
+                            book.zimcheck_summary.status ? 'mdi-check-circle' : 'mdi-alert-circle'
+                          }}
+                        </v-icon>
+                        {{ book.zimcheck_summary.status ? 'Passed' : 'Failed' }}
+                      </v-chip>
+                      <v-chip
+                        v-if="book.zimcheck_summary.error_count !== null"
+                        size="small"
+                        color="error"
+                        label
+                      >
+                        <v-icon start size="small">mdi-alert-octagon</v-icon>
+                        {{ book.zimcheck_summary.error_count }} error{{
+                          book.zimcheck_summary.error_count !== 1 ? 's' : ''
+                        }}
+                      </v-chip>
+                      <v-chip
+                        v-if="book.zimcheck_summary.warning_count !== null"
+                        size="small"
+                        color="warning"
+                        label
+                      >
+                        <v-icon start size="small">mdi-alert</v-icon>
+                        {{ book.zimcheck_summary.warning_count }} warning{{
+                          book.zimcheck_summary.warning_count !== 1 ? 's' : ''
+                        }}
+                      </v-chip>
+                      <v-chip v-if="book.zimcheck_summary.retcode !== null" size="small" label>
+                        Retcode: {{ book.zimcheck_summary.retcode }}
+                      </v-chip>
                     </div>
+                    <div
+                      v-if="book.zimcheck_summary.checks && book.zimcheck_summary.checks.length > 0"
+                      class="mt-2"
+                    >
+                      <div class="text-caption text-medium-emphasis mb-1">Checks:</div>
+                      <div class="d-flex flex-wrap ga-1">
+                        <v-chip
+                          v-for="check in book.zimcheck_summary.checks"
+                          :key="check"
+                          size="x-small"
+                          variant="tonal"
+                        >
+                          {{ check }}
+                        </v-chip>
+                      </div>
+                    </div>
+                  </v-col>
+                </v-row>
+
+                <!-- Zimcheck Results File -->
+                <v-row no-gutters class="py-2">
+                  <v-col cols="12" md="3">
+                    <div class="text-subtitle-2">Zimcheck Results File</div>
+                  </v-col>
+                  <v-col cols="12" md="9">
+                    <template v-if="book.zimcheck_result_url && !book.zimcheck_s3_deleted">
+                      <v-btn
+                        :href="book.zimcheck_result_url"
+                        target="_blank"
+                        size="small"
+                        variant="outlined"
+                        prepend-icon="mdi-download"
+                      >
+                        Download
+                      </v-btn>
+                    </template>
+                    <template v-else-if="book.zimcheck_s3_deleted">
+                      <span class="text-grey">
+                        <v-icon size="small" class="mr-1">mdi-delete</v-icon>
+                        Zimcheck results file has been deleted
+                      </span>
+                    </template>
+                    <template v-else>
+                      <span class="text-grey">No results file available</span>
+                    </template>
                   </v-col>
                 </v-row>
                 <v-divider class="my-2"></v-divider>


### PR DESCRIPTION
## Rationale
This PR enhances the UI by displaying the zimcheck results summary and optionally showing the download link if the zimcheck file has not been deleted. The copy button copies the summary and not the zimcheck results

<img width="1133" height="217" alt="Screenshot_20260626_120139" src="https://github.com/user-attachments/assets/5389a2a5-eaaa-416d-aecd-62147fdfe7d7" />
<img width="1061" height="297" alt="Screenshot_20260626_120127" src="https://github.com/user-attachments/assets/54eac8d9-0b69-4c3b-b6e5-e9faa5f3eb36" />

## Changes
- display zimcheck summary in UI
- optionally show link to zimcheck results file if results have not been deleted

This closes #376 
