### PR TITLE
add API/UI to manage title flavours

### DIFF
--- a/backend/src/cms_backend/api/routes/account.py
+++ b/backend/src/cms_backend/api/routes/account.py
@@ -10,17 +10,8 @@ from werkzeug.security import check_password_hash, generate_password_hash
 from cms_backend.api.routes.dependencies import get_current_account, require_permission
 from cms_backend.api.routes.http_errors import BadRequestError, ForbiddenError
 from cms_backend.api.routes.models import ListResponse, calculate_pagination_metadata
+from cms_backend.db import account as db_account
 from cms_backend.db import gen_dbsession
-from cms_backend.db.account import (
-    check_account_permission,
-    create_account_schema,
-    get_account_by_identifier,
-)
-from cms_backend.db.account import create_account as db_create_account
-from cms_backend.db.account import delete_account as db_delete_account
-from cms_backend.db.account import get_accounts as db_get_accounts
-from cms_backend.db.account import update_account as db_update_account
-from cms_backend.db.account import update_account_password as db_update_account_password
 from cms_backend.db.models import Account
 from cms_backend.roles import RoleEnum
 from cms_backend.schemas import BaseModel
@@ -49,7 +40,7 @@ def require_permission_if_not_self(namespace: str, name: str):
         ) or (account_identifier == current_account.username):
             return
 
-        if not check_account_permission(
+        if not db_account.check_account_permission(
             current_account, namespace=namespace, name=name
         ):
             raise ForbiddenError("You are not allowed to access this resource")
@@ -73,7 +64,7 @@ def get_accounts(
     params: Annotated[AccountsGetSchema, Query()],
 ) -> ListResponse[AccountSchema]:
     """Get a list of accounts"""
-    results = db_get_accounts(
+    results = db_account.get_accounts(
         db_session,
         skip=params.skip,
         limit=params.limit,
@@ -88,7 +79,9 @@ def get_accounts(
             limit=params.limit,
             page_size=len(results.records),
         ),
-        items=[create_account_schema(account) for account in results.records],
+        items=[
+            db_account.create_account_schema(account) for account in results.records
+        ],
     )
 
 
@@ -134,7 +127,7 @@ def create_account(
     account_schema: AccountCreateSchema,
     db_session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> AccountSchema:
-    account = db_create_account(
+    account = db_account.create_account(
         db_session,
         username=account_schema.username,
         display_name=cast(str, account_schema.display_name),
@@ -146,7 +139,7 @@ def create_account(
         ),
     )
 
-    return create_account_schema(account)
+    return db_account.create_account_schema(account)
 
 
 @router.get(
@@ -160,10 +153,10 @@ def get_account(
     db_session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> AccountSchema:
     """Get a specific account"""
-    account = get_account_by_identifier(
+    account = db_account.get_account_by_identifier(
         db_session, account_identifier=account_identifier
     )
-    return create_account_schema(account)
+    return db_account.create_account_schema(account)
 
 
 @router.patch(
@@ -176,7 +169,7 @@ def update_account(
     db_session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> Response:
     """Update a specific account"""
-    db_update_account(
+    db_account.update_account(
         db_session,
         account_id=account_identifier,
         request=request,
@@ -193,10 +186,10 @@ def delete_account(
     db_session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> Response:
     """Delete a specific account"""
-    account = get_account_by_identifier(
+    account = db_account.get_account_by_identifier(
         db_session, account_identifier=account_identifier
     )
-    db_delete_account(db_session, account_id=account.id)
+    db_account.delete_account(db_session, account_id=account.id)
     return Response(status_code=HTTPStatus.NO_CONTENT)
 
 
@@ -223,7 +216,7 @@ def update_account_password(
     current_account: Annotated[Account, Depends(get_current_account)],
 ) -> Response:
     """Update an account's password"""
-    account = get_account_by_identifier(
+    account = db_account.get_account_by_identifier(
         db_session, account_identifier=account_identifier
     )
     if not account.username:
@@ -234,7 +227,7 @@ def update_account_password(
     if (
         current_account.id == account.id
         and account.password_hash is not None
-        and not check_account_permission(
+        and not db_account.check_account_permission(
             current_account, namespace="account", name="update"
         )
     ):
@@ -244,7 +237,7 @@ def update_account_password(
         if not check_password_hash(account.password_hash, password_update.current):
             raise BadRequestError()
 
-    db_update_account_password(
+    db_account.update_account_password(
         db_session,
         account_id=account.id,
         password_hash=(

--- a/backend/src/cms_backend/api/routes/auth.py
+++ b/backend/src/cms_backend/api/routes/auth.py
@@ -10,16 +10,11 @@ from cms_backend.api.context import Context
 from cms_backend.api.routes.dependencies import get_current_account
 from cms_backend.api.routes.http_errors import UnauthorizedError
 from cms_backend.api.token import generate_access_token
+from cms_backend.db import account as db_account
 from cms_backend.db import gen_dbsession
-from cms_backend.db.account import create_account_schema, get_account_by_username
+from cms_backend.db import refresh_token as db_refresh_token
 from cms_backend.db.exceptions import RecordDoesNotExistError
 from cms_backend.db.models import Account
-from cms_backend.db.refresh_token import (
-    create_refresh_token,
-    delete_refresh_token,
-    expire_refresh_tokens,
-    get_refresh_token,
-)
 from cms_backend.schemas import BaseModel
 from cms_backend.schemas.orms import AccountSchema
 from cms_backend.utils.datetime import getnow
@@ -46,18 +41,20 @@ class Token(BaseModel):
 
 
 def _access_token_response(
-    db_session: OrmSession, db_account: Account, response: Response
+    db_session: OrmSession, account: Account, response: Response
 ):
     response.headers["Cache-Control"] = "no-store"
     response.headers["Pragma"] = "no-cache"
     issue_time = getnow()
     return Token(
         access_token=generate_access_token(
-            account_id=str(db_account.id),
+            account_id=str(account.id),
             issue_time=issue_time,
         ),
         refresh_token=str(
-            create_refresh_token(session=db_session, account_id=db_account.id).token
+            db_refresh_token.create_refresh_token(
+                session=db_session, account_id=account.id
+            ).token
         ),
         expires_time=issue_time
         + datetime.timedelta(seconds=Context.jwt_token_expiry_duration),
@@ -69,17 +66,19 @@ def _auth_with_credentials(
 ):
     """Authorize an account with username and password."""
     try:
-        db_account = get_account_by_username(db_session, username=credentials.username)
+        account = db_account.get_account_by_username(
+            db_session, username=credentials.username
+        )
     except RecordDoesNotExistError as exc:
         raise UnauthorizedError() from exc
 
     if not (
-        db_account.password_hash
-        and check_password_hash(db_account.password_hash, credentials.password)
+        account.password_hash
+        and check_password_hash(account.password_hash, credentials.password)
     ):
         raise UnauthorizedError("Invalid credentials")
 
-    return _access_token_response(db_session, db_account, response)
+    return _access_token_response(db_session, account, response)
 
 
 def _refresh_access_token(
@@ -87,18 +86,20 @@ def _refresh_access_token(
 ):
     """Issue a new set of access and refresh tokens."""
     try:
-        db_refresh_token = get_refresh_token(db_session, token=refresh_token)
+        token_record = db_refresh_token.get_refresh_token(
+            db_session, token=refresh_token
+        )
     except RecordDoesNotExistError as exc:
         raise UnauthorizedError() from exc
 
     now = getnow()
-    if db_refresh_token.expire_time < now:
+    if token_record.expire_time < now:
         raise UnauthorizedError("Refresh token expired")
 
-    delete_refresh_token(db_session, token=refresh_token)
-    expire_refresh_tokens(db_session, expire_time=now)
+    db_refresh_token.delete_refresh_token(db_session, token=refresh_token)
+    db_refresh_token.expire_refresh_tokens(db_session, expire_time=now)
 
-    return _access_token_response(db_session, db_refresh_token.account, response)
+    return _access_token_response(db_session, token_record.account, response)
 
 
 @router.post("/authorize")
@@ -125,4 +126,4 @@ def get_current_account_info(
     current_account: Annotated[Account, Depends(get_current_account)],
 ) -> AccountSchema:
     """Get the current authenticated account's information including scopes."""
-    return create_account_schema(current_account)
+    return db_account.create_account_schema(current_account)

--- a/backend/src/cms_backend/api/routes/books.py
+++ b/backend/src/cms_backend/api/routes/books.py
@@ -9,30 +9,10 @@ from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend.api.routes.dependencies import get_current_account, require_permission
 from cms_backend.api.routes.models import ListResponse, calculate_pagination_metadata
+from cms_backend.db import book as db_book
+from cms_backend.db import book_actions as db_book_actions
+from cms_backend.db import books as db_books
 from cms_backend.db import gen_dbsession
-from cms_backend.db.book import backup_book as db_backup_book
-from cms_backend.db.book import (
-    create_book_full_schema,
-    create_book_history_schema,
-)
-from cms_backend.db.book import delete_book as db_delete_book
-from cms_backend.db.book import get_book as db_get_book
-from cms_backend.db.book import get_book_history as db_get_book_history
-from cms_backend.db.book import get_book_history_entry as db_get_book_history_entry
-from cms_backend.db.book import move_book as db_move_book
-from cms_backend.db.book import recover_book as db_recover_book
-from cms_backend.db.book import remove_book_backup as db_remove_book_backup
-from cms_backend.db.book import revert_book as db_revert_book
-from cms_backend.db.book import update_book as db_update_book
-from cms_backend.db.book import update_book_issues as db_update_book_issues
-from cms_backend.db.book_actions import (
-    apply_book_promotion_actions,
-    get_book_promotion_actions,
-)
-from cms_backend.db.books import get_book_flavours as db_get_book_flavours
-from cms_backend.db.books import get_book_languages as db_get_book_languages
-from cms_backend.db.books import get_books as db_get_books
-from cms_backend.db.books import get_zim_urls as db_get_zim_urls
 from cms_backend.db.models import Account
 from cms_backend.schemas import BaseModel
 from cms_backend.schemas.fields import LimitFieldMax200, NotEmptyString, SkipField
@@ -67,7 +47,7 @@ def get_books(
 ) -> ListResponse[BookLightSchema]:
     """Get a list of books"""
 
-    results = db_get_books(session, params=params)
+    results = db_books.get_books(session, params=params)
 
     return ListResponse[BookLightSchema](
         meta=calculate_pagination_metadata(
@@ -85,14 +65,14 @@ def get_zim_urls(
     zim_ids: Annotated[list[UUID], Query()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> ZimUrlsSchema:
-    return db_get_zim_urls(session, zim_ids)
+    return db_books.get_zim_urls(session, zim_ids)
 
 
 @router.get("/languages")
 def get_book_languages(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> BookLanguagesSchema:
-    return db_get_book_languages(session)
+    return db_books.get_book_languages(session)
 
 
 @router.get("/flavours")
@@ -100,7 +80,7 @@ def get_book_flavours(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
     title_id: Annotated[UUID | None, Query()] = None,
 ) -> ListResponse[str]:
-    results = db_get_book_flavours(session, title_id=title_id)
+    results = db_books.get_book_flavours(session, title_id=title_id)
     return ListResponse[str](
         meta=calculate_pagination_metadata(
             nb_records=results.nb_records,
@@ -118,7 +98,9 @@ def get_book(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> BookFullSchema:
     """Get a book by ID"""
-    return create_book_full_schema(db_get_book(session=session, book_id=book_id))
+    return db_book.create_book_full_schema(
+        db_book.get_book(session=session, book_id=book_id)
+    )
 
 
 @router.patch(
@@ -131,8 +113,8 @@ def update_book(
     request: BookUpdateSchema,
     current_account: Account = Depends(get_current_account),
 ) -> BookFullSchema:
-    return create_book_full_schema(
-        db_update_book(
+    return db_book.create_book_full_schema(
+        db_book.update_book(
             session, book_id=book_id, payload=request, author_id=current_account.id
         )
     )
@@ -148,8 +130,8 @@ def delete_book(
     *,
     force_delete: Annotated[bool, Query()] = False,
 ) -> BookFullSchema:
-    return create_book_full_schema(
-        db_delete_book(session, book_id=book_id, force_delete=force_delete)
+    return db_book.create_book_full_schema(
+        db_book.delete_book(session, book_id=book_id, force_delete=force_delete)
     )
 
 
@@ -161,7 +143,9 @@ def recover_book(
     book_id: Annotated[UUID, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> BookFullSchema:
-    return create_book_full_schema(db_recover_book(session, book_id=book_id))
+    return db_book.create_book_full_schema(
+        db_book.recover_book(session, book_id=book_id)
+    )
 
 
 @router.post(
@@ -173,8 +157,8 @@ def move_book(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
     request: BookMoveSchema,
 ) -> BookFullSchema:
-    return create_book_full_schema(
-        db_move_book(session, book_id=book_id, destination=request.destination)
+    return db_book.create_book_full_schema(
+        db_book.move_book(session, book_id=book_id, destination=request.destination)
     )
 
 
@@ -186,7 +170,9 @@ def backup_book(
     book_id: Annotated[UUID, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> BookFullSchema:
-    return create_book_full_schema(db_backup_book(session, book_id=book_id))
+    return db_book.create_book_full_schema(
+        db_book.backup_book(session, book_id=book_id)
+    )
 
 
 @router.get(
@@ -197,9 +183,9 @@ def get_book_issues(
     book_id: Annotated[UUID, Path()],
     session: OrmSession = Depends(gen_dbsession),
 ) -> JSONResponse:
-    book = db_get_book(session, book_id)
+    book = db_book.get_book(session, book_id)
     return JSONResponse(
-        content=db_update_book_issues(session, book),
+        content=db_book.update_book_issues(session, book),
         status_code=HTTPStatus.OK,
     )
 
@@ -224,13 +210,13 @@ def promote_book(
     dry_run: Annotated[bool, Query()] = True,
 ) -> JSONResponse:
     if dry_run:
-        actions = get_book_promotion_actions(session, book_id=book_id)
+        actions = db_book_actions.get_book_promotion_actions(session, book_id=book_id)
         return JSONResponse(
             content={"actions": [action.model_dump(mode="json") for action in actions]},
             status_code=HTTPStatus.OK,
         )
     else:
-        apply_book_promotion_actions(
+        db_book_actions.apply_book_promotion_actions(
             session,
             book_id=book_id,
             author_id=current_account.id,
@@ -252,7 +238,7 @@ def get_book_history(
     skip: Annotated[SkipField, Query()] = 0,
     limit: Annotated[LimitFieldMax200, Query()] = 200,
 ) -> ListResponse[BookHistorySchema]:
-    results = db_get_book_history(session, book_id=book_id, skip=skip, limit=limit)
+    results = db_book.get_book_history(session, book_id=book_id, skip=skip, limit=limit)
     return ListResponse(
         items=results.records,
         meta=calculate_pagination_metadata(
@@ -273,10 +259,10 @@ def get_book_history_entry(
     history_id: Annotated[UUID, Path()],
     session: OrmSession = Depends(gen_dbsession),
 ) -> BookHistorySchema:
-    history_entry = db_get_book_history_entry(
+    history_entry = db_book.get_book_history_entry(
         session, book_id=book_id, history_id=history_id
     )
-    return create_book_history_schema(history_entry)
+    return db_book.create_book_history_schema(history_entry)
 
 
 @router.patch(
@@ -291,7 +277,7 @@ def revert_book(
     current_account: Account = Depends(get_current_account),
 ) -> JSONResponse:
     """Revert a book to a previous history."""
-    db_revert_book(
+    db_book.revert_book(
         session,
         book_id=book_id,
         history_id=history_id,
@@ -312,4 +298,6 @@ def remove_book_backup(
     book_id: Annotated[UUID, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> BookFullSchema:
-    return create_book_full_schema(db_remove_book_backup(session, book_id=book_id))
+    return db_book.create_book_full_schema(
+        db_book.remove_book_backup(session, book_id=book_id)
+    )

--- a/backend/src/cms_backend/api/routes/collection.py
+++ b/backend/src/cms_backend/api/routes/collection.py
@@ -11,26 +11,8 @@ from sqlalchemy.orm import Session as OrmSession
 from cms_backend.api.routes.dependencies import get_current_account, require_permission
 from cms_backend.api.routes.models import ListResponse, calculate_pagination_metadata
 from cms_backend.api.routes.utils import build_library_xml
+from cms_backend.db import collection as db_collection
 from cms_backend.db import gen_dbsession
-from cms_backend.db.collection import create_collection as db_create_collection
-from cms_backend.db.collection import (
-    create_collection_full_schema,
-    create_collection_history_schema,
-    get_collection_by_name_or_none,
-    get_latest_books_for_collection,
-)
-from cms_backend.db.collection import get_collection as db_get_collection
-from cms_backend.db.collection import (
-    get_collection_history as db_get_collection_history,
-)
-from cms_backend.db.collection import (
-    get_collection_history_entry as db_get_collection_history_entry,
-)
-from cms_backend.db.collection import get_collections as db_get_collections
-from cms_backend.db.collection import (
-    revert_collection as db_revert_collection,
-)
-from cms_backend.db.collection import update_collection as db_update_collection
 from cms_backend.db.exceptions import RecordDoesNotExistError
 from cms_backend.db.models import Account
 from cms_backend.schemas import BaseModel
@@ -62,7 +44,7 @@ def get_collections(
 ) -> ListResponse[CollectionLightSchema]:
     """Get a list of collections"""
 
-    results = db_get_collections(
+    results = db_collection.get_collections(
         session, skip=params.skip, limit=params.limit, name=params.name
     )
 
@@ -98,8 +80,8 @@ def create_collection(
     request: CollectionCreateSchema,
 ):
     """Create a collection"""
-    return create_collection_full_schema(
-        db_create_collection(
+    return db_collection.create_collection_full_schema(
+        db_collection.create_collection(
             session,
             author_id=current_account.id,
             name=request.name,
@@ -128,8 +110,8 @@ def get_collection(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ):
     """Get collection by collection ID (UUID) or name."""
-    collection = db_get_collection(session, collection_id_or_name)
-    return create_collection_full_schema(collection)
+    collection = db_collection.get_collection(session, collection_id_or_name)
+    return db_collection.create_collection_full_schema(collection)
 
 
 @router.patch(
@@ -143,8 +125,8 @@ def update_collection(
     session: OrmSession = Depends(gen_dbsession),
 ) -> CollectionFullSchema:
     """Update a collection's data"""
-    return create_collection_full_schema(
-        db_update_collection(
+    return db_collection.create_collection_full_schema(
+        db_collection.update_collection(
             session,
             collection_id=collection_id_or_name,
             request=collection_data,
@@ -160,12 +142,14 @@ def _get_catalog_xml_content(
     collection = None
     try:
         try:
-            collection = db_get_collection(session, collection_id_or_name)
+            collection = db_collection.get_collection(session, collection_id_or_name)
         except RecordDoesNotExistError:
             pass
     except ValueError:
         # Not a valid UUID, try as name
-        collection = get_collection_by_name_or_none(session, collection_id_or_name)
+        collection = db_collection.get_collection_by_name_or_none(
+            session, collection_id_or_name
+        )
 
     if collection is None:
         return (
@@ -174,7 +158,7 @@ def _get_catalog_xml_content(
             HTTPStatus.NOT_FOUND,
         )
 
-    entries = get_latest_books_for_collection(session, collection.id)
+    entries = db_collection.get_latest_books_for_collection(session, collection.id)
     xml_content = build_library_xml(entries, path_prefix=path_prefix)
 
     return xml_content, HTTPStatus.OK
@@ -228,7 +212,7 @@ def get_collection_history(
     skip: Annotated[SkipField, Query()] = 0,
     limit: Annotated[LimitFieldMax200, Query()] = 200,
 ) -> ListResponse[CollectionHistorySchema]:
-    results = db_get_collection_history(
+    results = db_collection.get_collection_history(
         session, collection_id=collection_id_or_name, skip=skip, limit=limit
     )
     return ListResponse(
@@ -251,10 +235,10 @@ def get_collection_history_entry(
     history_id: Annotated[UUID, Path()],
     session: OrmSession = Depends(gen_dbsession),
 ) -> CollectionHistorySchema:
-    history_entry = db_get_collection_history_entry(
+    history_entry = db_collection.get_collection_history_entry(
         session, collection_id=collection_id_or_name, history_id=history_id
     )
-    return create_collection_history_schema(history_entry)
+    return db_collection.create_collection_history_schema(history_entry)
 
 
 @router.patch(
@@ -269,7 +253,7 @@ def revert_collection(
     current_account: Account = Depends(get_current_account),
 ) -> JSONResponse:
     """Revert a collection to a previous history."""
-    db_revert_collection(
+    db_collection.revert_collection(
         session,
         collection_id=collection_id_or_name,
         history_id=history_id,

--- a/backend/src/cms_backend/api/routes/dependencies.py
+++ b/backend/src/cms_backend/api/routes/dependencies.py
@@ -8,12 +8,8 @@ from sqlalchemy.orm import Session as OrmSession
 from cms_backend.api.context import Context
 from cms_backend.api.routes.http_errors import UnauthorizedError
 from cms_backend.api.token import JWTClaims, token_decoder
+from cms_backend.db import account as db_account
 from cms_backend.db import gen_dbsession, gen_manual_dbsession
-from cms_backend.db.account import (
-    check_account_permission,
-    create_account,
-    get_account_by_id_or_none,
-)
 from cms_backend.db.models import Account
 from cms_backend.roles import RoleEnum
 
@@ -57,18 +53,20 @@ def get_current_account_or_none_with_session(
     ) -> Account | None:
         if claims is None:
             return None
-        account = get_account_by_id_or_none(session, account_id=claims.sub)
+        account = db_account.get_account_by_id_or_none(session, account_id=claims.sub)
         # If this claim has a "name" property, we create a new account account
         if account is None and Context.create_new_oauth_account:
             if not claims.name:
                 raise UnauthorizedError("Token is missing 'profile' scope")
-            create_account(
+            db_account.create_account(
                 session,
                 display_name=claims.name,
                 role=RoleEnum.VIEWER,
                 idp_sub=claims.sub,
             )
-            account = get_account_by_id_or_none(session, account_id=claims.sub)
+            account = db_account.get_account_by_id_or_none(
+                session, account_id=claims.sub
+            )
 
         return account
 
@@ -118,7 +116,7 @@ def require_permission(*, namespace: str, name: str):
     def _check_permission(
         current_account: Annotated[Account, Depends(get_current_account)],
     ) -> Account:
-        if not check_account_permission(
+        if not db_account.check_account_permission(
             current_account, namespace=namespace, name=name
         ):
             raise UnauthorizedError(

--- a/backend/src/cms_backend/api/routes/events.py
+++ b/backend/src/cms_backend/api/routes/events.py
@@ -5,8 +5,8 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend.api.routes.models import ListResponse, calculate_pagination_metadata
+from cms_backend.db import event as db_event
 from cms_backend.db import gen_dbsession
-from cms_backend.db.event import get_events as db_get_events
 from cms_backend.schemas import BaseModel
 from cms_backend.schemas.fields import LimitFieldMax200, NotEmptyString, SkipField
 from cms_backend.schemas.orms import EventLightSchema
@@ -28,7 +28,7 @@ def get_events(
 ) -> ListResponse[EventLightSchema]:
     """Get a list of events"""
 
-    results = db_get_events(
+    results = db_event.get_events(
         session,
         skip=params.skip,
         limit=params.limit,

--- a/backend/src/cms_backend/api/routes/staging.py
+++ b/backend/src/cms_backend/api/routes/staging.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend.api.routes.utils import build_library_xml
 from cms_backend.db import gen_dbsession
-from cms_backend.db.staging import get_staging_books_library_data
+from cms_backend.db import staging as db_staging
 
 router = APIRouter(prefix="/staging", tags=["staging"])
 
@@ -20,7 +20,7 @@ async def get_library_catalog_xml(
 ):
     """Get staging catalog as XML library."""
 
-    entries = get_staging_books_library_data(session)
+    entries = db_staging.get_staging_books_library_data(session)
     xml_content = build_library_xml(entries, path_prefix=path_prefix)
     etag = xxhash.xxh64(xml_content.encode("utf-8")).hexdigest()
 
@@ -37,7 +37,7 @@ async def head_library_catalog_xml(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
     path_prefix: Annotated[str | None, Query()] = None,
 ):
-    entries = get_staging_books_library_data(session)
+    entries = db_staging.get_staging_books_library_data(session)
     xml_content = build_library_xml(entries, path_prefix=path_prefix)
     etag = xxhash.xxh64(xml_content.encode("utf-8")).hexdigest()
     return Response(

--- a/backend/src/cms_backend/api/routes/titles.py
+++ b/backend/src/cms_backend/api/routes/titles.py
@@ -13,32 +13,17 @@ from cms_backend.api.routes.dependencies import (
 )
 from cms_backend.api.routes.http_errors import ForbiddenError
 from cms_backend.api.routes.models import ListResponse, calculate_pagination_metadata
+from cms_backend.db import account as db_account
+from cms_backend.db import flavour as db_flavour
 from cms_backend.db import gen_dbsession
-from cms_backend.db.account import check_account_permission
+from cms_backend.db import title as db_title
 from cms_backend.db.models import Account
-from cms_backend.db.title import archive_title as db_archive_title
-from cms_backend.db.title import archive_titles as db_archive_titles
-from cms_backend.db.title import create_title as db_create_title
-from cms_backend.db.title import (
-    create_title_full_schema,
-    create_title_history_schema,
-    create_title_light_schema,
-)
-from cms_backend.db.title import get_title_by_id as db_get_title_by_id
-from cms_backend.db.title import get_title_by_name as db_get_title_by_name
-from cms_backend.db.title import get_title_history as db_get_title_history
-from cms_backend.db.title import get_title_history_entry as db_get_title_history_entry
-from cms_backend.db.title import get_titles as db_get_titles
-from cms_backend.db.title import merge_titles as db_merge_titles
-from cms_backend.db.title import restore_title as db_restore_title
-from cms_backend.db.title import restore_titles as db_restore_titles
-from cms_backend.db.title import revert_title as db_revert_title
-from cms_backend.db.title import update_title as db_update_title
 from cms_backend.schemas import BaseModel
 from cms_backend.schemas.fields import (
     LimitFieldMax200,
     NotEmptyString,
     SkipField,
+    ZimFlavour,
 )
 from cms_backend.schemas.models import (
     RestoreTitlesSchema,
@@ -46,6 +31,7 @@ from cms_backend.schemas.models import (
     TitleUpdateSchema,
 )
 from cms_backend.schemas.orms import (
+    TitleFlavourSchema,
     TitleFullSchema,
     TitleHistorySchema,
     TitleLightSchema,
@@ -80,10 +66,12 @@ def get_titles(
 ) -> ListResponse[TitleLightSchema]:
     if params.archived and not (
         current_account
-        and check_account_permission(current_account, namespace="title", name="archive")
+        and db_account.check_account_permission(
+            current_account, namespace="title", name="archive"
+        )
     ):
         raise ForbiddenError("You are not allowed to view archived titles.")
-    results = db_get_titles(
+    results = db_title.get_titles(
         session,
         skip=params.skip,
         limit=params.limit,
@@ -113,7 +101,7 @@ def merge_titles(
     request: MergeTitlesSchema,
     session: OrmSession = Depends(gen_dbsession),
 ) -> JSONResponse:
-    db_merge_titles(session, request.target, request.sources)
+    db_title.merge_titles(session, request.target, request.sources)
     return JSONResponse(
         content={"message": f"Titles have been merged with {request.target}"},
         status_code=HTTPStatus.OK,
@@ -127,10 +115,10 @@ def get_title(
 ) -> TitleFullSchema:
     """Get a title by ID with full details including books"""
     if is_valid_uuid(title_identifier):
-        title = db_get_title_by_id(session, title_id=UUID(title_identifier))
+        title = db_title.get_title_by_id(session, title_id=UUID(title_identifier))
     else:
-        title = db_get_title_by_name(session, name=title_identifier)
-    return create_title_full_schema(title)
+        title = db_title.get_title_by_name(session, name=title_identifier)
+    return db_title.create_title_full_schema(title)
 
 
 @router.post(
@@ -142,12 +130,12 @@ def create_title(
     current_account: Account = Depends(get_current_account),
 ) -> TitleLightSchema:
     """Create a new title"""
-    title = db_create_title(
+    title = db_title.create_title(
         session,
         author_id=current_account.id,
         payload=title_data,
     )
-    return create_title_light_schema(title)
+    return db_title.create_title_light_schema(title)
 
 
 @router.patch(
@@ -161,13 +149,13 @@ def update_title(
     current_account: Account = Depends(get_current_account),
 ) -> TitleLightSchema:
     """Update a title"""
-    title = db_update_title(
+    title = db_title.update_title(
         session,
         title_identifier=title_identifier,
         author_id=current_account.id,
         payload=title_data,
     )
-    return create_title_light_schema(title)
+    return db_title.create_title_light_schema(title)
 
 
 @router.post(
@@ -179,7 +167,7 @@ def archive_titles(
     session: OrmSession = Depends(gen_dbsession),
     current_account: Account = Depends(get_current_account),
 ) -> Response:
-    db_archive_titles(
+    db_title.archive_titles(
         session,
         title_names=request.title_names,
         author_id=current_account.id,
@@ -196,7 +184,7 @@ def restore_archived_titles(
     session: OrmSession = Depends(gen_dbsession),
     current_account: Account = Depends(get_current_account),
 ) -> Response:
-    db_restore_titles(
+    db_title.restore_titles(
         session,
         title_names=request.title_names,
         author_id=current_account.id,
@@ -214,12 +202,12 @@ def archive_title(
     current_account: Account = Depends(get_current_account),
 ) -> TitleLightSchema:
     """Mark a title as archived"""
-    title = db_archive_title(
+    title = db_title.archive_title(
         session,
         title_identifier=title_identifier,
         author_id=current_account.id,
     )
-    return create_title_light_schema(title)
+    return db_title.create_title_light_schema(title)
 
 
 @router.patch(
@@ -232,12 +220,12 @@ def restore_archived_title(
     current_account: Account = Depends(get_current_account),
 ) -> TitleLightSchema:
     """Restore an archived title"""
-    title = db_restore_title(
+    title = db_title.restore_title(
         session,
         title_identifier=title_identifier,
         author_id=current_account.id,
     )
-    return create_title_light_schema(title)
+    return db_title.create_title_light_schema(title)
 
 
 @router.get(
@@ -250,7 +238,7 @@ def get_title_history(
     skip: Annotated[SkipField, Query()] = 0,
     limit: Annotated[LimitFieldMax200, Query()] = 200,
 ) -> ListResponse[TitleHistorySchema]:
-    results = db_get_title_history(
+    results = db_title.get_title_history(
         session, title_identifier=title_identifier, skip=skip, limit=limit
     )
     return ListResponse(
@@ -265,6 +253,54 @@ def get_title_history(
 
 
 @router.get(
+    "/{title_identifier}/flavours",
+)
+def get_title_flavours(
+    title_identifier: Annotated[NotEmptyString, Path()],
+    session: OrmSession = Depends(gen_dbsession),
+    skip: Annotated[SkipField, Query()] = 0,
+    limit: Annotated[LimitFieldMax200, Query()] = 200,
+) -> ListResponse[TitleFlavourSchema]:
+    title = db_title.get_title(session, title_identifier=title_identifier)
+    results = db_flavour.get_title_flavours(
+        session, title_id=title.id, skip=skip, limit=limit
+    )
+    return ListResponse(
+        items=results.records,
+        meta=calculate_pagination_metadata(
+            nb_records=results.nb_records,
+            skip=skip,
+            limit=limit,
+            page_size=len(results.records),
+        ),
+    )
+
+
+@router.delete(
+    "/{title_identifier}/flavours/{flavour}",
+    dependencies=[
+        Depends(require_permission(namespace="title", name="update")),
+        Depends(require_permission(namespace="book", name="delete")),
+    ],
+)
+def delete_title_flavour(
+    title_identifier: Annotated[NotEmptyString, Path()],
+    flavour: Annotated[ZimFlavour, Path()],
+    session: OrmSession = Depends(gen_dbsession),
+) -> JSONResponse:
+    title = db_title.get_title(session, title_identifier=title_identifier)
+    db_flavour.delete_title_flavour(session, title_id=title.id, flavour=flavour)
+    return JSONResponse(
+        content={
+            "message": (
+                f"title flavour '{flavour}' for title '{title.name}' has been deleted"
+            )
+        },
+        status_code=HTTPStatus.OK,
+    )
+
+
+@router.get(
     "/{title_identifier}/history/{history_id}",
     dependencies=[Depends(require_permission(namespace="title", name="update"))],
 )
@@ -273,10 +309,10 @@ def get_title_history_entry(
     history_id: Annotated[UUID, Path()],
     session: OrmSession = Depends(gen_dbsession),
 ) -> TitleHistorySchema:
-    history_entry = db_get_title_history_entry(
+    history_entry = db_title.get_title_history_entry(
         session, title_identifier=title_identifier, history_id=history_id
     )
-    return create_title_history_schema(history_entry)
+    return db_title.create_title_history_schema(history_entry)
 
 
 @router.patch(
@@ -291,7 +327,7 @@ def revert_title(
     current_account: Account = Depends(get_current_account),
 ) -> JSONResponse:
     """Revert a title to a previous history."""
-    db_revert_title(
+    db_title.revert_title(
         session,
         title_identifier=title_identifier,
         history_id=history_id,

--- a/backend/src/cms_backend/api/routes/utils.py
+++ b/backend/src/cms_backend/api/routes/utils.py
@@ -1,13 +1,13 @@
 import math
 from xml.etree import ElementTree as ET
 
-from cms_backend.db.collection import LibraryBookData
+from cms_backend.db import collection as db_collection
 from cms_backend.utils.filename import construct_download_url
 from cms_backend.utils.zim import convert_tags
 
 
 def build_library_xml(
-    entries: list[LibraryBookData], *, path_prefix: str | None = None
+    entries: list[db_collection.LibraryBookData], *, path_prefix: str | None = None
 ) -> str:
     """Build XML library catalog from books."""
     library_elem = ET.Element("library")

--- a/backend/src/cms_backend/api/routes/warehouse.py
+++ b/backend/src/cms_backend/api/routes/warehouse.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session as OrmSession
 
 from cms_backend.api.routes.dependencies import gen_dbsession
 from cms_backend.api.routes.models import ListResponse, calculate_pagination_metadata
-from cms_backend.db.warehouse import get_warehouses as db_get_warehouses
+from cms_backend.db import warehouse as db_warehouse
 from cms_backend.schemas.fields import LimitFieldMax200, SkipField
 
 router = APIRouter(prefix="/warehouses", tags=["warehouses"])
@@ -18,7 +18,7 @@ def get_warehouses(
     limit: Annotated[LimitFieldMax200, Query()] = 200,
 ):
     """Get a list of warehouses"""
-    result = db_get_warehouses(session, skip=skip, limit=limit)
+    result = db_warehouse.get_warehouses(session, skip=skip, limit=limit)
     return ListResponse(
         items=result.records,
         meta=calculate_pagination_metadata(

--- a/backend/src/cms_backend/api/routes/zimfarm_notifications.py
+++ b/backend/src/cms_backend/api/routes/zimfarm_notifications.py
@@ -10,18 +10,7 @@ from cms_backend import logger
 from cms_backend.api.routes.dependencies import require_permission
 from cms_backend.api.routes.models import ListResponse, calculate_pagination_metadata
 from cms_backend.db import gen_dbsession
-from cms_backend.db.zimfarm_notification import (
-    create_zimfarm_notification as db_create_zimfarm_notification,
-)
-from cms_backend.db.zimfarm_notification import (
-    get_zimfarm_notification as db_get_zimfarm_notification,
-)
-from cms_backend.db.zimfarm_notification import (
-    get_zimfarm_notification_or_none as db_get_zimfarm_notification_or_none,
-)
-from cms_backend.db.zimfarm_notification import (
-    get_zimfarm_notifications as db_get_zimfarm_notifications,
-)
+from cms_backend.db import zimfarm_notification as db_zimfarm_notification
 from cms_backend.schemas import BaseModel, WithExtraModel
 from cms_backend.schemas.fields import LimitFieldMax200, NotEmptyString, SkipField
 from cms_backend.schemas.orms import (
@@ -55,7 +44,7 @@ async def get_zimfarm_notifications(
 ) -> ListResponse[ZimfarmNotificationLightSchema]:
     """Get a list of zimfarm notifications"""
 
-    results = db_get_zimfarm_notifications(
+    results = db_zimfarm_notification.get_zimfarm_notifications(
         session,
         skip=params.skip,
         limit=params.limit,
@@ -89,13 +78,15 @@ async def create_zimfarm_notification(
 ) -> Response:
     """Create a zimfarm notification"""
 
-    if db_get_zimfarm_notification_or_none(session=session, notification_id=request.id):
+    if db_zimfarm_notification.get_zimfarm_notification_or_none(
+        session=session, notification_id=request.id
+    ):
         logger.warning(f"Ignoring duplicate Zimfarm notification for id {request.id}")
         return Response(status_code=HTTPStatus.ACCEPTED)
 
     content = request.model_dump()
     content.pop("id")
-    db_create_zimfarm_notification(
+    db_zimfarm_notification.create_zimfarm_notification(
         session,
         notification_id=request.id,
         content=content,
@@ -111,7 +102,7 @@ async def get_zimfarm_notification(
 ) -> ZimfarmNotificationFullSchema:
     """Create a zimfarm notification"""
 
-    db_notification = db_get_zimfarm_notification(
+    db_notification = db_zimfarm_notification.get_zimfarm_notification(
         session=session, notification_id=notification_id
     )
 

--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -14,7 +14,6 @@ from cms_backend.context import Context
 from cms_backend.db import count_from_stmt
 from cms_backend.db.book_location import create_book_target_locations
 from cms_backend.db.exceptions import RecordDoesNotExistError
-from cms_backend.db.flavour import get_title_flavours
 from cms_backend.db.models import Book, BookHistory, ZimfarmNotification
 from cms_backend.db.rules import (
     apply_retention_rules,
@@ -731,7 +730,7 @@ def get_book_issues(
         ]
 
     if book_has_flavour_mismatch(book):
-        title_flavours = get_title_flavours(book.title)
+        title_flavours = [tf.flavour for tf in book.title.flavours]
         issues["flavour mismatch"] = [
             f"book flavour {book.flavour} is not in list of "
             f"title flavours: {','.join(title_flavours)}"
@@ -1194,7 +1193,7 @@ def book_has_flavour_mismatch(
     if book.title is None:
         raise ValueError("Book must be associated with a title.")
 
-    title_flavours = get_title_flavours(book.title)
+    title_flavours = [tf.flavour for tf in book.title.flavours]
 
     # Title has flavours but book has no flavour or flavour not in book flavours
     if title_flavours and book.flavour not in title_flavours:

--- a/backend/src/cms_backend/db/flavour.py
+++ b/backend/src/cms_backend/db/flavour.py
@@ -3,13 +3,26 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.orm import Session as OrmSession
 
+from cms_backend.db import book as db_book
+from cms_backend.db import count_from_stmt
 from cms_backend.db.exceptions import RecordDoesNotExistError
-from cms_backend.db.models import Title, TitleFlavour
-from cms_backend.schemas.orms import TitleFlavourSchema
+from cms_backend.db.models import Book, Title, TitleFlavour
+from cms_backend.schemas.orms import ListResult, TitleFlavourSchema
 
 
-def get_title_flavours(title: Title) -> list[str]:
-    return [title_flavour.flavour for title_flavour in title.flavours]
+def get_title_flavours(
+    session: OrmSession, title_id: UUID, *, limit: int = 20, skip: int = 0
+) -> ListResult[TitleFlavourSchema]:
+    stmt = select(TitleFlavour).where(TitleFlavour.title_id == title_id)
+    return ListResult[TitleFlavourSchema](
+        nb_records=count_from_stmt(session, stmt),
+        records=[
+            create_title_flavour_schema(tf)
+            for tf in session.scalars(
+                stmt.offset(skip).limit(limit).order_by(TitleFlavour.flavour)
+            )
+        ],
+    )
 
 
 def create_title_flavour_schema(tf: TitleFlavour) -> TitleFlavourSchema:
@@ -26,6 +39,7 @@ def create_title_flavour(
     title.flavours.append(title_flavour)
     session.add(title_flavour)
     session.flush()
+    return title_flavour
 
 
 def get_title_flavour_or_none(
@@ -47,3 +61,29 @@ def get_title_flavour(
             f"Title flavour {flavour} for title {title_id} does not exists"
         )
     return title_flavour
+
+
+def delete_title_flavour(session: OrmSession, title_id: UUID, flavour: str):
+    """Delete a title flavour and mark associated books for deletion.
+
+    Only books that are in staging, prod or quarantine and do not have any pending
+    operations are eligible for deletion.
+    """
+    tf = get_title_flavour_or_none(session, title_id=title_id, flavour=flavour)
+    if tf is None:
+        raise RecordDoesNotExistError(
+            f"Title flavour '{flavour}' for title {title_id} does not exist"
+        )
+    book_ids_to_delete = session.scalars(
+        select(Book.id).where(
+            Book.needs_processing.is_(False),
+            Book.needs_processing.is_(False),
+            Book.location_kind.in_(["staging", "prod", "quarantine"]),
+            Book.title_id == tf.title_id,
+            Book.flavour == tf.flavour,
+        )
+    ).all()
+    for book_id in book_ids_to_delete:
+        db_book.delete_book(session, book_id=book_id)
+    session.delete(tf)
+    session.flush()

--- a/backend/src/cms_backend/schemas/orms.py
+++ b/backend/src/cms_backend/schemas/orms.py
@@ -21,6 +21,13 @@ class TitleFlavourSchema(BaseModel):
     flavour: str
     recipe_id: UUID | None
 
+    @computed_field
+    @property
+    def recipe_link(self) -> str | None:
+        if self.recipe_id is None:
+            return None
+        return f"{Context.zimfarm_api_url}/recipes/{self.recipe_id}"
+
 
 class TitleLightSchema(BaseModel):
     """

--- a/backend/tests/api/routes/test_titles.py
+++ b/backend/tests/api/routes/test_titles.py
@@ -17,6 +17,7 @@ from cms_backend.db.models import (
     Collection,
     Event,
     Title,
+    TitleFlavour,
     Warehouse,
 )
 from cms_backend.db.title import update_title
@@ -896,6 +897,79 @@ def test_merge_titles_required_permissions(
     response = client.post(
         "/v1/titles/merge",
         json={"target": title1.name, "sources": [title2.name]},
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "skip,limit,expected_count",
+    [
+        pytest.param(0, 3, 3, id="first-page"),
+        pytest.param(3, 3, 1, id="second-page"),
+        pytest.param(8, 3, 0, id="page-num-too-high-no-results"),
+        pytest.param(0, 1, 1, id="first-page-with-low-limit"),
+        pytest.param(0, 20, 4, id="first-page-with-high-limit"),
+    ],
+)
+def test_get_title_flavours_pagination(
+    dbsession: OrmSession,
+    client: TestClient,
+    create_title: Callable[..., Title],
+    access_token: str,
+    skip: int,
+    limit: int,
+    expected_count: int,
+):
+    """Test retrieving title flavours"""
+    title = create_title(name="wikipedia_en_test")
+    flavours = ["maxi", "mini", "nopic", ""]
+    for flavour in flavours:
+        tf = TitleFlavour(flavour=flavour, recipe_id=None)
+        tf.title = title
+        dbsession.add(tf)
+        dbsession.flush()
+
+    response = client.get(
+        f"/v1/titles/{title.id}/flavours?skip={skip}&limit={limit}",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert data["meta"]["skip"] == skip
+    assert data["meta"]["limit"] == limit
+    assert data["meta"]["page_size"] == expected_count
+    assert len(data["items"]) == expected_count
+
+
+@pytest.mark.parametrize(
+    "permission,expected_status_code",
+    [
+        pytest.param(RoleEnum.EDITOR, HTTPStatus.OK, id="editor"),
+        pytest.param(RoleEnum.VIEWER, HTTPStatus.UNAUTHORIZED, id="viewer"),
+    ],
+)
+def test_delete_title_flavour_required_permissions(
+    dbsession: OrmSession,
+    client: TestClient,
+    create_account: Callable[..., Account],
+    create_title: Callable[..., Title],
+    permission: RoleEnum,
+    expected_status_code: HTTPStatus,
+):
+    """Test deleting title flavour with different roles"""
+    title = create_title(name="wikipedia_en_test")
+    tf = TitleFlavour(flavour="maxi", recipe_id=None)
+    tf.title = title
+    dbsession.add(tf)
+    dbsession.flush()
+
+    account = create_account(permission=permission)
+    access_token = generate_access_token(
+        account_id=str(account.id), issue_time=getnow()
+    )
+    response = client.delete(
+        f"/v1/titles/{title.name}/flavours/maxi",
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert response.status_code == expected_status_code

--- a/backend/tests/db/test_flavour.py
+++ b/backend/tests/db/test_flavour.py
@@ -1,0 +1,69 @@
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session as OrmSession
+
+from cms_backend.db import flavour as db_flavour
+from cms_backend.db.models import Book, Title, TitleFlavour
+
+
+@pytest.mark.parametrize(
+    "skip,limit,expected_count",
+    [
+        pytest.param(0, 3, 3, id="first-page"),
+        pytest.param(3, 3, 1, id="second-page"),
+        pytest.param(8, 3, 0, id="page-num-too-high-no-results"),
+        pytest.param(0, 1, 1, id="first-page-with-low-limit"),
+        pytest.param(0, 20, 4, id="first-page-with-high-limit"),
+    ],
+)
+def test_get_title_flavours_pagination(
+    dbsession: OrmSession,
+    create_title: Callable[..., Title],
+    skip: int,
+    limit: int,
+    expected_count: int,
+):
+    """Test that get_title_flavours works correctly with skip and limit"""
+
+    title = create_title(name="wikipedia_en_all")
+    flavours = ["maxi", "mini", "nopic", ""]
+    for flavour in flavours:
+        tf = TitleFlavour(flavour=flavour, recipe_id=None)
+        tf.title = title
+        dbsession.add(tf)
+        dbsession.flush()
+
+    results = db_flavour.get_title_flavours(
+        dbsession, title_id=title.id, limit=limit, skip=skip
+    )
+
+    assert len(results.records) <= limit
+    assert len(results.records) == expected_count
+
+
+@patch("cms_backend.db.flavour.db_book.delete_book")
+def test_delete_title_flavour(
+    mock_delete_book: MagicMock,
+    dbsession: OrmSession,
+    create_title: Callable[..., Title],
+    create_book: Callable[..., Book],
+):
+    title = create_title(name="wikipedia_en_all")
+    tf = TitleFlavour(flavour="maxi", recipe_id=None)
+    tf.title = title
+    dbsession.add(tf)
+    dbsession.flush()
+    create_book(flavour="maxi", title_id=title.id)
+    db_flavour.delete_title_flavour(dbsession, title.id, tf.flavour)
+    mock_delete_book.assert_called_once()
+    assert (
+        dbsession.scalars(
+            select(TitleFlavour).where(
+                TitleFlavour.flavour == tf.flavour, TitleFlavour.title_id == title.id
+            )
+        ).one_or_none()
+        is None
+    )

--- a/frontend/src/components/TitleFlavourItem.vue
+++ b/frontend/src/components/TitleFlavourItem.vue
@@ -1,0 +1,89 @@
+<template>
+  <div>
+    <v-row no-gutters class="py-2 align-center">
+      <v-col cols="12" sm="4">
+        <span class="text-body-1 font-weight-medium">{{
+          flavour.flavour === '' ? 'Empty' : flavour.flavour
+        }}</span>
+      </v-col>
+      <v-col cols="12" sm="6">
+        <a
+          v-if="flavour.recipe_link"
+          :href="flavour.recipe_link"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-decoration-none"
+        >
+          <v-icon size="small" class="mr-1">mdi-open-in-new</v-icon>
+          View recipe on Zimfarm
+        </a>
+        <span v-else class="text-grey">Zimfarm recipe pending</span>
+      </v-col>
+      <v-col cols="12" sm="2" class="text-right">
+        <v-btn
+          v-if="canDelete"
+          icon="mdi-delete"
+          variant="text"
+          size="small"
+          color="error"
+          :disabled="disabled"
+          @click="showDialog = true"
+        />
+      </v-col>
+    </v-row>
+    <v-divider class="my-2"></v-divider>
+
+    <ConfirmDialog
+      v-model="showDialog"
+      title="Delete Flavour"
+      confirm-text="Delete Flavour"
+      cancel-text="Cancel"
+      confirm-color="error"
+      icon="mdi-delete"
+      icon-color="error"
+      :max-width="500"
+      @confirm="handleConfirm"
+      @cancel="showDialog = false"
+    >
+      <template #content>
+        <p class="mb-3">
+          Are you sure you want to delete the flavour
+          <strong>{{ flavour.flavour === '' ? 'Empty' : flavour.flavour }}</strong
+          >?
+        </p>
+        <p class="text-body-2 text-medium-emphasis">
+          Books belonging to this title with this flavour will be marked for deletion. This action
+          cannot be undone.
+        </p>
+      </template>
+    </ConfirmDialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import type { TitleFlavour } from '@/types/title'
+
+interface Props {
+  flavour: TitleFlavour
+  canDelete?: boolean
+  disabled?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  canDelete: false,
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  delete: [flavour: string]
+}>()
+
+const showDialog = ref(false)
+
+const handleConfirm = () => {
+  showDialog.value = false
+  emit('delete', props.flavour.flavour)
+}
+</script>

--- a/frontend/src/stores/title.ts
+++ b/frontend/src/stores/title.ts
@@ -1,7 +1,7 @@
 import { useAuthStore } from '@/stores/auth'
 import type { ListResponse, Paginator } from '@/types/base'
 import type { ErrorResponse } from '@/types/errors'
-import type { Title, TitleCreate, TitleLight, TitleUpdate } from '@/types/title'
+import type { Title, TitleCreate, TitleLight, TitleUpdate, TitleFlavour } from '@/types/title'
 import { translateErrors } from '@/utils/errors'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
@@ -199,6 +199,32 @@ export const useTitleStore = defineStore('title', () => {
     }
   }
 
+  const fetchTitleFlavours = async (titleId: string) => {
+    const service = await authStore.getApiService('titles')
+    try {
+      const response = await service.get<null, ListResponse<TitleFlavour>>(`/${titleId}/flavours`)
+      return response.items
+    } catch (_error) {
+      console.error('Failed to fetch flavours for title', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
+  const deleteTitleFlavour = async (titleId: string, flavour: string) => {
+    const service = await authStore.getApiService('titles')
+    try {
+      const response = await service.delete<null, Record<string, string>>(
+        `/${titleId}/flavours/${flavour}`,
+      )
+      return response
+    } catch (_error) {
+      console.error('Failed to delete flavour for title', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
   return {
     // State
     title,
@@ -218,5 +244,7 @@ export const useTitleStore = defineStore('title', () => {
     archiveTitles,
     restoreTitles,
     mergeTitles,
+    deleteTitleFlavour,
+    fetchTitleFlavours,
   }
 })

--- a/frontend/src/types/title.ts
+++ b/frontend/src/types/title.ts
@@ -1,4 +1,4 @@
-import type { BookLight } from './book'
+import type { BookLight } from '@/types/book'
 
 export interface WarehousePathInfo {
   path_id: string
@@ -17,7 +17,8 @@ export interface TitleCollection extends BaseTitleCollection {
 
 export interface TitleFlavour {
   flavour: string
-  recipe_id: string
+  recipe_id: string | null
+  recipe_link: string | null
 }
 
 export interface TitleLight {

--- a/frontend/src/views/TitleView.vue
+++ b/frontend/src/views/TitleView.vue
@@ -18,6 +18,13 @@
     </div>
 
     <div v-if="dataLoaded && title">
+      <v-row>
+        <v-col>
+          <h2 class="text-h6 text-md-h5">
+            <code>{{ title.name }}</code>
+          </h2>
+        </v-col>
+      </v-row>
       <v-tabs
         v-model="currentTab"
         class="mb-4"
@@ -36,6 +43,18 @@
         >
           <v-icon class="mr-2">mdi-information</v-icon>
           Info
+        </v-tab>
+
+        <v-tab
+          base-color="primary"
+          value="flavours"
+          :to="{
+            name: 'title-detail-tab',
+            params: { id: title.name, selectedTab: 'flavours' },
+          }"
+        >
+          <v-icon class="mr-2">mdi-tag-multiple</v-icon>
+          Flavours
         </v-tab>
 
         <v-tab
@@ -133,28 +152,6 @@
                   </v-col>
                   <v-col cols="12" md="9">
                     {{ title.maturity }}
-                  </v-col>
-                </v-row>
-                <v-divider class="my-2"></v-divider>
-
-                <v-row no-gutters class="py-2">
-                  <v-col cols="12" md="3">
-                    <div class="text-subtitle-2">Expected Flavours</div>
-                  </v-col>
-                  <v-col cols="12" md="9">
-                    <div v-if="title.flavours && title.flavours.length > 0">
-                      <v-chip
-                        v-for="tf in title.flavours"
-                        :key="tf.flavour"
-                        size="small"
-                        variant="outlined"
-                        color="primary"
-                        class="mr-2 mb-1"
-                      >
-                        {{ tf.flavour == '' ? 'Empty' : tf.flavour }}
-                      </v-chip>
-                    </div>
-                    <span v-else class="text-grey">No flavours set</span>
                   </v-col>
                 </v-row>
                 <v-divider class="my-2"></v-divider>
@@ -330,6 +327,31 @@
           </v-card>
         </v-window-item>
 
+        <!-- Flavours Tab -->
+        <v-window-item value="flavours">
+          <v-card flat>
+            <v-card-text class="pa-0">
+              <div v-if="loadingFlavours" class="text-center pa-8">
+                <v-progress-circular indeterminate size="24" class="mr-2" />
+                <span>Loading flavours...</span>
+              </div>
+              <div v-else class="ml-4 mr-4 mt-2 mb-2">
+                <div v-if="titleFlavours && titleFlavours.length > 0">
+                  <TitleFlavourItem
+                    v-for="tf in titleFlavours"
+                    :key="tf.flavour"
+                    :flavour="tf"
+                    :can-delete="!!canEditTitle"
+                    :disabled="deletingFlavour"
+                    @delete="handleDeleteFlavour"
+                  />
+                </div>
+                <div v-else class="py-4 text-center text-grey">No flavours set</div>
+              </div>
+            </v-card-text>
+          </v-card>
+        </v-window-item>
+
         <v-window-item value="history">
           <TitleHistory
             v-if="canEditTitle"
@@ -486,8 +508,10 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useDisplay } from 'vuetify'
 import TitleHistory from '@/components/TitleHistory.vue'
+import TitleFlavourItem from '@/components/TitleFlavourItem.vue'
 import { diff } from 'deep-diff'
 import type { EnhancedDiff } from '@/utils/diff'
+import type { TitleFlavour } from '@/types/title'
 
 const router = useRouter()
 
@@ -584,6 +608,9 @@ const bookStatusOptions = [
   { title: 'To Be Deleted', value: 'to_delete' },
   { title: 'All', value: 'all' },
 ]
+const titleFlavours = ref<TitleFlavour[]>([])
+const loadingFlavours = ref(false)
+const deletingFlavour = ref(false)
 
 const titleDifferences = computed(() => {
   if (!(title.value && pendingUpdatePayload.value)) return undefined
@@ -867,6 +894,44 @@ async function fetchCollections() {
   }
 }
 
+const loadFlavours = async () => {
+  if (!title.value) return
+
+  loadingFlavours.value = true
+  try {
+    const flavours = await titleStore.fetchTitleFlavours(title.value.name)
+    if (flavours) {
+      titleFlavours.value = flavours
+    }
+  } catch (err) {
+    console.error('Failed to load flavours', err)
+  } finally {
+    loadingFlavours.value = false
+  }
+}
+
+const handleDeleteFlavour = async (flavour: string) => {
+  if (!title.value) return
+
+  deletingFlavour.value = true
+  try {
+    const response = await titleStore.deleteTitleFlavour(title.value.name, flavour)
+    if (response) {
+      notificationStore.showSuccess(
+        `Flavour <code>${flavour === '' ? 'Empty' : flavour}</code> has been deleted.`,
+      )
+      await loadFlavours()
+    } else {
+      notificationStore.showErrors(titleStore.errors)
+    }
+  } catch (err) {
+    console.error('Failed to delete flavour', err)
+    notificationStore.showError('Failed to delete flavour')
+  } finally {
+    deletingFlavour.value = false
+  }
+}
+
 onMounted(async () => {
   await loadData(true, props.selectedTab === 'history', props.selectedTab === 'details')
 
@@ -875,9 +940,13 @@ onMounted(async () => {
   }
 
   // Redirect to details if trying to access restricted tabs without permission
-  if (props.selectedTab !== 'details' && !canEditTitle.value) {
+  if (props.selectedTab !== 'details' && props.selectedTab !== 'flavours' && !canEditTitle.value) {
     router.push({ name: 'title-detail', params: { id: props.id } })
     return
+  }
+
+  if (props.selectedTab === 'flavours' && title.value) {
+    await loadFlavours()
   }
 
   if (props.selectedTab === 'edit' && title.value) {
@@ -903,6 +972,10 @@ watch(
     currentTab.value = newTab
 
     await loadData(newTab == 'edit', newTab === 'history', newTab === 'details')
+
+    if (newTab === 'flavours' && title.value) {
+      await loadFlavours()
+    }
 
     if (newTab === 'edit' && title.value) {
       if (collections.value.length == 0) {


### PR DESCRIPTION
## Changes
- move flavours away from title edit and info tabs and create dedicated tab for viewing flavours
- add functionality to delete title flavour. this marks books belonging to the same flavour and title for deletion
- import top level module name instead of individual functions in module to reduce aliasing for the individual functions
- add title name header to detail tab

<img width="1126" height="464" alt="Screenshot_20260713_135039" src="https://github.com/user-attachments/assets/106cb114-8cbb-43f3-a3b9-cc5d94f9415a" />

<img width="1139" height="601" alt="Screenshot_20260713_135104" src="https://github.com/user-attachments/assets/a1ac08de-f514-4218-86e0-ca3d33f6f280" />

This closes #396 