### PR TITLE
update book issues when issues are fetched from API

### DIFF
--- a/backend/src/cms_backend/api/routes/books.py
+++ b/backend/src/cms_backend/api/routes/books.py
@@ -13,7 +13,6 @@ from cms_backend.api.routes.models import ListResponse, calculate_pagination_met
 from cms_backend.db import gen_dbsession
 from cms_backend.db.book import backup_book as db_backup_book
 from cms_backend.db.book import (
-    can_compute_book_issues,
     create_book_full_schema,
     create_book_history_schema,
 )
@@ -21,12 +20,12 @@ from cms_backend.db.book import delete_book as db_delete_book
 from cms_backend.db.book import get_book as db_get_book
 from cms_backend.db.book import get_book_history as db_get_book_history
 from cms_backend.db.book import get_book_history_entry as db_get_book_history_entry
-from cms_backend.db.book import get_book_issues as db_get_book_issues
 from cms_backend.db.book import move_book as db_move_book
 from cms_backend.db.book import recover_book as db_recover_book
 from cms_backend.db.book import remove_book_backup as db_remove_book_backup
 from cms_backend.db.book import revert_book as db_revert_book
 from cms_backend.db.book import update_book as db_update_book
+from cms_backend.db.book import update_book_issues as db_update_book_issues
 from cms_backend.db.books import get_book_flavours as db_get_book_flavours
 from cms_backend.db.books import get_book_languages as db_get_book_languages
 from cms_backend.db.books import get_books as db_get_books
@@ -216,19 +215,17 @@ def backup_book(
     return create_book_full_schema(db_backup_book(session, book_id=book_id))
 
 
-@router.get("/{book_id}/issues")
+@router.get(
+    "/{book_id}/issues",
+    dependencies=[Depends(require_permission(namespace="book", name="update"))],
+)
 def get_book_issues(
     book_id: Annotated[UUID, Path()],
     session: OrmSession = Depends(gen_dbsession),
 ) -> JSONResponse:
     book = db_get_book(session, book_id)
-    if not can_compute_book_issues(book):
-        issues = {}
-    else:
-        issues = db_get_book_issues(session, book)
-
     return JSONResponse(
-        content=issues,
+        content=db_update_book_issues(session, book),
         status_code=HTTPStatus.OK,
     )
 

--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -726,7 +726,7 @@ def update_book_issues(
     *,
     update_events: bool = False,
     raise_exceptions: bool = False,
-):
+) -> dict[str, list[str]]:
     """
     Update book issues based on it's associated title and optionally update book events.
 
@@ -735,21 +735,21 @@ def update_book_issues(
     """
 
     if not can_compute_book_issues(book):
-        return
+        return {}
 
-    issues = list(
-        get_book_issues(session, book, raise_exceptions=raise_exceptions).keys()
-    )
-    book.issues = issues
+    issues = get_book_issues(session, book, raise_exceptions=raise_exceptions)
+    issue_keys = list(issues.keys())
+    book.issues = issue_keys
     if update_events and book_is_whitelisted_from_zimcheck(book):
         book.events.append(f"{getnow()}: book is whitelisted for zimcheck quality")
-    if update_events and issues:
+    if update_events and issue_keys:
         book.events.append(
-            f"{getnow()}: book has the following issues: {','.join(issues)}"
+            f"{getnow()}: book has the following issues: {','.join(issue_keys)}"
         )
 
     session.add(book)
     session.flush()
+    return issues
 
 
 def get_zimcheck_errors(book: Book, *, raise_exceptions: bool = False) -> list[str]:

--- a/backend/tests/api/routes/test_books.py
+++ b/backend/tests/api/routes/test_books.py
@@ -698,15 +698,29 @@ def test_remove_book_backup_required_permissions(
     assert response.status_code == expected_status_code
 
 
+@pytest.mark.parametrize(
+    "permission,expected_status_code",
+    [
+        pytest.param(RoleEnum.EDITOR, HTTPStatus.OK, id="editor"),
+        pytest.param(RoleEnum.VIEWER, HTTPStatus.UNAUTHORIZED, id="viewer"),
+    ],
+)
 def test_get_book_issues(
     client: TestClient,
     dbsession: OrmSession,
+    create_account: Callable[..., Account],
     create_book: Callable[..., Book],
     create_title: Callable[..., Title],
     create_collection: Callable[..., Collection],
     create_book_location: Callable[..., BookLocation],
     create_warehouse: Callable[..., Warehouse],
+    permission: RoleEnum,
+    expected_status_code: HTTPStatus,
 ):
+    account = create_account(permission=permission)
+    access_token = generate_access_token(
+        account_id=str(account.id), issue_time=getnow()
+    )
     warehouse = create_warehouse()
     content = {
         "Name": "test_en_all",
@@ -769,5 +783,6 @@ def test_get_book_issues(
 
     response = client.get(
         f"/v1/books/{book.id}/issues",
+        headers={"Authorization": f"Bearer {access_token}"},
     )
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == expected_status_code

--- a/frontend/src/components/BookStatus.vue
+++ b/frontend/src/components/BookStatus.vue
@@ -78,7 +78,7 @@
           <v-list-item-title class="text-wrap">{{ warning }}</v-list-item-title>
         </v-list-item>
 
-        <div>
+        <div v-if="canViewBookIssues">
           <v-divider class="my-0" />
           <v-btn
             color="primary"
@@ -103,6 +103,13 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { Book, BookLight } from '@/types/book'
+import { useAuthStore } from '@/stores/auth'
+
+const authStore = useAuthStore()
+
+const canViewBookIssues = computed(() => {
+  return authStore.hasPermission('book', 'update')
+})
 
 const menuOpen = ref(false)
 

--- a/frontend/src/views/BookView.vue
+++ b/frontend/src/views/BookView.vue
@@ -177,6 +177,7 @@
 
         <v-tab
           base-color="primary"
+          v-if="canViewBookIssues"
           value="issues"
           :to="{
             name: 'book-detail-tab',
@@ -806,6 +807,10 @@ const canEditBook = computed(() => {
     !book.value.title_archived &&
     book.value.location_kind != 'deleted'
   )
+})
+
+const canViewBookIssues = computed(() => {
+  return authStore.hasPermission('book', 'update')
 })
 
 const canMoveBook = computed(() => {


### PR DESCRIPTION
## Changes
- restrict API/UI to view book issues to accounts with `update` permissions on `book`
- update book issues when API to fetch book issues is called

This closes #381 