### PR TITLE
show illustration file sizes in bytes

### DIFF
--- a/frontend/src/components/InlineImageEditor.vue
+++ b/frontend/src/components/InlineImageEditor.vue
@@ -187,9 +187,16 @@
       </div>
     </v-sheet>
 
-    <!-- Description -->
-    <div v-if="description" class="text-caption text-grey mt-2">
-      {{ description }}
+    <!-- Description & File Size -->
+    <div
+      v-if="description || (showPreview && fileSizeText)"
+      class="d-flex align-center justify-space-between mt-2"
+    >
+      <span v-if="description" class="text-caption text-grey">{{ description }}</span>
+      <span v-else />
+      <span v-if="showPreview && fileSizeText" class="text-caption text-grey-darken-1">{{
+        fileSizeText
+      }}</span>
     </div>
 
     <!-- Error Message -->
@@ -213,6 +220,7 @@
 import { ref, computed, watch } from 'vue'
 import { Cropper } from 'vue-advanced-cropper'
 import 'vue-advanced-cropper/dist/style.css'
+import { base64ByteSize } from '@/utils/format'
 
 interface Props {
   modelValue?: string | null
@@ -259,6 +267,11 @@ const dimensionsText = computed(() => {
     return `${imageDimensions.value.width} × ${imageDimensions.value.height} px`
   }
   return ''
+})
+
+const fileSizeText = computed(() => {
+  if (!internalImageData.value) return ''
+  return `${base64ByteSize(internalImageData.value)} bytes`
 })
 
 const detectMimeTypeFromDataUrl = (dataUrl: string): string => {

--- a/frontend/src/components/TitleForm.vue
+++ b/frontend/src/components/TitleForm.vue
@@ -278,12 +278,17 @@
               Different from latest book which has:
             </div>
             <div class="d-flex align-center justify-space-between mb-2">
-              <v-img
-                :src="getImageDataUrl(bookMetadata?.illustration_48x48_at_1)"
-                width="48"
-                height="48"
-                class="rounded border"
-              />
+              <div class="d-flex flex-column flex-grow-1">
+                <v-img
+                  :src="getImageDataUrl(bookMetadata?.illustration_48x48_at_1)"
+                  width="48"
+                  height="48"
+                  class="rounded border w-100"
+                />
+                <span class="text-caption text-grey-darken-1 mt-1">
+                  {{ bookIllustrationSize }}
+                </span>
+              </div>
               <v-btn
                 size="small"
                 variant="outlined"
@@ -472,6 +477,7 @@ import { computed, inject, ref, watch } from 'vue'
 import { byGrapheme } from 'split-by-grapheme'
 import constants from '@/constants'
 import type { Config } from '@/config'
+import { base64ByteSize } from '@/utils/format'
 
 interface Props {
   title?: Title | null
@@ -629,6 +635,12 @@ const getImageDataUrl = (base64String: string | undefined): string | undefined =
   }
   return `data:image/png;base64,${base64String}`
 }
+
+const bookIllustrationSize = computed(() => {
+  const illustration = bookMetadata.value?.illustration_48x48_at_1
+  if (!illustration) return ''
+  return `${base64ByteSize(illustration)} bytes`
+})
 
 const collectionNames = computed(() => {
   return collectionsStore.collections.map((collection) => collection.name)

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -20,3 +20,23 @@ export function formatDt(value?: string, format: string = 'fff') {
 export function formattedBytesSize(value: number) {
   return filesize(value, { base: 2, standard: 'iec', precision: 3 }) // display in KiB, MiB,... instead of KB, MB,...
 }
+
+/**
+ * Calculate the byte size of base64-encoded data.
+ */
+export function base64ByteSize(base64String: string): number {
+  const base64 = base64String.includes(',') ? base64String.split(',')[1] : base64String
+  if (!base64) return 0
+  // Each base64 character represents 6 bits; 4 chars = 3 bytes
+  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0
+  return (base64.length * 3) / 4 - padding
+}
+
+/**
+ * Return a human-readable file size for base64-encoded data.
+ */
+export function base64FormattedSize(base64String: string): string {
+  const bytes = base64ByteSize(base64String)
+  if (bytes === 0) return ''
+  return formattedBytesSize(bytes)
+}


### PR DESCRIPTION
## Changes
- show illustration file sizes in bytes both in title form and inline image editor

<img width="990" height="378" alt="Screenshot_20260629_124230" src="https://github.com/user-attachments/assets/9e0a961c-0918-45ee-881d-c3813871393e" />
<img width="1026" height="180" alt="Screenshot_20260629_124215" src="https://github.com/user-attachments/assets/06d46817-9f16-4137-8504-9722f7975ffa" />
