### PR TITLE
show buttons to set title metadata from title

### DIFF
--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -419,7 +419,7 @@ def recover_book(session: OrmSession, book_id: UUID) -> Book:
 def get_differing_metadata_keys(book: Book) -> list[str]:
     """Get the list of metadata keys that are different between book and it's title.
 
-    Assumes book and title both have mandatory metadata set.
+    Assumes book has mandatory metadata set.
     Assumes that the book name and title name already match, thus aren't checked.
     """
 
@@ -433,6 +433,10 @@ def get_differing_metadata_keys(book: Book) -> list[str]:
         "Description": book.zim_metadata["Description"],
         "Language": book.zim_metadata["Language"],
         "Illustration_48x48@1": book.zim_metadata["Illustration_48x48@1"],
+        "LongDescription": book.zim_metadata.get("LongDescription"),
+        "License": book.zim_metadata.get("License"),
+        "Relation": book.zim_metadata.get("Relation"),
+        "Source": book.zim_metadata.get("Source"),
     }
 
     title_metadata = {
@@ -442,6 +446,10 @@ def get_differing_metadata_keys(book: Book) -> list[str]:
         "Description": book.title.description,
         "Language": book.title.language,
         "Illustration_48x48@1": book.title.illustration_48x48_at_1,
+        "LongDescription": book.title.long_description,
+        "License": book.title.license,
+        "Relation": book.title.relation,
+        "Source": book.title.source,
     }
 
     return [key for key in book_metadata if book_metadata[key] != title_metadata[key]]

--- a/backend/src/cms_backend/db/book_actions.py
+++ b/backend/src/cms_backend/db/book_actions.py
@@ -22,7 +22,6 @@ from cms_backend.db.flavour import (
     get_title_flavour_or_none,
 )
 from cms_backend.db.models import Book
-from cms_backend.db.rules import title_is_missing_mandatory_metadata
 from cms_backend.db.title import create_title, restore_title, update_title
 from cms_backend.schemas.models import (
     BaseBookPromotionAction,
@@ -39,6 +38,169 @@ from cms_backend.utils.zim import (
     get_missing_keys,
     get_missing_metadata_keys,
 )
+
+
+def _get_update_title_metadata_action(book: Book) -> BookPromotionAction | None:
+    if differing_metadata_keys := get_differing_metadata_keys(book):
+        metadata_to_identifier_map = {
+            "Title": "title",
+            "Creator": "creator",
+            "Publisher": "publisher",
+            "Description": "description",
+            "Language": "language",
+            "Illustration_48x48@1": "illustration_48x48_at_1",
+            "LongDescription": "long_description",
+            "License": "license",
+            "Relation": "relation",
+            "Source": "source",
+        }
+        return BookPromotionAction(
+            kind="update_title_metadata",
+            requirement="optional",
+            data={
+                metadata_to_identifier_map[key]: book.zim_metadata.get(key)
+                for key in differing_metadata_keys
+            },
+            message="Update title metadata from book",
+        )
+
+
+def _get_unknown_languages_action(book: Book) -> BookPromotionAction | None:
+    unknown_languages = get_book_unsupported_languages(book)
+    if unknown_languages:
+        return BookPromotionAction(
+            kind="unknown_languages",
+            requirement="information",
+            data={},
+            message=(
+                "Book has unknown language code(s): "
+                f"{','.join(unknown_languages)}. "
+                "Please contact a CMS admin if code(s) look legit to you."
+            ),
+        )
+
+
+def _get_zimcheck_issues_action(book: Book) -> BookPromotionAction | None:
+    zimcheck_errors = get_zimcheck_errors(book, raise_exceptions=False)
+    if zimcheck_errors and book.zimcheck_summary:
+        zimcheck_summary = ZimcheckSummarySchema.model_validate(book.zimcheck_summary)
+        return BookPromotionAction(
+            kind="zimcheck_issues",
+            requirement="information",
+            data={},
+            message=f"Book has {zimcheck_summary.error_count} zimcheck error(s). ",
+        )
+
+
+def _get_create_title_action(book: Book) -> BookPromotionAction | None:
+    if book.title is None:
+        return BookPromotionAction(
+            kind="create_title",
+            requirement="mandatory",
+            data={
+                "name": book.name,
+                "maturity": "stable",
+                "title": book.zim_metadata["Title"],
+                "creator": book.zim_metadata["Creator"],
+                "publisher": book.zim_metadata["Publisher"],
+                "description": book.zim_metadata["Description"],
+                "language": book.zim_metadata["Language"],
+                "illustration_48x48_at_1": book.zim_metadata["Illustration_48x48@1"],
+                "flavours": [
+                    {
+                        "flavour": book.flavour,
+                        "recipe_link": construct_recipe_link(book.recipe_id),
+                    }
+                ],
+                "collection_titles": [],
+            },
+            message="Create new title. Please configure title collection(s).",
+        )
+
+
+def _get_restore_title_action(book: Book) -> BookPromotionAction | None:
+    if book.title is None:
+        raise ValueError("Book must be associated with a title")
+
+    if book.title.archived:
+        return BookPromotionAction(
+            kind="restore_title",
+            requirement="mandatory",
+            data={"title_names": [book.title.name]},
+            message=f"Restore title '{book.title.name}' from archive",
+        )
+
+
+def _get_update_title_maturity_action(book: Book) -> BookPromotionAction | None:
+    if book.title is None:
+        raise ValueError("Book must be associated with a title")
+
+    if book.title.maturity != "stable":
+        return BookPromotionAction(
+            kind="update_title_maturity",
+            requirement="optional",
+            data={
+                "maturity": "stable",
+            },
+            message=f"Mark title '{book.title.maturity}' as stable.",
+        )
+
+
+def _get_set_title_collections_action(book: Book) -> BookPromotionAction | None:
+    if book.title is None:
+        raise ValueError("Book must be associated with a title")
+
+    if len(book.title.collections) == 0:
+        return BookPromotionAction(
+            kind="set_title_collections",
+            requirement="mandatory",
+            data={
+                "collection_titles": [],
+            },
+            message="Configure title collection(s)",
+        )
+
+
+def _get_create_title_flavour_action(book: Book) -> BookPromotionAction | None:
+    if book.title is None:
+        raise ValueError("Book must be associated with a title")
+
+    if book_has_flavour_mismatch(book):
+        title_flavours = [tf.flavour for tf in book.title.flavours]
+        return BookPromotionAction(
+            kind="create_title_flavour",
+            requirement="mandatory",
+            data={
+                "flavour": book.flavour,
+                "recipe_link": construct_recipe_link(book.recipe_id),
+            },
+            message=(
+                f"Add '{book.flavour}' to title flavours: {','.join(title_flavours)}"
+            ),
+        )
+
+
+def _get_update_flavour_recipe_action(
+    session: OrmSession, book: Book
+) -> BookPromotionAction | None:
+    if book.title is None:
+        raise ValueError("Book must be associated with a title")
+
+    if book_has_recipe_issue(book):
+        matching_flavour = get_title_flavour(session, book.title.id, book.flavour)
+        return BookPromotionAction(
+            kind="update_flavour_recipe",
+            requirement="mandatory",
+            data={
+                "recipe_id": book.recipe_id,
+                "recipe_link": construct_recipe_link(book.recipe_id),
+            },
+            message=(
+                f"Update flavour recipe from "
+                f"{construct_recipe_link(matching_flavour.recipe_id)} to "
+                f"{construct_recipe_link(book.recipe_id)}"
+            ),
+        )
 
 
 def get_book_promotion_actions(
@@ -67,150 +229,33 @@ def get_book_promotion_actions(
             "possibly be promoted through to 'prod'"
         )
 
-    unknown_languages = get_book_unsupported_languages(book)
-    if unknown_languages:
-        actions.append(
-            BookPromotionAction(
-                kind="unknown_languages",
-                requirement="information",
-                data={},
-                message=(
-                    "Book has unknown language code(s): "
-                    f"{','.join(unknown_languages)}. "
-                    "Please contact a CMS admin if code(s) look legit to you."
-                ),
-            )
-        )
+    if action := _get_unknown_languages_action(book):
+        actions.append(action)
 
-    zimcheck_errors = get_zimcheck_errors(book, raise_exceptions=False)
-    if zimcheck_errors and book.zimcheck_summary:
-        zimcheck_summary = ZimcheckSummarySchema.model_validate(book.zimcheck_summary)
-        actions.append(
-            BookPromotionAction(
-                kind="zimcheck_issues",
-                requirement="information",
-                data={},
-                message=f"Book has {zimcheck_summary.error_count} zimcheck error(s). ",
-            )
-        )
+    if action := _get_zimcheck_issues_action(book):
+        actions.append(action)
 
-    if book.title is None:
-        actions.append(
-            BookPromotionAction(
-                kind="create_title",
-                requirement="mandatory",
-                data={
-                    "name": book.name,
-                    "maturity": "stable",
-                    "title": book.zim_metadata["Title"],
-                    "creator": book.zim_metadata["Creator"],
-                    "publisher": book.zim_metadata["Publisher"],
-                    "description": book.zim_metadata["Description"],
-                    "language": book.zim_metadata["Language"],
-                    "illustration_48x48_at_1": book.zim_metadata[
-                        "Illustration_48x48@1"
-                    ],
-                    "flavours": [
-                        {
-                            "flavour": book.flavour,
-                            "recipe_link": construct_recipe_link(book.recipe_id),
-                        }
-                    ],
-                    "collection_titles": [],
-                },
-                message="Create new title. Please configure title collection(s).",
-            )
-        )
+    if action := _get_create_title_action(book):
+        actions.append(action)
         return actions
 
-    title = book.title
+    if action := _get_restore_title_action(book):
+        actions.append(action)
 
-    if title.archived:
-        actions.append(
-            BookPromotionAction(
-                kind="restore_title",
-                requirement="mandatory",
-                data={"title_names": [title.name]},
-                message=f"Restore title '{title.name}' from archive",
-            )
-        )
+    if action := _get_update_title_metadata_action(book):
+        actions.append(action)
 
-    if title_is_missing_mandatory_metadata(title) or get_differing_metadata_keys(book):
-        actions.append(
-            BookPromotionAction(
-                kind="update_title_metadata",
-                requirement="optional",
-                data={
-                    "title": book.zim_metadata["Title"],
-                    "creator": book.zim_metadata["Creator"],
-                    "publisher": book.zim_metadata["Publisher"],
-                    "description": book.zim_metadata["Description"],
-                    "language": book.zim_metadata["Language"],
-                    "illustration_48x48_at_1": book.zim_metadata[
-                        "Illustration_48x48@1"
-                    ],
-                },
-                message="Update title metadata",
-            )
-        )
+    if action := _get_update_title_maturity_action(book):
+        actions.append(action)
 
-    if title.maturity != "stable":
-        actions.append(
-            BookPromotionAction(
-                kind="update_title_maturity",
-                requirement="optional",
-                data={
-                    "maturity": "stable",
-                },
-                message=f"Mark title '{title.maturity}' as stable.",
-            )
-        )
-    if len(title.collections) == 0:
-        actions.append(
-            BookPromotionAction(
-                kind="set_title_collections",
-                requirement="mandatory",
-                data={
-                    "collection_titles": [],
-                },
-                message="Configure title collection(s)",
-            )
-        )
+    if action := _get_set_title_collections_action(book):
+        actions.append(action)
 
-    if book_has_flavour_mismatch(book):
-        title_flavours = [tf.flavour for tf in title.flavours]
-        actions.append(
-            BookPromotionAction(
-                kind="create_title_flavour",
-                requirement="mandatory",
-                data={
-                    "flavour": book.flavour,
-                    "recipe_link": construct_recipe_link(book.recipe_id),
-                },
-                message=(
-                    f"Add '{book.flavour}' to title flavours: "
-                    f"{','.join(title_flavours)}"
-                ),
-            )
-        )
+    if action := _get_create_title_flavour_action(book):
+        actions.append(action)
 
-    if book_has_recipe_issue(book):
-        matching_flavour = get_title_flavour(session, title.id, book.flavour)
-        actions.append(
-            BookPromotionAction(
-                kind="update_flavour_recipe",
-                requirement="mandatory",
-                data={
-                    "recipe_id": book.recipe_id,
-                    "recipe_link": construct_recipe_link(book.recipe_id),
-                },
-                message=(
-                    f"Update flavour recipe from "
-                    f"{construct_recipe_link(matching_flavour.recipe_id)} to "
-                    f"{construct_recipe_link(book.recipe_id)}"
-                ),
-            )
-        )
+    if action := _get_update_flavour_recipe_action(session, book):
+        actions.append(action)
 
     return actions
 
@@ -340,14 +385,13 @@ def apply_book_promotion_actions(
             case "restore_title":
                 _apply_restore_title_action(session, action, book, author_id)
             case "update_title_metadata":
+                expected_action = next(
+                    action
+                    for action in expected_actions
+                    if action.kind == "update_title_metadata"
+                )
                 missing_keys = get_missing_keys(
-                    action.data,
-                    "title",
-                    "creator",
-                    "publisher",
-                    "description",
-                    "language",
-                    "illustration_48x48_at_1",
+                    action.data, *expected_action.data.keys()
                 )
                 if missing_keys:
                     raise ValueError("Title must be updated with mandatory metadata")

--- a/backend/tests/db/test_book_actions.py
+++ b/backend/tests/db/test_book_actions.py
@@ -286,7 +286,7 @@ def test_promotion_actions_missing_mandatory_title_metadata(
     ]
     assert len(metadata_actions) == 1
     assert metadata_actions[0].requirement == "optional"
-    assert metadata_actions[0].data["title"] == "Test Article"
+    assert list(metadata_actions[0].data.keys()) == ["illustration_48x48_at_1"]
     assert (
         metadata_actions[0].data["illustration_48x48_at_1"] == illustration_48x48_at_1
     )

--- a/frontend/src/components/MetadataFieldWithDiff.vue
+++ b/frontend/src/components/MetadataFieldWithDiff.vue
@@ -1,0 +1,48 @@
+<template>
+  <div>
+    <!-- The input field comes from the parent via default slot -->
+    <slot />
+
+    <!-- Diff warning banner -->
+    <div v-if="showDiff" class="text-body-2" :class="{ 'mt-2': hasCustomContent, 'mb-2': true }">
+      <div class="mb-1 text-warning font-weight-medium">
+        {{ diffLabel }}
+      </div>
+      <div class="d-flex align-center justify-space-between" :class="{ 'mb-2': hasCustomContent }">
+        <!-- Custom diff content (e.g. illustration preview) -->
+        <template v-if="hasCustomContent">
+          <slot name="diff-content" />
+        </template>
+        <!-- Default: plain text value -->
+        <template v-else>
+          <strong>{{ diffValue ?? '(no value)' }}</strong>
+        </template>
+
+        <v-btn size="small" variant="outlined" color="warning" class="ml-3" @click="$emit('use')">
+          Use this
+        </v-btn>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, useSlots } from 'vue'
+
+defineProps<{
+  /** Whether to show the diff warning banner */
+  showDiff: boolean
+  /** Label text, e.g. "Different from title which has:" */
+  diffLabel: string
+  /** The comparison value to display (used when no #diff-content slot is provided) */
+  diffValue?: string | null
+}>()
+
+defineEmits<{
+  /** Emitted when the user clicks "Use this" */
+  use: []
+}>()
+
+const slots = useSlots()
+const hasCustomContent = computed(() => !!slots['diff-content'])
+</script>

--- a/frontend/src/components/PromoteBookDialog.vue
+++ b/frontend/src/components/PromoteBookDialog.vue
@@ -132,59 +132,193 @@
 
                     <!-- update_title_metadata -->
                     <template v-else-if="action.kind === 'update_title_metadata'">
-                      <v-row>
+                      <div
+                        v-if="existingTitle && hasAnyFieldDifferentFromTitle(index)"
+                        class="d-flex align-center justify-space-between mb-4"
+                      >
+                        <v-spacer />
+                        <v-btn
+                          color="primary"
+                          variant="elevated"
+                          size="small"
+                          prepend-icon="mdi-download"
+                          @click="useAllTitleValues(index)"
+                        >
+                          Use All from Title
+                        </v-btn>
+                      </div>
+                      <v-row v-if="actionData[index]?.title !== undefined">
                         <v-col cols="12">
-                          <TitleTextField
-                            :model-value="actionData[index].title"
-                            @update:model-value="actionData[index].title = $event"
-                            label="Title"
-                            :max-graphemes="titleMaxLength"
-                          />
+                          <MetadataFieldWithDiff
+                            :show-diff="isFieldDifferentFromTitle(index, 'title')"
+                            diff-label="Different from title which has:"
+                            :diff-value="existingTitle?.title"
+                            @use="useTitleValue(index, 'title')"
+                          >
+                            <TitleTextField
+                              :model-value="actionData[index].title"
+                              @update:model-value="actionData[index].title = $event"
+                              label="Title"
+                              :max-graphemes="titleMaxLength"
+                            />
+                          </MetadataFieldWithDiff>
                         </v-col>
                       </v-row>
-                      <v-row>
+                      <v-row v-if="actionData[index]?.creator !== undefined">
                         <v-col cols="12">
-                          <TitleTextField
-                            :model-value="actionData[index].creator"
-                            @update:model-value="actionData[index].creator = $event"
-                            label="Creator"
-                          />
+                          <MetadataFieldWithDiff
+                            :show-diff="isFieldDifferentFromTitle(index, 'creator')"
+                            diff-label="Different from title which has:"
+                            :diff-value="existingTitle?.creator"
+                            @use="useTitleValue(index, 'creator')"
+                          >
+                            <TitleTextField
+                              :model-value="actionData[index].creator"
+                              @update:model-value="actionData[index].creator = $event"
+                              label="Creator"
+                            />
+                          </MetadataFieldWithDiff>
                         </v-col>
                       </v-row>
-                      <v-row>
+                      <v-row v-if="actionData[index]?.publisher !== undefined">
                         <v-col cols="12">
-                          <TitleTextField
-                            :model-value="actionData[index].publisher"
-                            @update:model-value="actionData[index].publisher = $event"
-                            label="Publisher"
-                          />
+                          <MetadataFieldWithDiff
+                            :show-diff="isFieldDifferentFromTitle(index, 'publisher')"
+                            diff-label="Different from title which has:"
+                            :diff-value="existingTitle?.publisher"
+                            @use="useTitleValue(index, 'publisher')"
+                          >
+                            <TitleTextField
+                              :model-value="actionData[index].publisher"
+                              @update:model-value="actionData[index].publisher = $event"
+                              label="Publisher"
+                            />
+                          </MetadataFieldWithDiff>
                         </v-col>
                       </v-row>
-                      <v-row>
+                      <v-row v-if="actionData[index]?.license !== undefined">
                         <v-col cols="12">
-                          <TitleLanguageField
-                            :model-value="actionData[index].language"
-                            @update:model-value="actionData[index].language = $event"
-                          />
+                          <MetadataFieldWithDiff
+                            :show-diff="isFieldDifferentFromTitle(index, 'license')"
+                            diff-label="Different from title which has:"
+                            :diff-value="existingTitle?.license"
+                            @use="useTitleValue(index, 'license')"
+                          >
+                            <TitleTextField
+                              :model-value="actionData[index].license"
+                              @update:model-value="actionData[index].license = $event"
+                              label="License"
+                            />
+                          </MetadataFieldWithDiff>
                         </v-col>
                       </v-row>
-                      <v-row>
+                      <v-row v-if="actionData[index]?.language !== undefined">
                         <v-col cols="12">
-                          <TitleIllustrationField
-                            :model-value="actionData[index].illustration_48x48_at_1"
-                            @update:model-value="actionData[index].illustration_48x48_at_1 = $event"
-                          />
+                          <MetadataFieldWithDiff
+                            :show-diff="isFieldDifferentFromTitle(index, 'language')"
+                            diff-label="Different from title which has:"
+                            :diff-value="existingTitle?.language"
+                            @use="useTitleValue(index, 'language')"
+                          >
+                            <TitleLanguageField
+                              :model-value="actionData[index].language"
+                              @update:model-value="actionData[index].language = $event"
+                            />
+                          </MetadataFieldWithDiff>
                         </v-col>
                       </v-row>
-                      <v-row>
+                      <v-row v-if="actionData[index]?.illustration_48x48_at_1 !== undefined">
                         <v-col cols="12">
-                          <TitleTextField
-                            :model-value="actionData[index].description"
-                            @update:model-value="actionData[index].description = $event"
-                            label="Description"
-                            textarea
-                            :max-graphemes="descriptionMaxLength"
-                          />
+                          <MetadataFieldWithDiff
+                            :show-diff="isFieldDifferentFromTitle(index, 'illustration_48x48_at_1')"
+                            diff-label="Different from title which has:"
+                            @use="useTitleValue(index, 'illustration_48x48_at_1')"
+                          >
+                            <TitleIllustrationField
+                              :model-value="actionData[index].illustration_48x48_at_1"
+                              @update:model-value="
+                                actionData[index].illustration_48x48_at_1 = $event
+                              "
+                            />
+                            <template #diff-content>
+                              <div class="d-flex flex-column flex-grow-1">
+                                <v-img
+                                  :src="getImageDataUrl(existingTitle?.illustration_48x48_at_1)"
+                                  width="48"
+                                  height="48"
+                                  class="rounded border w-100"
+                                />
+                              </div>
+                            </template>
+                          </MetadataFieldWithDiff>
+                        </v-col>
+                      </v-row>
+                      <v-row v-if="actionData[index]?.description !== undefined">
+                        <v-col cols="12">
+                          <MetadataFieldWithDiff
+                            :show-diff="isFieldDifferentFromTitle(index, 'description')"
+                            diff-label="Different from title which has:"
+                            :diff-value="existingTitle?.description"
+                            @use="useTitleValue(index, 'description')"
+                          >
+                            <TitleTextField
+                              :model-value="actionData[index].description"
+                              @update:model-value="actionData[index].description = $event"
+                              label="Description"
+                              textarea
+                              :max-graphemes="descriptionMaxLength"
+                            />
+                          </MetadataFieldWithDiff>
+                        </v-col>
+                      </v-row>
+                      <v-row v-if="actionData[index]?.long_description !== undefined">
+                        <v-col cols="12">
+                          <MetadataFieldWithDiff
+                            :show-diff="isFieldDifferentFromTitle(index, 'long_description')"
+                            diff-label="Different from title which has:"
+                            :diff-value="existingTitle?.long_description"
+                            @use="useTitleValue(index, 'long_description')"
+                          >
+                            <TitleTextField
+                              :model-value="actionData[index].long_description"
+                              @update:model-value="actionData[index].long_description = $event"
+                              label="Long Description"
+                              textarea
+                              :rows="5"
+                            />
+                          </MetadataFieldWithDiff>
+                        </v-col>
+                      </v-row>
+                      <v-row v-if="actionData[index]?.relation !== undefined">
+                        <v-col cols="12">
+                          <MetadataFieldWithDiff
+                            :show-diff="isFieldDifferentFromTitle(index, 'relation')"
+                            diff-label="Different from title which has:"
+                            :diff-value="existingTitle?.relation"
+                            @use="useTitleValue(index, 'relation')"
+                          >
+                            <TitleTextField
+                              :model-value="actionData[index].relation"
+                              @update:model-value="actionData[index].relation = $event"
+                              label="Relation"
+                            />
+                          </MetadataFieldWithDiff>
+                        </v-col>
+                      </v-row>
+                      <v-row v-if="actionData[index]?.source !== undefined">
+                        <v-col cols="12">
+                          <MetadataFieldWithDiff
+                            :show-diff="isFieldDifferentFromTitle(index, 'source')"
+                            diff-label="Different from title which has:"
+                            :diff-value="existingTitle?.source"
+                            @use="useTitleValue(index, 'source')"
+                          >
+                            <TitleTextField
+                              :model-value="actionData[index].source"
+                              @update:model-value="actionData[index].source = $event"
+                              label="Source"
+                            />
+                          </MetadataFieldWithDiff>
                         </v-col>
                       </v-row>
                     </template>
@@ -347,16 +481,18 @@ import TitleIllustrationField from '@/components/TitleIllustrationField.vue'
 import TitleCollectionsField from '@/components/TitleCollectionsField.vue'
 import TitleMaturityField from '@/components/TitleMaturityField.vue'
 import TitleForm from '@/components/TitleForm.vue'
+import MetadataFieldWithDiff from '@/components/MetadataFieldWithDiff.vue'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import { useBookStore } from '@/stores/book'
 import { useTitleStore } from '@/stores/title'
-import constants from '@/constants'
+import constants, { TITLE_METADATA_FIELDS, type TitleMetadataFieldKey } from '@/constants'
 import type { Config } from '@/config'
 import type { Book, BookPromotionAction } from '@/types/book'
 import type { CollectionLight } from '@/types/collections'
 import type { Title } from '@/types/title'
 import { diff } from 'deep-diff'
 import type { EnhancedDiff } from '@/utils/diff'
+import { getImageDataUrl } from '@/utils/image'
 import DiffViewer from '@/components/DiffViewer.vue'
 import { computed, inject, ref, watch } from 'vue'
 
@@ -436,18 +572,24 @@ const titleDiffs = computed(() => {
           creator: existingTitle.value!.creator,
           publisher: existingTitle.value!.publisher,
           description: existingTitle.value!.description,
+          license: existingTitle.value!.license,
           language: existingTitle.value!.language,
           illustration_48x48_at_1: existingTitle.value!.illustration_48x48_at_1,
           long_description: existingTitle.value!.long_description,
+          relation: existingTitle.value!.relation,
+          source: existingTitle.value!.source,
         }
         next = {
           title: data.title ?? null,
           creator: data.creator ?? null,
           publisher: data.publisher ?? null,
           description: data.description ?? null,
+          license: data.license ?? null,
           language: data.language ?? null,
           illustration_48x48_at_1: data.illustration_48x48_at_1 ?? null,
           long_description: data.long_description ?? null,
+          relation: data.relation ?? null,
+          source: data.source ?? null,
         }
         break
       }
@@ -557,6 +699,41 @@ function formatActionKind(kind: string): string {
 function toggleAction(index: number) {
   if (actions.value[index].requirement !== 'optional') return
   actionChecked.value[index] = !actionChecked.value[index]
+}
+
+// Fields that can be compared between the action data and the existing title
+type TitleMetadataFields = Record<TitleMetadataFieldKey, string | undefined>
+
+function isFieldDifferentFromTitle(index: number, field: keyof TitleMetadataFields): boolean {
+  if (!existingTitle.value) return false
+  const titleValue = existingTitle.value[field]
+  const actionValue = actionData.value[index]?.[field]
+  if (titleValue === undefined) return false
+  return titleValue !== actionValue
+}
+
+function useTitleValue(index: number, field: keyof TitleMetadataFields): void {
+  if (!existingTitle.value) return
+  const value = existingTitle.value[field]
+  if (value !== undefined) {
+    actionData.value[index][field] = value
+  }
+}
+
+const hasAnyFieldDifferentFromTitle = (index: number): boolean => {
+  if (!existingTitle.value) return false
+  return TITLE_METADATA_FIELDS.some(
+    (field) =>
+      actionData.value[index]?.[field] !== undefined && isFieldDifferentFromTitle(index, field),
+  )
+}
+
+function useAllTitleValues(index: number): void {
+  TITLE_METADATA_FIELDS.forEach((field) => {
+    if (actionData.value[index]?.[field] !== undefined && isFieldDifferentFromTitle(index, field)) {
+      useTitleValue(index, field)
+    }
+  })
 }
 
 watch(isOpen, async (newValue) => {

--- a/frontend/src/components/TitleForm.vue
+++ b/frontend/src/components/TitleForm.vue
@@ -33,128 +33,99 @@
 
       <v-row>
         <v-col cols="12" :md="inDialog ? 12 : 6">
-          <TitleTextField v-model="formData.title" label="Title" :max-graphemes="titleMaxLength" />
-          <div v-if="!inDialog && isFieldDifferent('title')" class="text-body-2 mb-2">
-            <div class="mb-1 text-warning font-weight-medium">
-              Different from latest book which has:
-            </div>
-            <div class="d-flex align-center justify-space-between">
-              <strong>{{ bookMetadata?.title }}</strong>
-              <v-btn
-                size="small"
-                variant="outlined"
-                color="warning"
-                class="ml-3"
-                @click="useBookValue('title')"
-                >Use this</v-btn
-              >
-            </div>
-          </div>
+          <MetadataFieldWithDiff
+            :show-diff="!inDialog && isFieldDifferent('title')"
+            diff-label="Different from latest book which has:"
+            :diff-value="bookMetadata?.title"
+            @use="useBookValue('title')"
+          >
+            <TitleTextField
+              v-model="formData.title"
+              label="Title"
+              :max-graphemes="titleMaxLength"
+            />
+          </MetadataFieldWithDiff>
         </v-col>
         <v-col cols="12" :md="inDialog ? 12 : 6">
-          <TitleTextField v-model="formData.creator" label="Creator" />
-          <div v-if="!inDialog && isFieldDifferent('creator')" class="text-body-2 mb-2">
-            <div class="mb-1 text-warning font-weight-medium">
-              Different from latest book which has:
-            </div>
-            <div class="d-flex align-center justify-space-between">
-              <strong>{{ bookMetadata?.creator }}</strong>
-              <v-btn
-                size="small"
-                variant="outlined"
-                color="warning"
-                class="ml-3"
-                @click="useBookValue('creator')"
-                >Use this</v-btn
-              >
-            </div>
-          </div>
+          <MetadataFieldWithDiff
+            :show-diff="!inDialog && isFieldDifferent('creator')"
+            diff-label="Different from latest book which has:"
+            :diff-value="bookMetadata?.creator"
+            @use="useBookValue('creator')"
+          >
+            <TitleTextField v-model="formData.creator" label="Creator" />
+          </MetadataFieldWithDiff>
         </v-col>
       </v-row>
 
       <v-row>
         <v-col cols="12" :md="inDialog ? 12 : 6">
-          <TitleTextField v-model="formData.publisher" label="Publisher" />
-          <div v-if="!inDialog && isFieldDifferent('publisher')" class="text-body-2 mb-2">
-            <div class="mb-1 text-warning font-weight-medium">
-              Different from latest book which has:
-            </div>
-            <div class="d-flex align-center justify-space-between">
-              <strong>{{ bookMetadata?.publisher }}</strong>
-              <v-btn
-                size="small"
-                variant="outlined"
-                color="warning"
-                class="ml-3"
-                @click="useBookValue('publisher')"
-                >Use this</v-btn
-              >
-            </div>
-          </div>
+          <MetadataFieldWithDiff
+            :show-diff="!inDialog && isFieldDifferent('publisher')"
+            diff-label="Different from latest book which has:"
+            :diff-value="bookMetadata?.publisher"
+            @use="useBookValue('publisher')"
+          >
+            <TitleTextField v-model="formData.publisher" label="Publisher" />
+          </MetadataFieldWithDiff>
         </v-col>
         <v-col cols="12" :md="inDialog ? 12 : 6">
-          <TitleLanguageField v-model="formData.language" />
-          <div v-if="!inDialog && isFieldDifferent('language')" class="text-body-2 mb-2">
-            <div class="mb-1 text-warning font-weight-medium">
-              Different from latest book which has:
-            </div>
-            <div class="d-flex align-center justify-space-between">
-              <strong>{{ bookMetadata?.language }}</strong>
-              <v-btn
-                size="small"
-                variant="outlined"
-                color="warning"
-                class="ml-3"
-                @click="useBookValue('language')"
-                >Use this</v-btn
-              >
-            </div>
-          </div>
+          <MetadataFieldWithDiff
+            :show-diff="!inDialog && isFieldDifferent('language')"
+            diff-label="Different from latest book which has:"
+            :diff-value="bookMetadata?.language"
+            @use="useBookValue('language')"
+          >
+            <TitleLanguageField v-model="formData.language" />
+          </MetadataFieldWithDiff>
         </v-col>
       </v-row>
 
       <v-row>
         <v-col cols="12" :md="inDialog ? 12 : 6">
-          <TitleTextField v-model="formData.license" label="License" />
-          <div v-if="!inDialog && isFieldDifferent('license')" class="text-body-2 mb-2">
-            <div class="mb-1 text-warning font-weight-medium">
-              Different from latest book which has:
-            </div>
-            <div class="d-flex align-center justify-space-between">
-              <strong>{{ bookMetadata?.license }}</strong>
-              <v-btn
-                size="small"
-                variant="outlined"
-                color="warning"
-                class="ml-3"
-                @click="useBookValue('license')"
-                >Use this</v-btn
-              >
-            </div>
-          </div>
+          <MetadataFieldWithDiff
+            :show-diff="!inDialog && isFieldDifferent('license')"
+            diff-label="Different from latest book which has:"
+            :diff-value="bookMetadata?.license"
+            @use="useBookValue('license')"
+          >
+            <TitleTextField v-model="formData.license" label="License" />
+          </MetadataFieldWithDiff>
         </v-col>
         <v-col cols="12" :md="inDialog ? 12 : 6">
-          <TitleTextField v-model="formData.relation" label="Relation" />
+          <MetadataFieldWithDiff
+            :show-diff="!inDialog && isFieldDifferent('relation')"
+            diff-label="Different from latest book which has:"
+            :diff-value="bookMetadata?.relation"
+            @use="useBookValue('relation')"
+          >
+            <TitleTextField v-model="formData.relation" label="Relation" />
+          </MetadataFieldWithDiff>
         </v-col>
       </v-row>
 
       <v-row>
         <v-col cols="12" :md="inDialog ? 12 : 6">
-          <TitleTextField v-model="formData.source" label="Source" />
+          <MetadataFieldWithDiff
+            :show-diff="!inDialog && isFieldDifferent('source')"
+            diff-label="Different from latest book which has:"
+            :diff-value="bookMetadata?.source"
+            @use="useBookValue('source')"
+          >
+            <TitleTextField v-model="formData.source" label="Source" />
+          </MetadataFieldWithDiff>
         </v-col>
       </v-row>
 
       <v-row>
         <v-col cols="12">
-          <TitleIllustrationField v-model="formData.illustration_48x48_at_1" />
-          <div
-            v-if="!inDialog && isFieldDifferent('illustration_48x48_at_1')"
-            class="text-body-2 mt-2 mb-2"
+          <MetadataFieldWithDiff
+            :show-diff="!inDialog && isFieldDifferent('illustration_48x48_at_1')"
+            diff-label="Different from latest book which has:"
+            @use="useBookValue('illustration_48x48_at_1')"
           >
-            <div class="mb-1 text-warning font-weight-medium">
-              Different from latest book which has:
-            </div>
-            <div class="d-flex align-center justify-space-between mb-2">
+            <TitleIllustrationField v-model="formData.illustration_48x48_at_1" />
+            <template #diff-content>
               <div class="d-flex flex-column flex-grow-1">
                 <v-img
                   :src="getImageDataUrl(bookMetadata?.illustration_48x48_at_1)"
@@ -164,70 +135,44 @@
                 />
                 <span class="text-caption text-grey-darken-1 mt-1">{{ bookIllustrationSize }}</span>
               </div>
-              <v-btn
-                size="small"
-                variant="outlined"
-                color="warning"
-                class="ml-3"
-                @click="useBookValue('illustration_48x48_at_1')"
-                >Use this</v-btn
-              >
-            </div>
-          </div>
+            </template>
+          </MetadataFieldWithDiff>
         </v-col>
       </v-row>
 
       <v-row>
         <v-col cols="12">
-          <TitleTextField
-            v-model="formData.description"
-            label="Description"
-            textarea
-            :max-graphemes="descriptionMaxLength"
-          />
-          <div v-if="!inDialog && isFieldDifferent('description')" class="text-body-2 mb-2">
-            <div class="mb-1 text-warning font-weight-medium">
-              Different from latest book which has:
-            </div>
-            <div class="d-flex align-center justify-space-between">
-              <strong>{{ bookMetadata?.description }}</strong>
-              <v-btn
-                size="small"
-                variant="outlined"
-                color="warning"
-                class="ml-3"
-                @click="useBookValue('description')"
-                >Use this</v-btn
-              >
-            </div>
-          </div>
+          <MetadataFieldWithDiff
+            :show-diff="!inDialog && isFieldDifferent('description')"
+            diff-label="Different from latest book which has:"
+            :diff-value="bookMetadata?.description"
+            @use="useBookValue('description')"
+          >
+            <TitleTextField
+              v-model="formData.description"
+              label="Description"
+              textarea
+              :max-graphemes="descriptionMaxLength"
+            />
+          </MetadataFieldWithDiff>
         </v-col>
       </v-row>
 
       <v-row v-if="!inDialog">
         <v-col cols="12">
-          <TitleTextField
-            v-model="formData.long_description"
-            label="Long Description"
-            textarea
-            :rows="5"
-          />
-          <div v-if="isFieldDifferent('long_description')" class="text-body-2 mb-2">
-            <div class="mb-1 text-warning font-weight-medium">
-              Different from latest book which has:
-            </div>
-            <div class="d-flex align-center justify-space-between">
-              <strong>{{ bookMetadata?.long_description }}</strong>
-              <v-btn
-                size="small"
-                variant="outlined"
-                color="warning"
-                class="ml-3"
-                @click="useBookValue('long_description')"
-                >Use this</v-btn
-              >
-            </div>
-          </div>
+          <MetadataFieldWithDiff
+            :show-diff="isFieldDifferent('long_description')"
+            diff-label="Different from latest book which has:"
+            :diff-value="bookMetadata?.long_description"
+            @use="useBookValue('long_description')"
+          >
+            <TitleTextField
+              v-model="formData.long_description"
+              label="Long Description"
+              textarea
+              :rows="5"
+            />
+          </MetadataFieldWithDiff>
         </v-col>
       </v-row>
     </div>
@@ -260,13 +205,15 @@ import TitleTextField from '@/components/TitleTextField.vue'
 import TitleLanguageField from '@/components/TitleLanguageField.vue'
 import TitleIllustrationField from '@/components/TitleIllustrationField.vue'
 import TitleCollectionsField from '@/components/TitleCollectionsField.vue'
+import MetadataFieldWithDiff from '@/components/MetadataFieldWithDiff.vue'
 import type { BaseTitleCollection, Title, TitleUpdate } from '@/types/title'
 import type { CollectionLight } from '@/types/collections'
 import type { Book } from '@/types/book'
 import { computed, inject, ref, watch } from 'vue'
-import constants from '@/constants'
+import constants, { TITLE_METADATA_FIELDS, type TitleMetadataFieldKey } from '@/constants'
 import type { Config } from '@/config'
 import { base64ByteSize } from '@/utils/format'
+import { getImageDataUrl } from '@/utils/image'
 
 interface Props {
   title?: Title | null
@@ -313,16 +260,7 @@ const originalCollections = ref<BaseTitleCollection[]>([])
 const isEditMode = computed(() => props.title !== null && props.title.id !== '')
 
 // Book metadata comparison
-type BookMetadataFields = {
-  title: string | undefined
-  creator: string | undefined
-  publisher: string | undefined
-  description: string | undefined
-  long_description: string | undefined
-  language: string | undefined
-  license: string | undefined
-  illustration_48x48_at_1: string | undefined
-}
+type BookMetadataFields = Record<TitleMetadataFieldKey, string | undefined>
 
 const bookMetadata = computed<BookMetadataFields | null>(() => {
   if (!props.latestBook?.zim_metadata) return null
@@ -336,6 +274,8 @@ const bookMetadata = computed<BookMetadataFields | null>(() => {
     language: metadata.Language as string | undefined,
     license: metadata.License as string | undefined,
     illustration_48x48_at_1: metadata['Illustration_48x48@1'] as string | undefined,
+    relation: metadata.Relation as string | undefined,
+    source: metadata.Source as string | undefined,
   }
 })
 
@@ -343,55 +283,28 @@ const isFieldDifferent = (field: keyof BookMetadataFields) => {
   if (!bookMetadata.value || !isEditMode.value) return false
   const bookValue = bookMetadata.value[field]
   const titleValue = formData.value[field as keyof typeof formData.value]
-  if (bookValue === undefined || bookValue === null) return false
-  if (bookValue === titleValue) return false
-  return true
+  if (bookValue === undefined) return false
+  return bookValue !== titleValue
 }
 
 const hasAnyDifferences = computed(() => {
   if (!bookMetadata.value || !isEditMode.value) return false
-  const fields: (keyof BookMetadataFields)[] = [
-    'title',
-    'creator',
-    'publisher',
-    'description',
-    'long_description',
-    'language',
-    'license',
-    'illustration_48x48_at_1',
-  ]
-  return fields.some((field) => isFieldDifferent(field))
+  return TITLE_METADATA_FIELDS.some((field) => isFieldDifferent(field))
 })
 
 const useBookValue = (field: keyof BookMetadataFields) => {
   if (!bookMetadata.value) return
   const value = bookMetadata.value[field]
-  if (value !== undefined && value !== null) {
+  if (value !== undefined) {
     ;(formData.value[field as keyof typeof formData.value] as string | null) = value
   }
 }
 
 const useAllBookValues = () => {
   if (!bookMetadata.value) return
-  const fields: (keyof BookMetadataFields)[] = [
-    'title',
-    'creator',
-    'publisher',
-    'description',
-    'long_description',
-    'language',
-    'license',
-    'illustration_48x48_at_1',
-  ]
-  fields.forEach((field) => {
+  TITLE_METADATA_FIELDS.forEach((field) => {
     if (isFieldDifferent(field)) useBookValue(field)
   })
-}
-
-const getImageDataUrl = (base64String: string | undefined): string | undefined => {
-  if (!base64String) return undefined
-  if (base64String.startsWith('data:') || base64String.startsWith('http')) return base64String
-  return `data:image/png;base64,${base64String}`
 }
 
 const bookIllustrationSize = computed(() => {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,6 +1,21 @@
 import type { Config } from '@/config'
 import type { InjectionKey } from 'vue'
 
+export const TITLE_METADATA_FIELDS = [
+  'title',
+  'creator',
+  'publisher',
+  'license',
+  'language',
+  'illustration_48x48_at_1',
+  'description',
+  'long_description',
+  'relation',
+  'source',
+] as const
+
+export type TitleMetadataFieldKey = (typeof TITLE_METADATA_FIELDS)[number]
+
 export default {
   config: Symbol() as InjectionKey<Config>,
   COOKIE_LIFETIME_EXPIRY: '10y', // 10 years

--- a/frontend/src/utils/image.ts
+++ b/frontend/src/utils/image.ts
@@ -1,0 +1,5 @@
+export function getImageDataUrl(base64String: string | null | undefined): string | undefined {
+  if (!base64String) return undefined
+  if (base64String.startsWith('data:') || base64String.startsWith('http')) return base64String
+  return `data:image/png;base64,${base64String}`
+}


### PR DESCRIPTION
## Changes
- include in message that updates to title metadata are coming from book
- show difference between title metadata and book metadata and show button to use title metadata instead of book metadata
- include `License` and `LongDescription` book metadata

<img width="922" height="569" alt="Screenshot_20260720_154659" src="https://github.com/user-attachments/assets/74ee048c-3db5-45e6-b332-22ba220e966a" />
<img width="913" height="585" alt="Screenshot_20260720_154641" src="https://github.com/user-attachments/assets/50e38fdf-1d43-4704-a6e7-523f76ddd210" />


This fixes #431 