### PR TITLE
update recipe flags on zimfarm

### DIFF
--- a/backend/src/cms_backend/schemas/orms.py
+++ b/backend/src/cms_backend/schemas/orms.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, TypeVar
 from uuid import UUID
 
-from pydantic import Field, computed_field
+from pydantic import computed_field
 
 from cms_backend import construct_recipe_api_link, construct_recipe_link
 from cms_backend.context import Context
@@ -194,12 +194,17 @@ class BookFullSchema(BookLightSchema):
     has_backup: bool
     zimcheck_summary: ZimcheckSummarySchema | None
     zimcheck_s3_deleted: bool
-    recipe_id: UUID | None = Field(exclude=True)
+    recipe_id: UUID | None
 
     @computed_field
     @property
     def recipe_link(self) -> str | None:
         return construct_recipe_link(self.recipe_id)
+
+    @computed_field
+    @property
+    def recipe_api_link(self) -> str | None:
+        return construct_recipe_api_link(self.recipe_id)
 
 
 class BookHistorySchema(BaseModel):

--- a/frontend/src/components/MetadataFieldWithDiff.vue
+++ b/frontend/src/components/MetadataFieldWithDiff.vue
@@ -30,7 +30,7 @@
 import { computed, useSlots } from 'vue'
 
 defineProps<{
-  /** Whether to show the diff warning banner */
+  /** Whether to show the diff banner */
   showDiff: boolean
   /** Label text, e.g. "Different from title which has:" */
   diffLabel: string

--- a/frontend/src/components/PromoteBookDialog.vue
+++ b/frontend/src/components/PromoteBookDialog.vue
@@ -132,20 +132,28 @@
 
                     <!-- update_title_metadata -->
                     <template v-else-if="action.kind === 'update_title_metadata'">
-                      <div
-                        v-if="existingTitle && hasAnyFieldDifferentFromTitle(index)"
-                        class="d-flex align-center justify-space-between mb-4"
-                      >
-                        <v-spacer />
-                        <v-btn
-                          color="primary"
-                          variant="elevated"
-                          size="small"
-                          prepend-icon="mdi-download"
-                          @click="useAllTitleValues(index)"
-                        >
-                          Use All from Title
-                        </v-btn>
+                      <div class="d-flex align-center justify-space-between mb-4">
+                        <div class="d-flex align-center ga-2">
+                          <v-progress-circular
+                            v-if="loadingRecipeMetadata"
+                            indeterminate
+                            size="16"
+                            width="2"
+                            class="mr-2"
+                          />
+                        </div>
+                        <div class="d-flex align-center ga-2">
+                          <v-btn
+                            v-if="existingTitle && hasAnyFieldDifferentFromTitle(index)"
+                            color="primary"
+                            variant="elevated"
+                            size="small"
+                            prepend-icon="mdi-download"
+                            @click="useAllTitleValues(index)"
+                          >
+                            Use All from Title
+                          </v-btn>
+                        </div>
                       </div>
                       <v-row v-if="actionData[index]?.title !== undefined">
                         <v-col cols="12">
@@ -242,12 +250,15 @@
                             />
                             <template #diff-content>
                               <div class="d-flex flex-column flex-grow-1">
-                                <v-img
-                                  :src="getImageDataUrl(existingTitle?.illustration_48x48_at_1)"
-                                  width="48"
-                                  height="48"
-                                  class="rounded border w-100"
-                                />
+                                <template v-if="existingTitle?.illustration_48x48_at_1">
+                                  <v-img
+                                    :src="getImageDataUrl(existingTitle.illustration_48x48_at_1)"
+                                    width="48"
+                                    height="48"
+                                    class="rounded border w-100"
+                                  />
+                                </template>
+                                <strong v-else>(no value)</strong>
                               </div>
                             </template>
                           </MetadataFieldWithDiff>
@@ -472,6 +483,17 @@
       </div>
     </template>
   </ConfirmDialog>
+
+  <RecipeUpdateDialog
+    v-if="recipeOfflinerDefFlag && recipeOfflinerDefSpec"
+    v-model="showRecipeUpdateDialog"
+    :recipe-metadata="recipeMetadata"
+    :actions="actions"
+    :action-data="actionData"
+    :def-flag="recipeOfflinerDefFlag"
+    :def-spec="recipeOfflinerDefSpec"
+    :recipe-link="props.book?.recipe_link"
+  />
 </template>
 
 <script setup lang="ts">
@@ -485,15 +507,22 @@ import MetadataFieldWithDiff from '@/components/MetadataFieldWithDiff.vue'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import { useBookStore } from '@/stores/book'
 import { useTitleStore } from '@/stores/title'
+import { useNotificationStore } from '@/stores/notification'
+import { useZimfarmRecipeStore } from '@/stores/zimfarm/recipe'
+import { useZimfarmOfflinerStore } from '@/stores/zimfarm/offliner'
 import constants, { TITLE_METADATA_FIELDS, type TitleMetadataFieldKey } from '@/constants'
 import type { Config } from '@/config'
 import type { Book, BookPromotionAction } from '@/types/book'
 import type { CollectionLight } from '@/types/collections'
 import type { Title } from '@/types/title'
+import type { OfflinerDefinitionFlag, OfflinerDefinitionSpec } from '@/types/zimfarm/offliner'
 import { diff } from 'deep-diff'
 import type { EnhancedDiff } from '@/utils/diff'
 import { getImageDataUrl } from '@/utils/image'
+import { extractRecipeMetadataValues } from '@/utils/recipe'
+import httpRequest from '@/utils/httpRequest'
 import DiffViewer from '@/components/DiffViewer.vue'
+import RecipeUpdateDialog from '@/components/RecipeUpdateDialog.vue'
 import { computed, inject, ref, watch } from 'vue'
 
 interface Props {
@@ -512,6 +541,9 @@ const emit = defineEmits<{
 const config = inject<Config>(constants.config)!
 const bookStore = useBookStore()
 const titleStore = useTitleStore()
+const notificationStore = useNotificationStore()
+const recipeStore = useZimfarmRecipeStore()
+const offlinerStore = useZimfarmOfflinerStore()
 
 const isOpen = computed({
   get: () => props.modelValue,
@@ -532,6 +564,31 @@ const existingTitle = ref<Title | null>(null)
 const submitting = ref(false)
 const submitError = ref<string | null>(null)
 const showConfirmDialog = ref(false)
+const loadingRecipeMetadata = ref(false)
+
+/** Resolved recipe metadata values keyed by CMS field name. */
+const recipeMetadata = ref<Record<string, string | null>>({})
+const recipeOfflinerDefFlag = ref<OfflinerDefinitionFlag | null>(null)
+const recipeOfflinerDefSpec = ref<OfflinerDefinitionSpec | null>(null)
+const showRecipeUpdateDialog = ref(false)
+
+const hasRecipeMetadataDifferences = computed(() => {
+  if (Object.values(recipeMetadata.value).every((v) => v == null)) return false
+
+  const metaAction = actions.value.find((a) => a.kind === 'update_title_metadata')
+  if (!metaAction) return false
+
+  const index = actions.value.indexOf(metaAction)
+  const newData = actionData.value[index]
+  if (!newData) return false
+
+  for (const field of TITLE_METADATA_FIELDS) {
+    if (newData[field] !== undefined && newData[field] !== (recipeMetadata.value[field] ?? null)) {
+      return true
+    }
+  }
+  return false
+})
 
 const hasAnyActionChecked = computed(() => {
   // Allow promoting when all actions are purely informational
@@ -726,6 +783,58 @@ function useAllTitleValues(index: number): void {
   })
 }
 
+async function loadRecipeMetadata(recipeId: string) {
+  const recipe = await recipeStore.fetchRecipe(recipeId)
+  if (!recipe) {
+    console.warn('Failed to fetch recipe:', recipeId)
+    return
+  }
+
+  const [defFlag, defSpec] = await Promise.all([
+    offlinerStore.fetchOfflinerDefinitionFlag(recipe.offliner, recipe.version),
+    offlinerStore.fetchOfflinerDefinitionSpec(recipe.offliner, recipe.version),
+  ])
+
+  if (!defFlag || !defSpec) {
+    console.warn('Failed to fetch offliner definitions for', recipe.offliner, recipe.version)
+    return
+  }
+
+  recipeMetadata.value = extractRecipeMetadataValues(defFlag, defSpec, recipe.config.offliner)
+  recipeOfflinerDefFlag.value = defFlag
+  recipeOfflinerDefSpec.value = defSpec
+
+  // If the illustration is a URL, fetch it upfront and convert to base64. This is
+  // because zimfarm API accepts blobs as bas64 strings and our blob diff viewer
+  // also uses base64 strings when showing comparison
+  const illustrationValue = recipeMetadata.value['illustration_48x48_at_1']
+  if (illustrationValue && illustrationValue.startsWith('http')) {
+    try {
+      const service = httpRequest({})
+      const blob = await service.get<unknown, Blob>(illustrationValue, {
+        responseType: 'blob',
+      })
+      if (blob) {
+        const dataUrl: string = await new Promise((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onloadend = () => resolve(reader.result as string)
+          reader.onerror = () => reject(reader.error)
+          reader.readAsDataURL(blob)
+        })
+        recipeMetadata.value['illustration_48x48_at_1'] = dataUrl.includes(',')
+          ? dataUrl.split(',')[1]
+          : dataUrl
+      } else {
+        recipeMetadata.value['illustration_48x48_at_1'] = null
+        notificationStore.showError('Failed to fetch recipe illustration')
+      }
+    } catch {
+      recipeMetadata.value['illustration_48x48_at_1'] = null
+      notificationStore.showError('Failed to fetch recipe illustration')
+    }
+  }
+}
+
 watch(isOpen, async (newValue) => {
   if (newValue && props.book) await loadDryRun()
 })
@@ -739,6 +848,7 @@ async function loadDryRun() {
   actions.value = []
   actionChecked.value = {}
   actionData.value = {}
+  recipeMetadata.value = {}
 
   if (props.book.title_id) {
     existingTitle.value = await titleStore.fetchTitleById(props.book.title_id)
@@ -761,6 +871,18 @@ async function loadDryRun() {
     dryRunError.value = 'An unexpected error occurred while analyzing promotion requirements'
   } finally {
     loadingDryRun.value = false
+  }
+
+  // Fetch recipe metadata if we have an update_title_metadata action
+  if (props.book.recipe_id && actions.value.some((a) => a.kind === 'update_title_metadata')) {
+    loadingRecipeMetadata.value = true
+    try {
+      await loadRecipeMetadata(props.book.recipe_id)
+    } catch (err) {
+      console.error('Failed to resolve recipe metadata', err)
+    } finally {
+      loadingRecipeMetadata.value = false
+    }
   }
 }
 
@@ -808,6 +930,10 @@ async function executePromote() {
 
     emit('promoted')
     isOpen.value = false
+
+    if (hasRecipeMetadataDifferences.value && props.book.recipe_id) {
+      showRecipeUpdateDialog.value = true
+    }
   } catch (err) {
     console.error('Failed to promote book', err)
     submitError.value = 'An unexpected error occurred while promoting the book'

--- a/frontend/src/components/RecipeUpdateDialog.vue
+++ b/frontend/src/components/RecipeUpdateDialog.vue
@@ -1,0 +1,483 @@
+<template>
+  <v-dialog v-if="canShow" v-model="isOpen" max-width="700px" persistent>
+    <v-card>
+      <v-card-title class="text-h5 pa-4 bg-primary">
+        <span class="text-white">Update Recipe on Zimfarm</span>
+      </v-card-title>
+
+      <v-card-text class="pt-4">
+        <v-alert
+          v-if="error && !permissionDenied"
+          type="error"
+          variant="tonal"
+          class="mb-4"
+          closable
+          @click:close="clearError"
+        >
+          {{ error }}
+        </v-alert>
+
+        <div v-if="checkingAuth || loading" class="text-center pa-8">
+          <v-progress-circular indeterminate size="48" />
+          <div class="mt-3 text-body-2 text-medium-emphasis">
+            {{ loadingMessage }}
+          </div>
+        </div>
+
+        <div v-else-if="needsAuth">
+          <p class="text-body-2 mb-3">
+            You need to authenticate with the Zimfarm API to update the recipe.
+          </p>
+          <v-text-field
+            v-model="username"
+            label="Zimfarm Username"
+            variant="outlined"
+            density="compact"
+            class="mb-2"
+            :disabled="authLoading"
+          />
+          <v-text-field
+            v-model="password"
+            label="Zimfarm Password"
+            type="password"
+            variant="outlined"
+            density="compact"
+            class="mb-3"
+            :disabled="authLoading"
+            @keyup.enter="authenticate"
+          />
+        </div>
+
+        <!-- Ready: authenticated, show diffs and field selection -->
+        <div v-else>
+          <v-alert v-if="permissionDenied" type="warning" variant="tonal" class="mb-4">
+            You do not have permission to update recipes on the Zimfarm API.
+          </v-alert>
+
+          <template v-if="!permissionDenied">
+            <p class="text-body-2 text-medium-emphasis mb-2">
+              The following title metadata values differ from the current recipe configuration.
+              Select the fields you would like to update on Zimfarm.
+            </p>
+
+            <p class="text-body-2 mb-3" v-if="props.recipeLink">
+              <a
+                :href="props.recipeLink"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-primary"
+              >
+                View Recipe on Zimfarm <v-icon size="x-small">mdi-open-in-new</v-icon>
+              </a>
+            </p>
+
+            <!-- Field selection checkboxes -->
+            <div v-if="Object.keys(fieldSelection).length > 0" class="mb-4">
+              <v-label class="text-body-2 font-weight-bold mb-2 d-block">Fields to update:</v-label>
+              <v-checkbox
+                v-for="key in Object.keys(fieldSelection)"
+                :key="key"
+                v-model="fieldSelection[key]"
+                :label="key"
+                density="compact"
+                hide-details
+              />
+            </div>
+
+            <DiffViewer v-if="diffs.length" :differences="diffs" class="mb-4" />
+            <p v-else class="text-body-2 text-medium-emphasis mb-4">
+              No configuration differences detected.
+            </p>
+          </template>
+        </div>
+      </v-card-text>
+
+      <v-card-actions class="pa-4">
+        <v-spacer />
+        <v-btn variant="text" :disabled="loading || checkingAuth" @click="close"> Skip </v-btn>
+
+        <!-- Auth form actions -->
+        <template v-if="needsAuth">
+          <v-btn
+            color="primary"
+            variant="elevated"
+            :loading="authLoading"
+            :disabled="!username || !password"
+            @click="authenticate"
+          >
+            Authenticate
+          </v-btn>
+        </template>
+
+        <v-btn v-if="canUpdateRecipe" color="primary" variant="elevated" @click="onConfirm">
+          Update Recipe
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+
+  <!-- Confirmation dialog shown before asking for credentials -->
+  <ConfirmDialog
+    v-model="showAuthConfirm"
+    title="Update Recipe on Zimfarm"
+    confirm-text="Proceed"
+    cancel-text="Cancel"
+    confirm-color="primary"
+    icon="mdi-information-outline"
+    icon-color="info"
+    @confirm="onAuthConfirm"
+    @cancel="onAuthCancel"
+  >
+    <template #content>
+      <p class="mb-3">
+        The following changes have been detected. Would you like to update the recipe on Zimfarm?
+      </p>
+      <DiffViewer :differences="allDiffs" />
+    </template>
+  </ConfirmDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { diff } from 'deep-diff'
+import type { EnhancedDiff } from '@/utils/diff'
+import { ZIM_METADATA_TO_CMS_FIELD } from '@/utils/recipe'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import DiffViewer from '@/components/DiffViewer.vue'
+import { useAuthStore } from '@/stores/auth'
+import { useNotificationStore } from '@/stores/notification'
+import { useZimfarmRecipeStore } from '@/stores/zimfarm/recipe'
+import type { BookPromotionAction } from '@/types/book'
+import type { User } from '@/types/user'
+import type { OfflinerDefinitionFlag, OfflinerDefinitionSpec } from '@/types/zimfarm/offliner'
+
+const props = defineProps<{
+  modelValue: boolean
+  recipeMetadata: Record<string, string | null>
+  actions: BookPromotionAction[]
+  actionData: Record<number, Record<string, unknown>>
+  defFlag: OfflinerDefinitionFlag
+  defSpec: OfflinerDefinitionSpec
+  recipeLink: string | null | undefined
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+}>()
+
+const authStore = useAuthStore()
+const notificationStore = useNotificationStore()
+const recipeStore = useZimfarmRecipeStore()
+
+const isOpen = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+})
+
+const canShow = ref(false)
+const checkingAuth = ref(false)
+const loading = ref(false)
+const loadingMessage = ref('')
+const error = ref<string | null>(null)
+const permissionDenied = ref(false)
+const needsAuth = ref(false)
+const showAuthConfirm = ref(false)
+const authLoading = ref(false)
+const username = ref('')
+const password = ref('')
+
+// Tracks which fields the user wants to update
+const fieldSelection = ref<Record<string, boolean>>({})
+
+const allDiffs = computed(() => {
+  if (Object.values(props.recipeMetadata).every((v) => v == null)) return []
+
+  const metaAction = props.actions.find((a) => a.kind === 'update_title_metadata')
+  if (!metaAction) return []
+
+  const index = props.actions.indexOf(metaAction)
+  const newData = props.actionData[index]
+  if (!newData) return []
+
+  const oldData: Record<string, unknown> = {}
+  const nextData: Record<string, unknown> = {}
+  const blobDataKeys = new Set<string>()
+
+  for (const zimMeta of props.defSpec.schema.zimMetadata) {
+    const cmsField = ZIM_METADATA_TO_CMS_FIELD[zimMeta.metadata]
+    if (!cmsField || newData[cmsField] === undefined) continue
+
+    const flag = props.defFlag.flags.find((f) => f.key === zimMeta.flag)
+    if (!flag) continue
+
+    oldData[flag.data_key] = props.recipeMetadata[cmsField] ?? null
+    nextData[flag.data_key] = newData[cmsField]
+
+    if (flag.type === 'blob') {
+      blobDataKeys.add(flag.data_key)
+    }
+  }
+
+  const differences = diff(oldData, nextData)
+  return (
+    ((differences || []) as EnhancedDiff[])
+      .filter((d) => d.kind !== undefined)
+      // When a recipe flag is not set (null), its value was auto-computed by the
+      // scraper. Don't treat that as a difference.
+      .filter((d) => !(d.kind === 'E' && d.lhs === null))
+      .map((d) => {
+        const enhanced: EnhancedDiff = { ...d }
+        if (d.path && d.path.length > 0 && blobDataKeys.has(String(d.path[0]))) {
+          enhanced.isBlob = true
+        }
+        return enhanced
+      })
+  )
+})
+
+const diffs = computed(() => {
+  return allDiffs.value.filter((d) => {
+    if (!d.path || d.path.length === 0) return true
+    return fieldSelection.value[String(d.path[0])] !== false
+  })
+})
+
+const zimfarmUser = ref<User | null>(null)
+
+const hasSelectedFields = computed(() => {
+  return Object.values(fieldSelection.value).some((v) => v)
+})
+
+const canUpdateRecipe = computed(() => {
+  return zimfarmUser.value?.scope?.recipes?.update === true && hasSelectedFields.value
+})
+
+watch(isOpen, async (open) => {
+  if (open) {
+    error.value = null
+    permissionDenied.value = false
+    needsAuth.value = false
+    username.value = ''
+    password.value = ''
+
+    const selection: Record<string, boolean> = {}
+    for (const d of diffs.value) {
+      if (d.path && d.path.length > 0) {
+        selection[String(d.path[0])] = true
+      }
+    }
+    fieldSelection.value = selection
+
+    canShow.value = false
+    zimfarmUser.value = null
+    showAuthConfirm.value = false
+    await checkAuthAndPermissions()
+  } else {
+    canShow.value = false
+  }
+})
+
+async function checkAuthAndPermissions(showPermissionWarning = false) {
+  checkingAuth.value = true
+  loadingMessage.value = 'Checking authentication...'
+  error.value = null
+  permissionDenied.value = false
+
+  try {
+    const isLocal = authStore.tokenType == 'local'
+
+    if (isLocal && !authStore.zimfarmProvider?.user) {
+      if (allDiffs.value.length > 0) {
+        showAuthConfirm.value = true
+      } else {
+        needsAuth.value = true
+        canShow.value = true
+      }
+      return
+    }
+
+    loadingMessage.value = 'Checking permissions...'
+    const service = await authStore.getZimfarmApiService('auth')
+    const zimfarmUserResult = (await service.get('/me')) as User | null
+    zimfarmUser.value = zimfarmUserResult
+    if (!zimfarmUserResult?.scope?.recipes?.update) {
+      if (showPermissionWarning) {
+        permissionDenied.value = true
+        canShow.value = true
+      } else {
+        isOpen.value = false
+      }
+      return
+    }
+
+    canShow.value = true
+  } catch (err) {
+    console.error('Failed to check recipe update auth', err)
+    error.value = 'Failed to verify zimfarm permissions'
+    canShow.value = true
+  } finally {
+    checkingAuth.value = false
+  }
+}
+
+async function onConfirm() {
+  error.value = null
+  await updateRecipe()
+}
+
+async function authenticate() {
+  if (!username.value || !password.value) return
+
+  authLoading.value = true
+  error.value = null
+
+  try {
+    await authStore.authenticateZimfarm(username.value, password.value)
+    if (authStore.zimfarmProvider?.user) {
+      needsAuth.value = false
+      await checkAuthAndPermissions(true)
+    } else {
+      error.value = 'Authentication succeeded but user data was not loaded'
+    }
+  } catch (err) {
+    console.error('Zimfarm authentication failed', err)
+    error.value = 'Failed to authenticate with Zimfarm'
+  } finally {
+    authLoading.value = false
+  }
+}
+
+function buildPayload(blobUrls: Record<string, string>): Record<string, unknown> | null {
+  if (Object.values(props.recipeMetadata).every((v) => v == null)) return null
+
+  const metaAction = props.actions.find((a) => a.kind === 'update_title_metadata')
+  if (!metaAction) return null
+
+  const index = props.actions.indexOf(metaAction)
+  const newData = props.actionData[index]
+  if (!newData) return null
+
+  const payload: Record<string, unknown> = {}
+
+  for (const zimMeta of props.defSpec.schema.zimMetadata) {
+    const cmsField = ZIM_METADATA_TO_CMS_FIELD[zimMeta.metadata]
+    if (!cmsField || newData[cmsField] === undefined) continue
+
+    const flag = props.defFlag.flags.find((f) => f.key === zimMeta.flag)
+    if (!flag) continue
+
+    if (!fieldSelection.value[flag.data_key]) continue
+
+    const newValue = newData[cmsField]
+    const oldValue = props.recipeMetadata[cmsField]
+    if (newValue === oldValue) continue
+
+    // For blob fields, use the uploaded URL instead of the raw base64 value
+    payload[flag.data_key] = blobUrls[flag.data_key] ?? newValue
+  }
+
+  if (Object.keys(payload).length === 0) return null
+
+  return { flags: { offliner: payload }, comment: 'Update recipe metadata flags from CMS' }
+}
+
+async function updateRecipe() {
+  const recipe = recipeStore.recipe
+  if (!recipe) {
+    error.value = 'Recipe data not available'
+    return
+  }
+
+  loading.value = true
+  error.value = null
+
+  try {
+    const metaAction = props.actions.find((a) => a.kind === 'update_title_metadata')
+    if (!metaAction) {
+      error.value = 'No title metadata action found'
+      return
+    }
+    const index = props.actions.indexOf(metaAction)
+    const newData = props.actionData[index]
+    if (!newData) {
+      error.value = 'No action data available'
+      return
+    }
+
+    // Upload blobs base64 data to zimfarm, and collect the returned URLs.
+    const blobUrls: Record<string, string> = {}
+
+    for (const zimMeta of props.defSpec.schema.zimMetadata) {
+      const cmsField = ZIM_METADATA_TO_CMS_FIELD[zimMeta.metadata]
+      if (!cmsField || newData[cmsField] === undefined) continue
+
+      const flag = props.defFlag.flags.find((f) => f.key === zimMeta.flag)
+      if (!flag || flag.type !== 'blob' || !flag.kind) continue
+
+      if (!fieldSelection.value[flag.data_key]) continue
+
+      const newValue = newData[cmsField]
+      const oldValue = props.recipeMetadata[cmsField]
+      if (newValue === oldValue) continue
+
+      if (typeof newValue !== 'string' || newValue.length === 0) continue
+
+      loadingMessage.value = `Uploading ${flag.data_key}...`
+
+      const blob = await recipeStore.createBlob(recipe.id, {
+        flag_name: flag.key,
+        kind: flag.kind,
+        data: newValue,
+        comments: `Update for field ${cmsField}`,
+      })
+
+      if (!blob) {
+        error.value = recipeStore.errors.join(', ') || `Failed to upload blob for ${flag.data_key}`
+        return
+      }
+
+      blobUrls[flag.data_key] = blob.url
+    }
+
+    loadingMessage.value = 'Building update payload...'
+    const payload = buildPayload(blobUrls)
+    if (!payload) {
+      error.value = 'Failed to build recipe update payload'
+      return
+    }
+
+    loadingMessage.value = 'Updating recipe...'
+    const result = await recipeStore.updateRecipe(recipe.id, payload)
+    if (!result) {
+      error.value = recipeStore.errors.join(', ') || 'Failed to update recipe'
+      return
+    }
+
+    notificationStore.showSuccess('Recipe updated successfully')
+    isOpen.value = false
+  } catch (err) {
+    console.error('Failed to update recipe', err)
+    error.value = 'An unexpected error occurred while updating recipe'
+  } finally {
+    loading.value = false
+  }
+}
+
+function close() {
+  isOpen.value = false
+}
+
+function onAuthConfirm() {
+  showAuthConfirm.value = false
+  needsAuth.value = true
+  canShow.value = true
+}
+
+function onAuthCancel() {
+  isOpen.value = false
+}
+
+function clearError() {
+  error.value = null
+}
+</script>

--- a/frontend/src/services/auth/LocalAuthProvider.ts
+++ b/frontend/src/services/auth/LocalAuthProvider.ts
@@ -8,11 +8,13 @@ import httpRequest from '@/utils/httpRequest'
  * Uses the CMS  API's /auth endpoints
  */
 export class LocalAuthProvider extends AuthProvider {
-  private cmsApiBaseUrl: string
+  private apiBaseUurl: string
+  private storageKey: string
 
-  constructor(cmsApiBaseUrl: string) {
-    super()
-    this.cmsApiBaseUrl = cmsApiBaseUrl
+  constructor(apiBaseUurl: string, storageKey?: string) {
+    super(apiBaseUurl)
+    this.apiBaseUurl = apiBaseUurl
+    this.storageKey = storageKey ?? constants.TOKEN_STORAGE_KEY
   }
 
   /**
@@ -21,7 +23,7 @@ export class LocalAuthProvider extends AuthProvider {
    */
   async initiateLogin(username?: string, password?: string): Promise<void> {
     const service = httpRequest({
-      baseURL: `${this.cmsApiBaseUrl}/auth`,
+      baseURL: `${this.apiBaseUurl}/auth`,
     })
     const response = await service.post<
       { username: string; password: string },
@@ -41,16 +43,16 @@ export class LocalAuthProvider extends AuthProvider {
   }
 
   saveToken(token: StoredToken): null {
-    localStorage.setItem(constants.TOKEN_STORAGE_KEY, JSON.stringify(token))
+    localStorage.setItem(this.storageKey, JSON.stringify(token))
     return null
   }
 
   removeToken(): void {
-    localStorage.removeItem(constants.TOKEN_STORAGE_KEY)
+    localStorage.removeItem(this.storageKey)
   }
 
   async loadToken(): Promise<StoredToken | null> {
-    const storedValue = localStorage.getItem(constants.TOKEN_STORAGE_KEY)
+    const storedValue = localStorage.getItem(this.storageKey)
     if (!storedValue) return null
     let storedToken: StoredToken
     try {
@@ -82,7 +84,7 @@ export class LocalAuthProvider extends AuthProvider {
    */
   async refreshAuth(refreshToken: string): Promise<StoredToken> {
     const service = httpRequest({
-      baseURL: `${this.cmsApiBaseUrl}/auth`,
+      baseURL: `${this.apiBaseUurl}/auth`,
     })
     const response = await service.post<
       { refresh_token: string },

--- a/frontend/src/services/auth/OAuthSessionProvider.ts
+++ b/frontend/src/services/auth/OAuthSessionProvider.ts
@@ -27,8 +27,8 @@ export class OAuthSessionProvider extends AuthProvider {
   #token: StoredToken | null = null // in memory reference to token
   #shouldLoadToken: boolean = true // if token should be loaded again
 
-  constructor(config: OAuthConfig) {
-    super()
+  constructor(config: OAuthConfig, cmsApiBaseUrl: string) {
+    super(cmsApiBaseUrl)
     this.config = config
   }
   /**
@@ -67,16 +67,20 @@ export class OAuthSessionProvider extends AuthProvider {
    * Session-based auth typically handles logout via server-side session destruction
    */
   async logout(): Promise<void> {
-    this.#token = null
-    this.#shouldLoadToken = false
+    if (this.#token) {
+      this.#token = null
+      this.#shouldLoadToken = false
 
-    const service = httpRequest({
-      baseURL: `${this.config.basePath}`,
-    })
-    const response = await service.get<null, LogoutSessionResponse>('/self-service/logout/browser')
-    await service.get<null, null>('/self-service/logout', {
-      params: { token: response.logout_token },
-    })
+      const service = httpRequest({
+        baseURL: `${this.config.basePath}`,
+      })
+      const response = await service.get<null, LogoutSessionResponse>(
+        '/self-service/logout/browser',
+      )
+      await service.get<null, null>('/self-service/logout', {
+        params: { token: response.logout_token },
+      })
+    }
   }
 
   /**

--- a/frontend/src/services/auth/base.ts
+++ b/frontend/src/services/auth/base.ts
@@ -1,14 +1,15 @@
 import type { Config } from '@/config'
 import type { StoredToken } from '@/types/auth'
+import type { User } from '@/types/user'
+import httpRequest from '@/utils/httpRequest'
 
 export interface OAuthConfig {
   basePath: string
 }
 
 export function getOAuthConfig(config: Config): OAuthConfig {
-  const basePath = config.OAUTH_BASE_URL
   return {
-    basePath: basePath,
+    basePath: config.OAUTH_BASE_URL,
   }
 }
 
@@ -17,6 +18,40 @@ export function getOAuthConfig(config: Config): OAuthConfig {
  * Defines the common interface that all auth providers must implement
  */
 export abstract class AuthProvider {
+  protected readonly apiBaseUrl: string
+  protected _user: User | null = null
+
+  constructor(apiBaseUrl: string) {
+    this.apiBaseUrl = apiBaseUrl
+  }
+
+  /**
+   * Returns the currently authenticated user, if any
+   */
+  get user(): User | null {
+    return this._user
+  }
+
+  /**
+   * Clear the stored user
+   */
+  clearUser(): void {
+    this._user = null
+  }
+
+  /**
+   * Fetches user information from the provider's backend
+   */
+  async fetchUserInfo(accessToken: string): Promise<User> {
+    const service = httpRequest({
+      baseURL: `${this.apiBaseUrl}/auth`,
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+    const response = (await service.get('/me')) as User
+    this._user = response
+    return response
+  }
+
   /**
    * Initiates the login flow
    */

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -23,14 +23,19 @@ export const useAuthStore = defineStore('auth', () => {
     throw new Error('Config is not defined')
   }
 
+  // Zimfarm and CMS ouath needs only one class as we can auth with the same token across
+  // both APIs but we need two local auth providers as they have differen tokens
   let oauthProvider: OAuthSessionProvider | null = null
   let localauthProvider: LocalAuthProvider | null = null
+  let zimfarmLocalAuthProvider: LocalAuthProvider | null = null
 
-  if (config.LOGIN_MODES.includes('local'))
-    localauthProvider = new LocalAuthProvider(config.CMS_API)
+  if (config.LOGIN_MODES.includes('local')) {
+    localauthProvider = new LocalAuthProvider(config.CMS_API, constants.TOKEN_STORAGE_KEY)
+    zimfarmLocalAuthProvider = new LocalAuthProvider(config.ZIMFARM_API, 'zimfarm-auth')
+  }
 
   if (config.LOGIN_MODES.includes('oauth'))
-    oauthProvider = new OAuthSessionProvider(getOAuthConfig(config))
+    oauthProvider = new OAuthSessionProvider(getOAuthConfig(config), config.CMS_API)
 
   const getAuthProvider = (providerType: AuthProviderType): AuthProvider => {
     switch (providerType) {
@@ -49,10 +54,28 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+  const getZimfarmAuthProvider = (providerType: AuthProviderType): AuthProvider => {
+    switch (providerType) {
+      case 'oauth':
+        if (!oauthProvider) {
+          throw new Error('OAuth provider not configured')
+        }
+        return oauthProvider
+      case 'local':
+        if (!zimfarmLocalAuthProvider) {
+          throw new Error('Local auth provider not configured')
+        }
+        return zimfarmLocalAuthProvider
+      default:
+        throw new Error(`Unknown auth provider type: ${providerType}`)
+    }
+  }
+
   // Track refresh state to prevent duplicate requests
   const isRefreshFailed = ref(false)
   const refreshPromise = ref<Promise<StoredToken | null> | null>(null)
   const refreshGeneration = ref(0)
+  const zimfarmRefreshPromise = ref<Promise<StoredToken | null> | null>(null)
 
   // Computed properties
   const isLoggedIn = computed(() => {
@@ -135,7 +158,8 @@ export const useAuthStore = defineStore('auth', () => {
         throw new Error('Invalid authentication token')
       }
       token.value = newToken
-      await fetchUserInfo(newToken.access_token)
+      await provider.fetchUserInfo(newToken.access_token)
+      user.value = provider.user
 
       errors.value = []
       provider.saveToken(newToken)
@@ -166,16 +190,65 @@ export const useAuthStore = defineStore('auth', () => {
     })
   }
 
-  const fetchUserInfo = async (accessToken: string) => {
+  const loadZimfarmToken = async (): Promise<StoredToken | null> => {
+    if (!tokenType.value) return null
+
+    const provider = getZimfarmAuthProvider(tokenType.value)
+
+    const storedToken = await provider.loadToken()
+    if (!storedToken) return null
+
+    const expiry = new Date(storedToken.expires_time)
+    if (new Date() < expiry) return storedToken
+
+    if (zimfarmRefreshPromise.value) {
+      return await zimfarmRefreshPromise.value
+    }
+
+    if (!storedToken.refresh_token) {
+      console.error('No zimfarm refresh token available')
+      provider.removeToken()
+      return null
+    }
+
+    zimfarmRefreshPromise.value = provider.refreshAuth(storedToken.refresh_token)
+
     try {
-      const apiService = httpRequest({
-        baseURL: `${config.CMS_API}/auth`,
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
+      const newToken = await zimfarmRefreshPromise.value
+      if (!newToken) {
+        throw new Error('Unable to refresh zimfarm token')
+      }
+      return newToken
+    } catch (error) {
+      console.error('Zimfarm token refresh failed:', error)
+      provider.removeToken()
+      return null
+    } finally {
+      zimfarmRefreshPromise.value = null
+    }
+  }
+
+  const getZimfarmApiService = async (baseURL: string) => {
+    const zimfarmToken = await loadZimfarmToken()
+    if (!zimfarmToken)
+      return httpRequest({
+        baseURL: `${config.ZIMFARM_API}/${baseURL}`,
       })
-      const response = (await apiService.get('/me')) as User
-      user.value = response
+
+    return httpRequest({
+      baseURL: `${config.ZIMFARM_API}/${baseURL}`,
+      headers: {
+        Authorization: `Bearer ${zimfarmToken.access_token}`,
+      },
+    })
+  }
+
+  const fetchUserInfo = async (accessToken: string) => {
+    if (!token.value?.token_type) return
+    const provider = getAuthProvider(token.value.token_type)
+    try {
+      await provider.fetchUserInfo(accessToken)
+      user.value = provider.user
       errors.value = []
     } catch (error) {
       console.error('Failed to fetch user info:', error)
@@ -231,7 +304,9 @@ export const useAuthStore = defineStore('auth', () => {
     }
 
     if (!user.value) {
-      await fetchUserInfo(storedToken.access_token)
+      const provider = getAuthProvider(storedToken.token_type)
+      await provider.fetchUserInfo(storedToken.access_token)
+      user.value = provider.user
     }
     token.value = storedToken
     return storedToken
@@ -274,7 +349,8 @@ export const useAuthStore = defineStore('auth', () => {
         return null
       }
 
-      await fetchUserInfo(newToken.access_token)
+      await provider.fetchUserInfo(newToken.access_token)
+      user.value = provider.user
       isRefreshFailed.value = false
       return newToken
     } catch (error) {
@@ -301,6 +377,10 @@ export const useAuthStore = defineStore('auth', () => {
       try {
         const provider = getAuthProvider(token.value?.token_type)
         await provider.logout()
+        const zimfarmProvider = getZimfarmAuthProvider(token.value?.token_type)
+        await zimfarmProvider.logout()
+        provider.clearUser()
+        zimfarmProvider.clearUser()
       } catch (error) {
         console.error('Error revoking token:', error)
       }
@@ -317,14 +397,34 @@ export const useAuthStore = defineStore('auth', () => {
     refreshPromise.value = null
   }
 
+  /**
+   * Authenticate with the zimfarm local auth provider.
+   * Runs the full auth flow on the provider without syncing to the
+   * store's user/token — consumers read zimfarmProvider.user directly.
+   */
+  const authenticateZimfarm = async (username: string, password: string) => {
+    if (!zimfarmLocalAuthProvider) {
+      throw new Error('Zimfarm auth provider not configured')
+    }
+    await zimfarmLocalAuthProvider.initiateLogin(username, password)
+    const newToken = await zimfarmLocalAuthProvider.loadToken()
+    if (!newToken) {
+      throw new Error('Invalid zimfarm authentication token')
+    }
+    await zimfarmLocalAuthProvider.fetchUserInfo(newToken.access_token)
+    zimfarmLocalAuthProvider.saveToken(newToken)
+    return zimfarmLocalAuthProvider
+  }
+
   const handleCallBack = async (providerType: AuthProviderType, callbackUrl: string) => {
     try {
       const provider = getAuthProvider(providerType)
       const newToken = await provider.onCallback(callbackUrl)
       token.value = newToken
 
-      // Fetch user info from backend using the Kiwix token
-      await fetchUserInfo(newToken.access_token)
+      // Fetch user info from backend using the provider
+      await provider.fetchUserInfo(newToken.access_token)
+      user.value = provider.user
       if (!user.value) return false
 
       errors.value = []
@@ -362,12 +462,17 @@ export const useAuthStore = defineStore('auth', () => {
 
     // Methods
     loadToken,
+    loadZimfarmToken,
     fetchUserInfo,
     renewToken,
     authenticate,
     logout,
     getApiService,
+    getZimfarmApiService,
+    getZimfarmAuthProvider,
     handleCallBack,
     hasPermission,
+    authenticateZimfarm,
+    zimfarmProvider: zimfarmLocalAuthProvider,
   }
 })

--- a/frontend/src/stores/zimfarm/offliner.ts
+++ b/frontend/src/stores/zimfarm/offliner.ts
@@ -1,29 +1,22 @@
 import type { ListResponse } from '@/types/base'
-import type { Config } from '@/config'
-import httpRequest from '@/utils/httpRequest'
 import type { ErrorResponse } from '@/types/errors'
-import constants from '@/constants'
+import type { OfflinerDefinitionFlag, OfflinerDefinitionSpec } from '@/types/zimfarm/offliner'
 import { translateErrors } from '@/utils/errors'
+import { useAuthStore } from '@/stores/auth'
 import { defineStore } from 'pinia'
-import { inject, ref } from 'vue'
+import { ref } from 'vue'
 
 export const useZimfarmOfflinerStore = defineStore('zimfarmOffliner', () => {
   const offliners = ref<string[]>([])
   const errors = ref<string[]>([])
 
-  const config = inject<Config>(constants.config)
-
-  if (!config) {
-    throw new Error('Config is not defined')
-  }
+  const authStore = useAuthStore()
 
   const fetchOffliners = async (limit: number = 100) => {
     if (offliners.value.length > 0) {
       return offliners.value
     }
-    const apiService = httpRequest({
-      baseURL: `${config.ZIMFARM_API}/offliners`,
-    })
+    const apiService = await authStore.getZimfarmApiService('offliners')
     try {
       const response = await apiService.get<null, ListResponse<string>>('', { params: { limit } })
       offliners.value = response.items
@@ -36,11 +29,43 @@ export const useZimfarmOfflinerStore = defineStore('zimfarmOffliner', () => {
     }
   }
 
+  const fetchOfflinerDefinitionFlag = async (offliner: string, version: string) => {
+    const apiService = await authStore.getZimfarmApiService('offliners')
+
+    try {
+      const response = await apiService.get<null, OfflinerDefinitionFlag>(`/${offliner}/${version}`)
+      errors.value = []
+      return response
+    } catch (_error) {
+      console.error('Failed to fetch offliner definition flags', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
+  const fetchOfflinerDefinitionSpec = async (offliner: string, version: string) => {
+    const apiService = await authStore.getZimfarmApiService('offliners')
+
+    try {
+      const response = await apiService.get<null, OfflinerDefinitionSpec>(
+        `/${offliner}/${version}/spec`,
+      )
+      errors.value = []
+      return response
+    } catch (_error) {
+      console.error('Failed to fetch offliner definition spec', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
   return {
     // state
     offliners,
     errors,
     // actions
     fetchOffliners,
+    fetchOfflinerDefinitionFlag,
+    fetchOfflinerDefinitionSpec,
   }
 })

--- a/frontend/src/stores/zimfarm/recipe.ts
+++ b/frontend/src/stores/zimfarm/recipe.ts
@@ -1,0 +1,68 @@
+import type { ErrorResponse } from '@/types/errors'
+import type { Recipe, Blob, CreateBlob } from '@/types/zimfarm/recipe'
+import { translateErrors } from '@/utils/errors'
+import { useAuthStore } from '@/stores/auth'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useZimfarmRecipeStore = defineStore('zimfarmRecipe', () => {
+  const errors = ref<string[]>([])
+  const recipe = ref<Recipe | null>(null)
+
+  const authStore = useAuthStore()
+
+  const fetchRecipe = async (recipeId: string, forceReload: boolean = false) => {
+    const service = await authStore.getZimfarmApiService('recipes')
+    // Check if we already have the recipe and don't need to force reload
+    if (!forceReload && recipe.value && recipe.value.id === recipeId) {
+      return recipe.value
+    }
+    try {
+      errors.value = []
+      recipe.value = null
+      const response = await service.get<null, Recipe>(`/${recipeId}`)
+      recipe.value = response
+      // generate artifacts_globs_str
+      recipe.value.config.artifacts_globs_str = recipe.value.config.artifacts_globs?.join('\n')
+    } catch (_error) {
+      console.error('Failed to load recipe', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+    }
+    return recipe.value
+  }
+
+  const createBlob = async (recipeId: string, request: CreateBlob) => {
+    try {
+      const service = await authStore.getZimfarmApiService('blobs')
+      const response = await service.post<CreateBlob, Blob>(`/${recipeId}`, request)
+      return response
+    } catch (_error) {
+      console.error('Failed to create blob', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
+  const updateRecipe = async (recipeId: string, payload: Record<string, unknown>) => {
+    const service = await authStore.getZimfarmApiService('recipes')
+    try {
+      errors.value = []
+      const response = await service.patch<Record<string, unknown>, Recipe>(`/${recipeId}`, payload)
+      return response
+    } catch (_error) {
+      console.error('Failed to update recipe', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
+  return {
+    // state
+    recipe,
+    errors,
+    // actions
+    fetchRecipe,
+    updateRecipe,
+    createBlob,
+  }
+})

--- a/frontend/src/types/book.ts
+++ b/frontend/src/types/book.ts
@@ -72,7 +72,9 @@ export interface Book extends BookLight {
   zimcheck_result_url: string | null
   zimcheck_s3_deleted: boolean
   zimcheck_summary: ZimcheckSummary | null
+  recipe_id: string | null
   recipe_link: string | null
+  recipe_api_link?: string
 }
 
 export interface ZimUrl {

--- a/frontend/src/types/zimfarm/offliner.ts
+++ b/frontend/src/types/zimfarm/offliner.ts
@@ -1,0 +1,44 @@
+export interface OfflinerFlagSchema {
+  data_key: string
+  secret?: boolean
+  description: string | null
+  choices:
+    | {
+        title: string
+        value: string
+      }[]
+    | null
+  label: string
+  key: string
+  required: boolean
+  type: string
+  min: number | null
+  max: number | null
+  min_graphemes: number | null
+  max_graphemes: number | null
+  pattern: string | null
+  kind: 'image' | 'illustration' | 'css' | 'html' | 'txt' | null
+  allow_remote_url: boolean
+}
+
+export interface OfflinerDefinitionFlag {
+  flags: OfflinerFlagSchema[]
+  help: string
+}
+
+export interface ZimMetadata {
+  metadata: string
+  flag: string
+}
+
+export interface OfflinerDefinitionSchema {
+  // not all fields of an offliner definition are included
+  zimMetadata: ZimMetadata[]
+}
+
+export interface OfflinerDefinitionSpec {
+  offliner: string
+  version: string
+  created_at: string
+  schema: OfflinerDefinitionSchema
+}

--- a/frontend/src/types/zimfarm/recipe.ts
+++ b/frontend/src/types/zimfarm/recipe.ts
@@ -1,0 +1,45 @@
+export interface OfflinerFlags {
+  offliner_id: string
+  [key: string]: unknown
+}
+
+export interface RecipeConfig {
+  platform?: string
+  warehouse_path: string
+  artifacts_globs?: string[]
+  artifacts_globs_str?: string // generated field
+  monitor: boolean
+  offliner: OfflinerFlags
+}
+
+export interface ExpandedRecipeConfig extends RecipeConfig {
+  mount_point: string
+  command: string[]
+  str_command: string
+}
+
+export interface Recipe {
+  // not all fields of a recipe are included in this interface
+  id: string
+  name: string
+  config: ExpandedRecipeConfig
+  version: string
+  offliner: string
+}
+
+export interface Blob {
+  id: string
+  flag_name: string
+  kind: string
+  url: string
+  checksum: string
+  comments: string
+  created_at: string
+}
+
+export interface CreateBlob {
+  flag_name: string
+  kind: string
+  data: string
+  comments: string
+}

--- a/frontend/src/utils/recipe.ts
+++ b/frontend/src/utils/recipe.ts
@@ -1,0 +1,46 @@
+import type { OfflinerDefinitionFlag, OfflinerDefinitionSpec } from '@/types/zimfarm/offliner'
+
+/**
+ * Maps ZIM metadata names (as they appear in the offliner definition spec's
+ * `zimMetadata[].metadata` field) to CMS title field keys.
+ */
+export const ZIM_METADATA_TO_CMS_FIELD: Record<string, string> = {
+  Title: 'title',
+  Creator: 'creator',
+  Publisher: 'publisher',
+  License: 'license',
+  Language: 'language',
+  Illustration: 'illustration_48x48_at_1',
+  Description: 'description',
+  LongDescription: 'long_description',
+  Relation: 'relation',
+  Source: 'source',
+}
+
+/**
+ * Extract CMS title metadata values from the recipe's offliner config.
+ *
+ * Given the offliner's definition flag, definition spec, and the recipe's
+ * `config.offliner` flags object, resolves each ZIM metadata field to a CMS
+ * field key and extracts the corresponding value.
+ */
+export function extractRecipeMetadataValues(
+  defFlag: OfflinerDefinitionFlag,
+  defSpec: OfflinerDefinitionSpec,
+  offlinerConfig: Record<string, unknown>,
+): Record<string, string | null> {
+  const result: Record<string, string | null> = {}
+
+  for (const zimMeta of defSpec.schema.zimMetadata) {
+    const cmsField = ZIM_METADATA_TO_CMS_FIELD[zimMeta.metadata]
+    if (!cmsField) continue
+
+    const flag = defFlag.flags.find((f) => f.key === zimMeta.flag)
+    if (!flag) continue
+
+    const rawValue = offlinerConfig[flag.data_key]
+    result[cmsField] = rawValue !== undefined && rawValue !== null ? String(rawValue) : null
+  }
+
+  return result
+}


### PR DESCRIPTION
## Rationale
This PR adds functionality to the UI to update flags responsible for recipe metadata from the CMS. During book promotion actions, if there are actions to update title metadata, UI loads recipe details and informs user to make corresponding changes to the zimfarm recipe that created the book

## Changes
- prompt user to update appropriate flags that are responsible for the metadata on zimfarm
- add methods to authenticate with zimfarm in cms auth store
- upload base64 blobs that are responsible for `Illustration` metadata to zimfarm before applying the patch with the returned URL

<img width="1114" height="620" alt="Screenshot_20260728_031111" src="https://github.com/user-attachments/assets/c906591c-5900-4449-a5c5-2bbe6ab4bd85" />
<img width="1111" height="643" alt="Screenshot_20260728_031119" src="https://github.com/user-attachments/assets/2983a11e-dcaa-476a-8b3b-c19b20d068d4" />
<img width="947" height="704" alt="Screenshot_20260728_031138" src="https://github.com/user-attachments/assets/78831f4a-122d-4e55-8c72-33b74621e838" />
<img width="1073" height="735" alt="Screenshot_20260728_031148" src="https://github.com/user-attachments/assets/9ce588cb-78d5-4c3c-b0f3-5d36e4240bd4" />

This closes #333 