### PR TITLE
convert recipe ID to string in title history entry

### DIFF
--- a/backend/src/cms_backend/db/book_actions.py
+++ b/backend/src/cms_backend/db/book_actions.py
@@ -390,11 +390,14 @@ def apply_book_promotion_actions(
                     for action in expected_actions
                     if action.kind == "update_title_metadata"
                 )
-                missing_keys = get_missing_keys(
-                    action.data, *expected_action.data.keys()
+                missing_keys = set(expected_action.data.keys()) - set(
+                    action.data.keys()
                 )
                 if missing_keys:
-                    raise ValueError("Title must be updated with mandatory metadata")
+                    raise ValueError(
+                        "Title must be updated with all metadata keys: "
+                        f"{' '.join(missing_keys)}"
+                    )
                 title_update_payload.update(**action.data)
             case "update_title_maturity":
                 if get_missing_keys(action.data, "maturity"):

--- a/backend/src/cms_backend/db/title.py
+++ b/backend/src/cms_backend/db/title.py
@@ -368,7 +368,11 @@ def create_title_history_entry(
         maturity=title.maturity,
         archived=title.archived,
         flavours=[
-            {"flavour": tf.flavour, "recipe_id": tf.recipe_id} for tf in title.flavours
+            {
+                "flavour": tf.flavour,
+                "recipe_id": str(tf.recipe_id) if tf.recipe_id else None,
+            }
+            for tf in title.flavours
         ],
         collection_titles=[
             {


### PR DESCRIPTION
## Changes
- convert recipe_id to string while dumping title history entry in DB
- relax logic to detect missing keys in title metadata update as some metadata values can be `None`

This fixes #440 