### PR TITLE
allow empty flavours

### DIFF
--- a/backend/src/cms_backend/api/routes/fields.py
+++ b/backend/src/cms_backend/api/routes/fields.py
@@ -124,7 +124,7 @@ LangCode = Annotated[
 ]
 
 ZimFlavour = Annotated[
-    NotEmptyString,
+    str,
     WrapValidator(skip_validation),
     AfterValidator(validate_zim_flavour),
 ]

--- a/backend/src/cms_backend/schemas/models.py
+++ b/backend/src/cms_backend/schemas/models.py
@@ -150,4 +150,4 @@ class TitleUpdateSchema(BaseTitleCreateUpdateSchema):
 
 class BookUpdateSchema(BaseModel):
     comment: NotEmptyString | None = None
-    flavour: NotEmptyString | None = None
+    flavour: str | None = None

--- a/frontend/src/components/EditBookForm.vue
+++ b/frontend/src/components/EditBookForm.vue
@@ -8,7 +8,6 @@
               v-model="localBook.flavour"
               label="Flavour"
               :items="formattedFlavourOptions"
-              :rules="[rules.required]"
               variant="outlined"
               :loading="loadingFlavours"
               :disabled="loading"
@@ -58,12 +57,8 @@ const formRef = ref()
 const formValid = ref(false)
 
 const localBook = ref({
-  flavour: props.book?.flavour || '',
+  flavour: props.book?.flavour,
 })
-
-const rules = {
-  required: (value: string) => !!value || 'This field is required',
-}
 
 const isDisabled = computed(() => {
   return props.loading || !hasChanges.value || !formValid.value
@@ -71,7 +66,7 @@ const isDisabled = computed(() => {
 
 const formattedFlavourOptions = computed(() => {
   return props.flavourOptions.map((option) => ({
-    title: option,
+    title: option == '' ? 'Empty' : option,
     value: option,
   }))
 })
@@ -86,7 +81,7 @@ watch(
   (newBook) => {
     if (newBook) {
       localBook.value = {
-        flavour: newBook.flavour || '',
+        flavour: newBook.flavour,
       }
       // Reset form validation when book changes
       formRef.value?.resetValidation()
@@ -97,7 +92,7 @@ watch(
 
 const handleSubmit = async () => {
   const { valid } = await formRef.value.validate()
-  if (valid) {
+  if (valid && typeof localBook.value.flavour === 'string') {
     emit('submit', {
       flavour: localBook.value.flavour,
     })

--- a/frontend/src/components/TitleForm.vue
+++ b/frontend/src/components/TitleForm.vue
@@ -51,7 +51,11 @@
             :items="availableFlavours"
             :loading="loadingFlavours"
             :rules="[rules.flavours]"
-          />
+          >
+            <template #item="{ props, item }">
+              <v-list-item v-bind="props" :title="item.title === '' ? 'Empty' : item.title" />
+            </template>
+          </v-combobox>
         </v-col>
       </v-row>
     </div>
@@ -790,7 +794,7 @@ const rules = {
   flavours: (value: string | string[]) => {
     if (!value || (Array.isArray(value) && value.length === 0)) return true
     const flavours = Array.isArray(value) ? value : [value]
-    const invalid = flavours.filter((f) => f && !/^[a-zA-Z]+$/.test(f))
+    const invalid = flavours.filter((f) => !/^[a-zA-Z]*$/.test(f))
     if (invalid.length > 0) {
       return `Flavours must contain only alphabetic characters. Invalid: ${invalid.join(', ')}`
     }
@@ -925,7 +929,7 @@ async function fetchFlavours() {
   try {
     const flavours = await bookStore.fetchBookFlavours()
     if (flavours) {
-      availableFlavours.value = flavours
+      availableFlavours.value = Array.from(new Set(['', ...flavours]))
     }
   } catch (err) {
     console.error('Failed to fetch flavours', err)

--- a/frontend/src/views/BookView.vue
+++ b/frontend/src/views/BookView.vue
@@ -309,7 +309,9 @@
                   </v-col>
                   <v-col cols="12" md="9">
                     <div>
-                      <span v-if="book.flavour">{{ book.flavour }}</span>
+                      <span v-if="book.flavour !== null">{{
+                        book.flavour == '' ? 'Empty' : book.flavour
+                      }}</span>
                       <span v-else class="text-grey">-</span>
                       <v-tooltip v-if="book.has_flavour_mismatch" location="top">
                         <template #activator="{ props: tooltipProps }">
@@ -965,7 +967,7 @@ const titleDataFromBook = computed<Title | null>(() => {
     license: (metadata.License as string | null | undefined) || null,
     relation: (metadata.Relation as string | null | undefined) || null,
     source: (metadata.Source as string | null | undefined) || null,
-    flavours: book.value.flavour ? [book.value.flavour] : [],
+    flavours: book.value.flavour != null ? [book.value.flavour] : [],
     events: [],
     books: [],
     collections: [],
@@ -1306,7 +1308,7 @@ watch(
       loadingFlavours.value = true
       const fetchedFlavours = await bookStore.fetchBookFlavours()
       if (fetchedFlavours) {
-        flavours.value = fetchedFlavours
+        flavours.value = Array.from(new Set(['', ...fetchedFlavours]))
       }
       loadingFlavours.value = false
     }

--- a/frontend/src/views/TitleView.vue
+++ b/frontend/src/views/TitleView.vue
@@ -142,7 +142,7 @@
                         color="primary"
                         class="mr-2 mb-1"
                       >
-                        {{ flavour }}
+                        {{ flavour == '' ? 'Empty' : flavour }}
                       </v-chip>
                     </div>
                     <span v-else class="text-grey">No flavours set</span>


### PR DESCRIPTION
## Changes
- allow flavour value sent via create/update for title to be empty string
- allow flavour value for book update to be empty string
- show empty option with label `Empty`

<img width="992" height="490" alt="Screenshot_20260706_161602" src="https://github.com/user-attachments/assets/ba219539-c18c-4cac-a592-9bd185c6d220" />
<img width="1052" height="591" alt="Screenshot_20260706_161520" src="https://github.com/user-attachments/assets/4a136c65-901f-4203-9e3a-27aeafa57e8e" />
<img width="711" height="349" alt="Screenshot_20260706_161504" src="https://github.com/user-attachments/assets/36aa269d-1fc5-4f21-8d06-51df4f801cd7" />


This closes #407 