### PR TITLE
expose current state of zimcheck result url in get_zim_urls

### DIFF
--- a/backend/src/cms_backend/db/books.py
+++ b/backend/src/cms_backend/db/books.py
@@ -197,6 +197,8 @@ def get_zim_urls_prod(session: OrmSession, zim_ids: list[UUID]) -> ZimUrlsSchema
     stmt = (
         select(
             Book.id.label("book_id"),
+            Book.zimcheck_s3_deleted.label("book_zimcheck_s3_deleted"),
+            Book.zimcheck_result_url.label("book_zimcheck_result_url"),
             Book.location_kind.label("book_location_kind"),
             Title.id.label("title_id"),
             Book.flavour.label("book_flavour"),
@@ -271,6 +273,14 @@ def get_zim_urls_prod(session: OrmSession, zim_ids: list[UUID]) -> ZimUrlsSchema
                     collection=row.collection_name,
                 )
             )
+        if not row.book_zimcheck_s3_deleted and row.book_zimcheck_result_url:
+            result.urls[row.book_id].append(
+                ZimUrlSchema(
+                    kind="zimcheck",
+                    url=AnyUrl(row.book_zimcheck_result_url),
+                    collection=row.collection_name,
+                )
+            )
 
     return result
 
@@ -282,6 +292,8 @@ def get_zim_urls_staging(session: OrmSession, zim_ids: list[UUID]) -> ZimUrlsSch
     stmt = (
         select(
             Book.id.label("book_id"),
+            Book.zimcheck_s3_deleted.label("book_zimcheck_s3_deleted"),
+            Book.zimcheck_result_url.label("book_zimcheck_result_url"),
             Book.location_kind.label("book_location_kind"),
             Title.id.label("title_id"),
             Book.flavour.label("book_flavour"),
@@ -337,6 +349,14 @@ def get_zim_urls_staging(session: OrmSession, zim_ids: list[UUID]) -> ZimUrlsSch
                 collection="staging",
             )
         )
+        if not row.book_zimcheck_s3_deleted and row.book_zimcheck_result_url:
+            result.urls[row.book_id].append(
+                ZimUrlSchema(
+                    kind="zimcheck",
+                    url=AnyUrl(row.book_zimcheck_result_url),
+                    collection="staging",
+                )
+            )
 
     return result
 
@@ -348,6 +368,8 @@ def get_zim_urls_backup(session: OrmSession, zim_ids: list[UUID]) -> ZimUrlsSche
     stmt = (
         select(
             Book.id.label("book_id"),
+            Book.zimcheck_s3_deleted.label("book_zimcheck_s3_deleted"),
+            Book.zimcheck_result_url.label("book_zimcheck_result_url"),
             Book.location_kind.label("book_location_kind"),
             Title.id.label("title_id"),
             Book.flavour.label("book_flavour"),
@@ -404,6 +426,15 @@ def get_zim_urls_backup(session: OrmSession, zim_ids: list[UUID]) -> ZimUrlsSche
                     url=AnyUrl(
                         f"{Context.backup_view_base_url}{filename_without_suffix}"
                     ),
+                    collection="backup",
+                )
+            )
+
+        if not row.book_zimcheck_s3_deleted and row.book_zimcheck_result_url:
+            result.urls[row.book_id].append(
+                ZimUrlSchema(
+                    kind="zimcheck",
+                    url=AnyUrl(row.book_zimcheck_result_url),
                     collection="backup",
                 )
             )

--- a/backend/src/cms_backend/schemas/models.py
+++ b/backend/src/cms_backend/schemas/models.py
@@ -26,7 +26,7 @@ ZIM_TITLE_NAME_REGEX = re.compile(
 class ZimUrlSchema(BaseModel):
     """Schema for a single zim URL"""
 
-    kind: Literal["view", "download"]
+    kind: Literal["view", "download", "zimcheck"]
     url: AnyUrl
     collection: str
 

--- a/backend/tests/db/test_books.py
+++ b/backend/tests/db/test_books.py
@@ -347,6 +347,7 @@ def test_get_zim_urls(
         zim_metadata={"Name": title.name},
         flavour="all",
         date="2023-01-01",
+        zimcheck_result_url="https://www.example.com/zimcheck.json",
     )
     book.title = title
     book.location_kind = "prod"
@@ -365,7 +366,7 @@ def test_get_zim_urls(
     result = get_zim_urls(dbsession, zim_ids=[book.id])
 
     assert book.id in result.urls
-    assert len(result.urls[book.id]) == 2
+    assert len(result.urls[book.id]) == 3
 
     download_url = next((u for u in result.urls[book.id] if u.kind == "download"), None)
     assert download_url is not None
@@ -376,6 +377,11 @@ def test_get_zim_urls(
     assert view_url is not None
     assert str(view_url.url) == "https://browse.library.kiwix.org/viewer#test_en_all"
     assert view_url.collection == collection.name
+
+    zimcheck_url = next((u for u in result.urls[book.id] if u.kind == "zimcheck"), None)
+    assert zimcheck_url is not None
+    assert str(zimcheck_url.url) == book.zimcheck_result_url
+    assert zimcheck_url.collection == collection.name
 
 
 def test_get_book_languages(
@@ -482,11 +488,70 @@ def test_get_zim_urls_book_in_staging(
 
     book = create_book(
         zim_metadata={"Name": title.name},
+        zimcheck_result_url="https://www.example.com/zimcheck.json",
         flavour="all",
         date="2023-01-01",
     )
     book.title = title
     book.location_kind = "staging"
+    title.books.append(book)
+
+    create_book_location(
+        book=book,
+        warehouse_id=Context.staging_warehouse_id,
+        path=Context.staging_base_path,
+        filename="test_en_all.zim",
+        status="current",
+    )
+
+    dbsession.flush()
+
+    result = get_zim_urls(dbsession, zim_ids=[book.id])
+    assert book.id in result.urls
+    assert len(result.urls[book.id]) == 3
+
+    download_url = next((u for u in result.urls[book.id] if u.kind == "download"), None)
+    assert download_url is not None
+    assert str(download_url.url) == "https://download.staging.acme.org/test_en_all.zim"
+    assert download_url.collection == "staging"
+
+    view_url = next((u for u in result.urls[book.id] if u.kind == "view"), None)
+    assert view_url is not None
+    assert str(view_url.url) == "https://library.staging.acme.org/viewer#test_en_all"
+    assert view_url.collection == "staging"
+
+    zimcheck_url = next((u for u in result.urls[book.id] if u.kind == "zimcheck"), None)
+    assert zimcheck_url is not None
+    assert str(zimcheck_url.url) == book.zimcheck_result_url
+
+
+def test_get_zim_urls_book_in_staging_omit_zimcheck_url(
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+    create_title: Callable[..., Title],
+    create_warehouse: Callable[..., Warehouse],
+    create_collection: Callable[..., Collection],
+    create_collection_title: Callable[..., CollectionTitle],
+    create_book_location: Callable[..., BookLocation],
+    warehouse: Warehouse,  # noqa: ARG001
+):
+    """Test zimcheck URLs are omitted when zimcheck results are deleted"""
+    warehouse_prod = create_warehouse()
+    title = create_title(name="test_en_all")
+    collection = create_collection(warehouse=warehouse_prod)
+
+    subpath = Path("wikipedia")
+    create_collection_title(title=title, collection=collection, path=subpath)
+
+    book = create_book(
+        zim_metadata={"Name": title.name},
+        zimcheck_result_url="https://www.example.com/zimcheck.json",
+        flavour="all",
+        date="2023-01-01",
+    )
+    book.title = title
+    book.location_kind = "staging"
+    book.zimcheck_s3_deleted = True
     title.books.append(book)
 
     create_book_location(
@@ -512,6 +577,8 @@ def test_get_zim_urls_book_in_staging(
     assert view_url is not None
     assert str(view_url.url) == "https://library.staging.acme.org/viewer#test_en_all"
     assert view_url.collection == "staging"
+    zimcheck_url = next((u for u in result.urls[book.id] if u.kind == "zimcheck"), None)
+    assert zimcheck_url is None
 
 
 def test_get_zim_urls_multiple_staging_books(

--- a/frontend/src/components/ZimUrlButtons.vue
+++ b/frontend/src/components/ZimUrlButtons.vue
@@ -3,8 +3,8 @@
     <v-progress-circular indeterminate size="20" width="2" />
     <span v-if="!compact" class="ml-2 text-grey">Loading URLs...</span>
   </div>
-  <div v-else-if="urls && urls.length > 0">
-    <v-tooltip v-for="url in urls" :key="`${url.kind}-${url.collection}`" location="bottom">
+  <div v-else-if="displayUrls.length > 0">
+    <v-tooltip v-for="url in displayUrls" :key="`${url.kind}-${url.collection}`" location="bottom">
       <template #activator="{ props: tooltipProps }">
         <v-btn
           v-bind="tooltipProps"
@@ -27,9 +27,10 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { ZimUrl } from '@/types/book'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     urls?: ZimUrl[]
     loading?: boolean
@@ -42,5 +43,9 @@ withDefaults(
     compact: false,
     emptyText: 'No URLs available',
   },
+)
+
+const displayUrls = computed(
+  () => props.urls?.filter((url) => url.kind === 'view' || url.kind === 'download') ?? [],
 )
 </script>


### PR DESCRIPTION
## Changes
- add zimcheck url to result of get_zim_urls if book has a zimcheck url that has not been deleted
- update ui component for showing zimurl buttons to omit urls of kind `zimcheck`

This  closes #377 