### PR TITLE
encapsulate location kinds in status filter

### DIFF
--- a/frontend/src/components/BookTable.vue
+++ b/frontend/src/components/BookTable.vue
@@ -166,7 +166,7 @@ interface Props {
   loadingText?: string
   filters?: {
     name: string
-    location_kind: string
+    status: string
     flag: string
   }
   isServerSide?: boolean
@@ -182,7 +182,7 @@ const props = withDefaults(defineProps<Props>(), {
   loading: false,
   errors: () => [],
   loadingText: 'Fetching books...',
-  filters: () => ({ name: '', location_kind: '', flag: '' }),
+  filters: () => ({ name: '', status: 'active', flag: '' }),
   isServerSide: true,
   showUrls: false,
   loadingUrls: false,

--- a/frontend/src/components/BooksBaseView.vue
+++ b/frontend/src/components/BooksBaseView.vue
@@ -105,7 +105,7 @@ const bookFilters = computed(() => {
   const derived = {
     name: '',
     flavour: '',
-    location_kind: '',
+    status: 'active',
   }
 
   if (query.name && typeof query.name === 'string') {
@@ -116,8 +116,8 @@ const bookFilters = computed(() => {
     derived.flavour = query.flavour
   }
 
-  if (query.location_kind && typeof query.location_kind === 'string') {
-    derived.location_kind = query.location_kind
+  if (query.status && typeof query.status === 'string') {
+    derived.status = query.status
   }
 
   return derived
@@ -140,6 +140,27 @@ const backupTooltipText = computed(() => {
   return count === 1 ? '1 matching backup book' : `${count} matching backup books`
 })
 
+function statusToLocationKinds(status: string): string[] | undefined {
+  switch (status) {
+    case 'active':
+      return ['quarantine', 'staging', 'prod']
+    case 'quarantine':
+      return ['quarantine']
+    case 'staging':
+      return ['staging']
+    case 'prod':
+      return ['prod']
+    case 'to_delete':
+      return ['to_delete']
+    case 'deleted':
+      return ['deleted']
+    case 'all':
+      return undefined
+    default:
+      return ['quarantine', 'staging', 'prod']
+  }
+}
+
 async function loadData(limit: number, skip: number, hideLoading: boolean = false) {
   if (!hideLoading) {
     loadingStore.startLoading('Fetching books...')
@@ -153,7 +174,7 @@ async function loadData(limit: number, skip: number, hideLoading: boolean = fals
     skip,
     undefined,
     undefined,
-    bookFilters.value.location_kind ? [bookFilters.value.location_kind] : undefined,
+    statusToLocationKinds(bookFilters.value.status),
     undefined, // flag not used in this view
     bookFilters.value.name || undefined,
     bookFilters.value.flavour || undefined,
@@ -214,8 +235,8 @@ function updateUrlFilters(sourceFilters: typeof bookFilters.value) {
     query.flavour = sourceFilters.flavour
   }
 
-  if (sourceFilters.location_kind) {
-    query.location_kind = sourceFilters.location_kind
+  if (sourceFilters.status && sourceFilters.status !== 'active') {
+    query.status = sourceFilters.status
   }
 
   router.push({
@@ -225,7 +246,7 @@ function updateUrlFilters(sourceFilters: typeof bookFilters.value) {
 }
 
 async function clearFilters() {
-  updateUrlFilters({ name: '', flavour: '', location_kind: '' })
+  updateUrlFilters({ name: '', flavour: '', status: 'active' })
 }
 
 async function handleBookFiltersChange(newFilters: typeof bookFilters.value) {
@@ -241,7 +262,7 @@ async function fetchBackupCount() {
     backupCount.value = await bookStore.countBooks(
       undefined,
       undefined,
-      currentFilters.location_kind ? [currentFilters.location_kind] : undefined,
+      statusToLocationKinds(currentFilters.status),
       undefined,
       currentFilters.name || undefined,
       currentFilters.flavour || undefined,
@@ -261,7 +282,7 @@ function navigateToBackups() {
 
   if (currentFilters.name) query.name = currentFilters.name
   if (currentFilters.flavour) query.flavour = currentFilters.flavour
-  if (currentFilters.location_kind) query.location_kind = currentFilters.location_kind
+  if (currentFilters.status !== 'active') query.status = currentFilters.status
 
   router.push({
     name: 'backup-books',

--- a/frontend/src/components/BooksViewFilters.vue
+++ b/frontend/src/components/BooksViewFilters.vue
@@ -29,14 +29,12 @@
         </v-col>
         <v-col cols="12" sm="6" md="4">
           <v-select
-            v-model="localFilters.location_kind"
-            label="Location"
-            :items="formattedLocationKindOptions"
-            placeholder="Select location kind"
+            v-model="localFilters.status"
+            label="Status"
+            :items="statusOptions"
             variant="outlined"
             density="compact"
             hide-details
-            clearable
             @update:model-value="emitFilters"
           />
         </v-col>
@@ -63,15 +61,13 @@ interface Props {
   filters: {
     name: string
     flavour: string
-    location_kind: string
+    status: string
   }
-  locationKindOptions?: string[]
   flavourOptions?: string[]
   loadingFlavours?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  locationKindOptions: () => ['quarantine', 'staging', 'prod'],
   flavourOptions: () => [],
   loadingFlavours: false,
 })
@@ -82,7 +78,7 @@ const emit = defineEmits<{
     filters: {
       name: string
       flavour: string
-      location_kind: string
+      status: string
     },
   ]
   clearFilters: []
@@ -92,7 +88,7 @@ const emit = defineEmits<{
 const localFilters = ref({
   name: props.filters.name,
   flavour: props.filters.flavour,
-  location_kind: props.filters.location_kind,
+  status: props.filters.status,
 })
 
 // Watch for prop changes and update local state
@@ -102,17 +98,10 @@ watch(
     localFilters.value = {
       name: newFilters.name,
       flavour: newFilters.flavour,
-      location_kind: newFilters.location_kind,
+      status: newFilters.status,
     }
   },
 )
-
-const formattedLocationKindOptions = computed(() => {
-  return props.locationKindOptions.map((option) => ({
-    title: option.charAt(0).toUpperCase() + option.slice(1),
-    value: option,
-  }))
-})
 
 const formattedFlavourOptions = computed(() => {
   return props.flavourOptions.map((option) => ({
@@ -121,11 +110,21 @@ const formattedFlavourOptions = computed(() => {
   }))
 })
 
+const statusOptions = [
+  { title: 'Active', value: 'active' },
+  { title: 'Quarantine', value: 'quarantine' },
+  { title: 'Staging', value: 'staging' },
+  { title: 'Published', value: 'prod' },
+  { title: 'To Be Deleted', value: 'to_delete' },
+  { title: 'Deleted', value: 'deleted' },
+  { title: 'All', value: 'all' },
+]
+
 const hasActiveFilters = computed(() => {
   return (
     props.filters.name.length > 0 ||
     props.filters.flavour.length > 0 ||
-    props.filters.location_kind.length > 0
+    props.filters.status !== 'active'
   )
 })
 
@@ -134,7 +133,7 @@ function emitFilters() {
   emit('filtersChanged', {
     name: localFilters.value.name,
     flavour: localFilters.value.flavour,
-    location_kind: localFilters.value.location_kind,
+    status: localFilters.value.status,
   })
 }
 

--- a/frontend/src/components/InboxBookFilters.vue
+++ b/frontend/src/components/InboxBookFilters.vue
@@ -15,14 +15,12 @@
         </v-col>
         <v-col cols="12" sm="6" md="4">
           <v-select
-            v-model="localFilters.location_kind"
-            label="Location"
-            :items="formattedLocationKindOptions"
-            placeholder="Select location kind"
+            v-model="localFilters.status"
+            label="Status"
+            :items="statusOptions"
             variant="outlined"
             density="compact"
             hide-details
-            clearable
             @update:model-value="emitFilters"
           />
         </v-col>
@@ -87,17 +85,15 @@ import { computed, ref, watch } from 'vue'
 interface Props {
   filters: {
     name: string
-    location_kind: string
+    status: string
     flag: string
     offliner: string
     issue: string
   }
-  locationKindOptions?: string[]
   offlinerOptions?: string[]
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  locationKindOptions: () => [],
   offlinerOptions: () => [],
 })
 
@@ -106,7 +102,7 @@ const emit = defineEmits<{
   filtersChanged: [
     filters: {
       name: string
-      location_kind: string
+      status: string
       flag: string
       offliner: string
       issue: string
@@ -118,7 +114,7 @@ const emit = defineEmits<{
 // Local filters state
 const localFilters = ref({
   name: props.filters.name,
-  location_kind: props.filters.location_kind,
+  status: props.filters.status,
   flag: props.filters.flag,
   offliner: props.filters.offliner,
   issue: props.filters.issue,
@@ -130,7 +126,7 @@ watch(
   (newFilters) => {
     localFilters.value = {
       name: newFilters.name,
-      location_kind: newFilters.location_kind,
+      status: newFilters.status,
       flag: newFilters.flag,
       offliner: newFilters.offliner,
       issue: newFilters.issue,
@@ -138,19 +134,21 @@ watch(
   },
 )
 
-const formattedLocationKindOptions = computed(() => {
-  return props.locationKindOptions.map((option) => ({
-    title: option.charAt(0).toUpperCase() + option.slice(1),
-    value: option,
-  }))
-})
-
 const formattedOfflinerOptions = computed(() => {
   return props.offlinerOptions.map((option) => ({
     title: option,
     value: option,
   }))
 })
+
+const statusOptions = [
+  { title: 'Active', value: 'active' },
+  { title: 'Quarantine', value: 'quarantine' },
+  { title: 'Staging', value: 'staging' },
+  { title: 'To Be Deleted', value: 'to_delete' },
+  { title: 'Deleted', value: 'deleted' },
+  { title: 'All', value: 'all' },
+]
 
 const flagOptions = [
   { title: 'Needs File Operation', value: 'needs_file_operation' },
@@ -171,18 +169,17 @@ const issueOptions = [
 const hasActiveFilters = computed(() => {
   return (
     props.filters.name.length > 0 ||
-    props.filters.location_kind.length > 0 ||
+    props.filters.status !== 'active' ||
     props.filters.flag?.length > 0 ||
     props.filters.offliner.length > 0 ||
     props.filters.issue?.length > 0
   )
 })
 
-// Emit filters when they change
 function emitFilters() {
   emit('filtersChanged', {
     name: localFilters.value.name,
-    location_kind: localFilters.value.location_kind,
+    status: localFilters.value.status,
     flag: localFilters.value.flag,
     offliner: localFilters.value.offliner,
     issue: localFilters.value.issue,

--- a/frontend/src/types/book.ts
+++ b/frontend/src/types/book.ts
@@ -1,5 +1,9 @@
 export type LocationKind = 'quarantine' | 'staging' | 'prod' | 'to_delete' | 'deleted'
 
+export type BookStatus = 'active' | 'deleted' | 'to_delete' | 'all'
+
+export const ACTIVE_LOCATION_KINDS: LocationKind[] = ['quarantine', 'staging', 'prod']
+
 export type BookPromotionActionKind =
   | 'unknown_languages'
   | 'zimcheck_issues'

--- a/frontend/src/views/InboxView.vue
+++ b/frontend/src/views/InboxView.vue
@@ -5,7 +5,6 @@
   <InboxBookFilters
     v-if="currentTab == 'books'"
     :filters="bookFilters"
-    :location-kind-options="['quarantine', 'staging']"
     :offliner-options="offlinerStore.offliners"
     @filters-changed="handleBookFiltersChange"
     @clear-filters="clearFilters"
@@ -165,7 +164,7 @@ const errors = ref<string[]>([])
 const bookFilters = computed(() => {
   const query = router.currentRoute.value.query
   const derived = {
-    location_kind: '',
+    status: 'active',
     name: '',
     flag: '',
     offliner: '',
@@ -175,8 +174,8 @@ const bookFilters = computed(() => {
     derived.name = query.name
   }
 
-  if (query.location_kind && typeof query.location_kind === 'string') {
-    derived.location_kind = query.location_kind
+  if (query.status && typeof query.status === 'string') {
+    derived.status = query.status
   }
 
   if (query.flag && typeof query.flag === 'string') {
@@ -220,6 +219,25 @@ const eventFilters = computed(() => {
 
 const intervalId = ref<number | null>(null)
 
+function statusToLocationKinds(status: string): string[] | undefined {
+  switch (status) {
+    case 'active':
+      return ['quarantine', 'staging', 'prod']
+    case 'quarantine':
+      return ['quarantine']
+    case 'staging':
+      return ['staging']
+    case 'to_delete':
+      return ['to_delete']
+    case 'deleted':
+      return ['deleted']
+    case 'all':
+      return undefined
+    default:
+      return ['quarantine', 'staging', 'prod']
+  }
+}
+
 const handleTabChange = (newTab: string) => {
   // Navigate to the new tab route
   router.push({
@@ -261,7 +279,7 @@ async function loadData(limit: number, skip: number, tab?: string, hideLoading: 
         skip,
         true,
         undefined, // id not used in inbox
-        bookFilters.value.location_kind ? [bookFilters.value.location_kind] : undefined,
+        statusToLocationKinds(bookFilters.value.status),
         bookFilters.value.flag || undefined,
         bookFilters.value.name || undefined,
         undefined, // flavour not used in inbox
@@ -350,8 +368,8 @@ function updateUrlFilters(
     query.id = sourceFilters.id
   }
 
-  if ('location_kind' in sourceFilters && sourceFilters.location_kind) {
-    query.location_kind = sourceFilters.location_kind
+  if ('status' in sourceFilters && sourceFilters.status !== 'active') {
+    query.status = sourceFilters.status
   }
 
   if ('flag' in sourceFilters && sourceFilters.flag) {
@@ -395,7 +413,7 @@ async function loadZimUrls() {
 async function clearFilters() {
   switch (currentTab.value) {
     case 'books':
-      updateUrlFilters({ name: '', location_kind: '', flag: '', offliner: '', issue: '' })
+      updateUrlFilters({ name: '', status: 'active', flag: '', offliner: '', issue: '' })
       break
     case 'zimfarm_notifications':
       updateUrlFilters({ id: '' })

--- a/frontend/src/views/TitleView.vue
+++ b/frontend/src/views/TitleView.vue
@@ -284,9 +284,19 @@
                     <div class="text-subtitle-2">Books</div>
                   </v-col>
                   <v-col cols="12" md="9">
-                    <v-row v-if="title.books.length > 0">
+                    <v-select
+                      v-model="bookStatusFilter"
+                      label="Book Status"
+                      :items="bookStatusOptions"
+                      variant="outlined"
+                      density="compact"
+                      hide-details
+                      class="my-3 my-md-0 mb-md-3"
+                      style="max-width: 250px"
+                    />
+                    <v-row v-if="filteredBooks.length > 0">
                       <v-col
-                        v-for="book in sortedBooks"
+                        v-for="book in filteredBooks"
                         :key="book.id"
                         cols="12"
                         sm="12"
@@ -459,7 +469,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useZimfarmOfflinerStore } from '@/stores/zimfarm/offliner'
 import { useTitleHistoryStore } from '@/stores/titleHistory'
 import type { Title, TitleUpdate } from '@/types/title'
-import type { Book, ZimUrl } from '@/types/book'
+import type { Book, BookStatus, ZimUrl } from '@/types/book'
 import type { CollectionLight } from '@/types/collections'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
@@ -501,6 +511,15 @@ const collections = ref<CollectionLight[]>([])
 const showConfirmDialog = ref(false)
 const pendingComment = ref('')
 const pendingUpdatePayload = ref<Partial<TitleUpdate> | null>(null)
+
+const bookStatusFilter = ref<BookStatus>('active')
+
+const bookStatusOptions = [
+  { title: 'Active', value: 'active' },
+  { title: 'Deleted', value: 'deleted' },
+  { title: 'To Be Deleted', value: 'to_delete' },
+  { title: 'All', value: 'all' },
+]
 
 const titleDifferences = computed(() => {
   if (!(title.value && pendingUpdatePayload.value)) return undefined
@@ -567,13 +586,23 @@ const sortedBooks = computed(() => {
   )
 })
 
+const filteredBooks = computed(() => {
+  if (bookStatusFilter.value === 'all') return sortedBooks.value
+  if (bookStatusFilter.value === 'deleted')
+    return sortedBooks.value.filter((b) => b.location_kind === 'deleted')
+  if (bookStatusFilter.value === 'to_delete')
+    return sortedBooks.value.filter((b) => b.location_kind === 'to_delete')
+  // active: exclude deleted and to_delete
+  return sortedBooks.value.filter((b) => !['deleted', 'to_delete'].includes(b.location_kind))
+})
+
 const loadLatestBook = async () => {
   if (!title.value?.books || title.value.books.length === 0) {
     latestBook.value = null
     return
   }
 
-  const latestBookId = sortedBooks.value[0]?.id
+  const latestBookId = filteredBooks.value[0]?.id
   if (!latestBookId) {
     latestBook.value = null
     return


### PR DESCRIPTION
## Rationale
The API already allows to filter books by multiple location kinds but UI only allows user to select only one location. Also, not all locations are available to the user primarily because `to_delete` and `to_delete` aren't "locations". This PR gives the filter a better name "Status" and adds options that have better meaning

<img width="1245" height="653" alt="Screenshot_20260713_010728" src="https://github.com/user-attachments/assets/141eaf00-a8ab-4864-b28a-55bcf7985b04" />
<img width="1120" height="576" alt="Screenshot_20260713_010714" src="https://github.com/user-attachments/assets/8f91a4c1-ea15-4de1-8c17-a664acc9cd90" />
<img width="1119" height="422" alt="Screenshot_20260713_010120" src="https://github.com/user-attachments/assets/763f1d04-9a38-480e-9651-5ebae93d9b69" />


This closes #420 