### PR TITLE
normalize book, title and title history illustrations

### DIFF
--- a/backend/maint-scripts/normalize_illustrations.py
+++ b/backend/maint-scripts/normalize_illustrations.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Maintenance script to normalize illustrations of books, titles and title histories"""
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session as OrmSession
+from sqlalchemy.orm.attributes import flag_modified
+
+from cms_backend import logger
+from cms_backend.db import Session
+from cms_backend.db.book import get_book
+from cms_backend.db.models import Book, Title, TitleHistory
+from cms_backend.db.title import get_title_by_id
+from cms_backend.utils.zim import normalize_illustration
+
+
+def normalize_book_illustrations(session: OrmSession):
+    book_ids = session.scalars(select(Book.id)).all()
+    nb_success = 0
+    nb_failed = 0
+    logger.info(f"Found {len(book_ids)} book(s) in database.")
+    for book_id in book_ids:
+        book = get_book(session, book_id=book_id)
+        if book.zim_metadata.get("Illustration_48x48@1"):
+            try:
+                logger.debug(f"Normalizing illustration for book {book_id}")
+                book.zim_metadata["Illustration_48x48@1"] = normalize_illustration(
+                    book.zim_metadata["Illustration_48x48@1"]
+                )
+                flag_modified(book, "zim_metadata")
+            except Exception as exc:
+                logger.warning(
+                    f"Unable to normalize illustration for book {book_id} illustration:"
+                    f"\n{exc}"
+                )
+                nb_failed += 1
+            else:
+                session.add(book)
+                nb_success += 1
+        else:
+            logger.warning(f"Book {book_id} has no illustration")
+
+    if nb_success:
+        session.commit()
+    logger.info(f"Finished normalizing book illustrations: {nb_success=}, {nb_failed=}")
+
+
+def normalize_title_illustrations(session: OrmSession):
+    title_ids = session.scalars(
+        select(Title.id).where(
+            Title.illustration_48x48_at_1.is_not(None),
+        )
+    ).all()
+    nb_success = 0
+    nb_failed = 0
+    logger.info(f"Found {len(title_ids)} titles(s) in database")
+    for title_id in title_ids:
+        title = get_title_by_id(session, title_id=title_id)
+        try:
+            logger.debug(f"Normalizing illustration for title {title_id}")
+            title.illustration_48x48_at_1 = normalize_illustration(
+                title.illustration_48x48_at_1  # pyright: ignore[reportArgumentType]
+            )
+        except Exception as exc:
+            logger.warning(
+                f"Unable to normalize illustration  for title {title_id} illustration: "
+                f"\n{exc}"
+            )
+            nb_failed += 1
+        else:
+            session.add(title)
+            nb_success += 1
+    if nb_success:
+        session.commit()
+    logger.info(
+        f"Finished normalizing title illustrations: {nb_success=}, {nb_failed=}"
+    )
+
+
+def normalize_title_history_illustrations(session: OrmSession):
+    title_history_ids = session.scalars(
+        select(TitleHistory.id).where(
+            TitleHistory.illustration_48x48_at_1.is_not(None),
+        )
+    ).all()
+    nb_success = 0
+    nb_failed = 0
+    logger.info(f"Found {len(title_history_ids)} title history in database")
+    for title_history_id in title_history_ids:
+        entry = session.scalars(
+            select(TitleHistory).where(TitleHistory.id == title_history_id)
+        ).one()
+        try:
+            logger.debug(
+                f"Normalizing illustration for title history {title_history_id}"
+            )
+            entry.illustration_48x48_at_1 = normalize_illustration(
+                entry.illustration_48x48_at_1  # pyright: ignore[reportArgumentType]
+            )
+        except Exception as exc:
+            logger.warning(
+                "Unable to normalize illustration for title history "
+                f"{title_history_id} illustration: \n{exc}"
+            )
+            nb_failed += 1
+        else:
+            session.add(entry)
+            nb_success += 1
+    if nb_success:
+        session.commit()
+    logger.info(
+        f"Finished normalizing illustrations for title history entries: {nb_success=}, "
+        f"{nb_failed=}"
+    )
+
+
+def main():
+
+    with Session() as session:
+        normalize_book_illustrations(session)
+        normalize_title_illustrations(session)
+        normalize_title_history_illustrations(session)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "xxhash == 3.7.0",
     "pycountry == 26.2.16",
     "requests == 2.34.2",
+    "pillow == 12.2.0",
 ]
 dynamic = ["version"]
 

--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -37,6 +37,7 @@ from cms_backend.utils.requests import query_api
 from cms_backend.utils.zim import (
     get_missing_keys,
     get_missing_metadata_keys,
+    normalize_illustration,
     parse_zimcheck_result,
 )
 
@@ -160,6 +161,11 @@ def create_book(
     name = zim_metadata.get("Name")
     date = zim_metadata.get("Date")
     flavour = zim_metadata.get("Flavour") or None
+
+    if zim_metadata.get("Illustration_48x48@1"):
+        zim_metadata["Illustration_48x48@1"] = normalize_illustration(
+            zim_metadata["Illustration_48x48@1"]
+        )
 
     book = Book(
         id=book_id,

--- a/backend/src/cms_backend/db/title.py
+++ b/backend/src/cms_backend/db/title.py
@@ -44,6 +44,7 @@ from cms_backend.schemas.orms import (
 )
 from cms_backend.utils import is_valid_uuid
 from cms_backend.utils.datetime import getnow
+from cms_backend.utils.zim import normalize_illustration
 
 
 def create_title_full_schema(title: Title) -> TitleFullSchema:
@@ -285,7 +286,11 @@ def create_title(
     title.creator = payload.creator
     title.publisher = payload.publisher
     title.language = payload.language
-    title.illustration_48x48_at_1 = payload.illustration_48x48_at_1
+    title.illustration_48x48_at_1 = (
+        normalize_illustration(payload.illustration_48x48_at_1)
+        if payload.illustration_48x48_at_1
+        else None
+    )
     title.license = payload.license
     title.relation = payload.relation
     title.source = payload.source
@@ -396,6 +401,10 @@ def update_title(
     update_data = payload.model_dump(
         exclude_unset=True, exclude={"collection_titles", "comment"}, mode="json"
     )
+    if update_data.get("illustration_48x48_at_1"):
+        update_data["illustration_48x48_at_1"] = normalize_illustration(
+            update_data["illustration_48x48_at_1"]
+        )
     name_changed = payload.name is not None and payload.name != title.name
 
     if update_data:

--- a/backend/src/cms_backend/utils/zim.py
+++ b/backend/src/cms_backend/utils/zim.py
@@ -154,7 +154,7 @@ def normalize_illustration(image_base64: str):
     # Save image without any metadata
     buffer = io.BytesIO()
     new_img = Image.new(image.mode, image.size)
-    new_img.putdata(image.get_flattened_data())
+    new_img.putdata(image.get_flattened_data())  # pyright: ignore[reportUnknownMemberType]
     new_img.save(buffer, format="PNG")
     buffer.seek(0)
     return base64.b64encode(buffer.getvalue()).decode()

--- a/backend/src/cms_backend/utils/zim.py
+++ b/backend/src/cms_backend/utils/zim.py
@@ -1,9 +1,16 @@
+import base64
+import io
 import re
 from typing import Any
+
+from PIL import Image, ImageFile
 
 from cms_backend import logger
 from cms_backend.context import parse_bool
 from cms_backend.schemas.orms import ZimcheckSummarySchema
+
+# https://github.com/python-pillow/Pillow/issues/1510#issuecomment-151458026
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 
 def get_missing_keys(payload: dict[str, Any], *keys: str) -> list[str]:
@@ -139,3 +146,15 @@ def parse_zimcheck_result(zimcheck: dict[str, Any]) -> ZimcheckSummarySchema:
         except Exception:
             logger.exception("encountered error while parsing zimcheck logs")
     return ZimcheckSummarySchema()
+
+
+def normalize_illustration(image_base64: str):
+    image_bytes = base64.b64decode(image_base64, validate=True)
+    image = Image.open(io.BytesIO(image_bytes))
+    # Save image without any metadata
+    buffer = io.BytesIO()
+    new_img = Image.new(image.mode, image.size)
+    new_img.putdata(image.get_flattened_data())
+    new_img.save(buffer, format="PNG")
+    buffer.seek(0)
+    return base64.b64encode(buffer.getvalue()).decode()

--- a/backend/tests/api/routes/test_titles.py
+++ b/backend/tests/api/routes/test_titles.py
@@ -23,6 +23,7 @@ from cms_backend.db.title import update_title
 from cms_backend.roles import RoleEnum
 from cms_backend.schemas.models import TitleUpdateSchema
 from cms_backend.utils.datetime import getnow
+from cms_backend.utils.zim import normalize_illustration
 
 
 def test_get_titles_empty(client: TestClient):
@@ -145,7 +146,9 @@ def test_create_title_required_fields_only(
     assert data["publisher"] == "Kiwix"
     assert data["language"] == "eng"
     assert data["description"] == "A free encyclopedia"
-    assert data["illustration_48x48_at_1"] == illustration_48x48_at_1
+    assert data["illustration_48x48_at_1"] == normalize_illustration(
+        illustration_48x48_at_1
+    )
 
     # Verify the title was created in the database
     title = dbsession.get(Title, data["id"])
@@ -210,7 +213,9 @@ def test_create_title_all_fields(
     assert data["language"] == "eng"
     assert data["description"] == "A free encyclopedia"
     assert data["long_description"] == "Wikipedia is a free online encyclopedia."
-    assert data["illustration_48x48_at_1"] == illustration_48x48_at_1
+    assert data["illustration_48x48_at_1"] == normalize_illustration(
+        illustration_48x48_at_1
+    )
     assert data["license"] == "CC-BY-SA"
     assert data["relation"] == "wikipedia"
     assert data["source"] == "https://en.wikipedia.org"
@@ -225,7 +230,9 @@ def test_create_title_all_fields(
     assert title.language == "eng"
     assert title.description == "A free encyclopedia"
     assert title.long_description == "Wikipedia is a free online encyclopedia."
-    assert title.illustration_48x48_at_1 == illustration_48x48_at_1
+    assert title.illustration_48x48_at_1 == normalize_illustration(
+        illustration_48x48_at_1
+    )
     assert title.license == "CC-BY-SA"
     assert title.relation == "wikipedia"
     assert title.source == "https://en.wikipedia.org"
@@ -541,7 +548,9 @@ def test_update_title_metadata(
     assert data["language"] == "eng"
     assert data["description"] == "A free encyclopedia"
     assert data["long_description"] == "Wikipedia is a free online encyclopedia."
-    assert data["illustration_48x48_at_1"] == illustration_48x48_at_1
+    assert data["illustration_48x48_at_1"] == normalize_illustration(
+        illustration_48x48_at_1
+    )
     assert data["license"] == "CC-BY-SA"
     assert data["relation"] == "wikipedia"
     assert data["source"] == "https://en.wikipedia.org"
@@ -554,7 +563,9 @@ def test_update_title_metadata(
     assert title.language == "eng"
     assert title.description == "A free encyclopedia"
     assert title.long_description == "Wikipedia is a free online encyclopedia."
-    assert title.illustration_48x48_at_1 == illustration_48x48_at_1
+    assert title.illustration_48x48_at_1 == normalize_illustration(
+        illustration_48x48_at_1
+    )
     assert title.license == "CC-BY-SA"
     assert title.relation == "wikipedia"
     assert title.source == "https://en.wikipedia.org"

--- a/backend/tests/db/test_title.py
+++ b/backend/tests/db/test_title.py
@@ -29,6 +29,7 @@ from cms_backend.db.title import (
 )
 from cms_backend.schemas.models import TitleUpdateSchema
 from cms_backend.schemas.orms import BaseTitleCollectionSchema
+from cms_backend.utils.zim import normalize_illustration
 
 
 def test_get_title_by_name_or_none(
@@ -309,7 +310,9 @@ def test_update_title_metadata(
     assert updated_title.language == "eng"
     assert updated_title.description == "A free encyclopedia"
     assert updated_title.long_description == "Wikipedia is a free online encyclopedia."
-    assert updated_title.illustration_48x48_at_1 == illustration_48x48_at_1
+    assert updated_title.illustration_48x48_at_1 == normalize_illustration(
+        illustration_48x48_at_1
+    )
     assert updated_title.license == "CC-BY-SA"
     assert updated_title.relation == "wikipedia"
     assert updated_title.source == "https://en.wikipedia.org"
@@ -507,7 +510,9 @@ def test_revert_title(
     assert reverted_title.language == "eng"
     assert reverted_title.description == "Description V1"
     assert reverted_title.long_description == "Long description V1"
-    assert reverted_title.illustration_48x48_at_1 == illustration_48x48_at_1
+    assert reverted_title.illustration_48x48_at_1 == normalize_illustration(
+        illustration_48x48_at_1
+    )
     assert reverted_title.license == "CC-BY-SA 3.0"
     assert reverted_title.relation == "wikipedia_v1"
     assert reverted_title.source == "https://en.wikipedia.org/v1"


### PR DESCRIPTION
## Changes
- normalize book illustrations when they arrive from cms by stripping away all metadata
- use same normalization when title is created/updated
- add maint-script to normalize existing books, titles and title history in database. output of nromalization is always the same no matter how many times run

This fixes #320 