### PR TITLE
show all informational issues as actions

### DIFF
--- a/backend/src/cms_backend/db/book.py
+++ b/backend/src/cms_backend/db/book.py
@@ -797,6 +797,26 @@ def get_book_unsupported_languages(book: Book) -> list[str]:
     return unknown_languages
 
 
+def get_latest_prod_book(session: OrmSession, book: Book):
+    """Get the latest prod book that has the same title and flavour as book.
+
+    If none is found, the book is returned.
+    """
+    latest_book = session.scalars(
+        select(Book)
+        .where(
+            Book.location_kind == "prod",
+            Book.id != book.id,
+            Book.title_id == book.title_id,
+            Book.flavour == book.flavour,
+        )
+        .order_by(Book.created_at.desc())
+    ).first()
+    if latest_book is None:
+        latest_book = book
+    return latest_book
+
+
 def get_book_issues(
     session: OrmSession, book: Book, *, raise_exceptions: bool = False
 ) -> dict[str, list[str]]:
@@ -842,19 +862,7 @@ def get_book_issues(
     if metadata_issues:
         issues["bad metadata"] = metadata_issues
 
-    # Get the latest prod book that isn't the current book
-    latest_book = session.scalars(
-        select(Book)
-        .where(
-            Book.location_kind == "prod",
-            Book.id != book.id,
-            Book.title_id == book.title_id,
-            Book.flavour == book.flavour,
-        )
-        .order_by(Book.created_at.desc())
-    ).first()
-    if latest_book is None:
-        latest_book = book
+    latest_book = get_latest_prod_book(session, book)
 
     article_count_issues = get_book_article_count_issues(
         book=book, latest_book=latest_book

--- a/backend/src/cms_backend/db/book_actions.py
+++ b/backend/src/cms_backend/db/book_actions.py
@@ -10,9 +10,12 @@ from cms_backend.db.book import (
     book_has_flavour_mismatch,
     book_has_recipe_issue,
     get_book,
+    get_book_article_count_issues,
+    get_book_media_count_issues,
     get_book_or_none,
     get_book_unsupported_languages,
     get_differing_metadata_keys,
+    get_latest_prod_book,
     get_zimcheck_errors,
     move_book_to_destination,
 )
@@ -83,13 +86,46 @@ def _get_unknown_languages_action(book: Book) -> BookPromotionAction | None:
 
 def _get_zimcheck_issues_action(book: Book) -> BookPromotionAction | None:
     zimcheck_errors = get_zimcheck_errors(book, raise_exceptions=False)
-    if zimcheck_errors and book.zimcheck_summary:
-        zimcheck_summary = ZimcheckSummarySchema.model_validate(book.zimcheck_summary)
+    if zimcheck_errors:
+        if book.zimcheck_summary:
+            zimcheck_summary = ZimcheckSummarySchema.model_validate(
+                book.zimcheck_summary
+            )
+            return BookPromotionAction(
+                kind="zimcheck_issues",
+                requirement="information",
+                data={},
+                message=f"Book has {zimcheck_summary.error_count} zimcheck error(s). ",
+            )
         return BookPromotionAction(
             kind="zimcheck_issues",
             requirement="information",
             data={},
-            message=f"Book has {zimcheck_summary.error_count} zimcheck error(s). ",
+            message=";".join(zimcheck_errors),
+        )
+
+
+def _get_media_count_issues_action(book: Book, latest_book: Book):
+    media_count_issues = get_book_media_count_issues(book=book, latest_book=latest_book)
+    if media_count_issues:
+        return BookPromotionAction(
+            kind="media_count",
+            requirement="information",
+            data={},
+            message=";".join(media_count_issues),
+        )
+
+
+def _get_article_count_issues_action(book: Book, latest_book: Book):
+    article_count_issues = get_book_article_count_issues(
+        book=book, latest_book=latest_book
+    )
+    if article_count_issues:
+        return BookPromotionAction(
+            kind="article_count",
+            requirement="information",
+            data={},
+            message=";".join(article_count_issues),
         )
 
 
@@ -239,6 +275,13 @@ def get_book_promotion_actions(
         actions.append(action)
 
     if action := _get_zimcheck_issues_action(book):
+        actions.append(action)
+
+    latest_book = get_latest_prod_book(session, book)
+    if action := _get_media_count_issues_action(book, latest_book):
+        actions.append(action)
+
+    if action := _get_article_count_issues_action(book, latest_book):
         actions.append(action)
 
     if action := _get_create_title_action(book):
@@ -456,7 +499,12 @@ def apply_book_promotion_actions(
                 title_update_payload.update(**action.data)
             case "update_flavour_recipe":
                 _apply_update_flavour_recipe_action(session, action, book)
-            case "unknown_languages" | "zimcheck_issues":
+            case (
+                "unknown_languages"
+                | "zimcheck_issues"
+                | "media_count"
+                | "article_count"
+            ):
                 pass
 
     if book.title is None:

--- a/backend/src/cms_backend/schemas/models.py
+++ b/backend/src/cms_backend/schemas/models.py
@@ -185,6 +185,8 @@ type BookPromotionActionKind = Literal[
     "create_title_flavour",
     "set_title_collections",
     "update_flavour_recipe",
+    "article_count",
+    "media_count",
 ]
 
 type BookPromotionRequirement = Literal["mandatory", "optional", "information"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -413,12 +413,21 @@ def create_collection_title(
         title: Title | None = None,
         collection: Collection | None = None,
         path: str | Path = "/test/path",
+        media_count_increase_threshold: float | None = None,
+        article_count_increase_threshold: float | None = None,
+        media_count_decrease_threshold: float | None = None,
+        article_count_decrease_threshold: float | None = None,
     ) -> CollectionTitle:
         if title is None:
             title = create_title()
 
         if collection is None:
-            collection = create_collection()
+            collection = create_collection(
+                article_count_increase_threshold=article_count_increase_threshold,
+                article_count_decrease_threshold=article_count_decrease_threshold,
+                media_count_increase_threshold=media_count_increase_threshold,
+                media_count_decrease_threshold=media_count_decrease_threshold,
+            )
 
         collection_title = CollectionTitle(
             path=Path(path) if isinstance(path, str) else path

--- a/backend/tests/db/test_book_actions.py
+++ b/backend/tests/db/test_book_actions.py
@@ -664,7 +664,139 @@ def test_promotion_actions_multiple_actions(
     assert "create_title_flavour" in kinds
 
 
+@patch("cms_backend.db.book_actions.get_zimcheck_errors")
+def test_promotion_media_count_issue(
+    mock_get_zimcheck_errors: MagicMock,
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+    create_title: Callable[..., Title],
+    create_collection_title: Callable[..., CollectionTitle],
+    illustration_48x48_at_1: str,
+):
+    """A book with all media count issue returns media count action"""
+    mock_get_zimcheck_errors.return_value = []
+    book = create_book(
+        flavour="maxi",
+        zim_metadata={
+            "Name": "test_en_all",
+            "Title": "Test Article",
+            "Creator": "Test Creator",
+            "Publisher": "Test Publisher",
+            "Date": "2025-01-01",
+            "Description": "Test description",
+            "Language": "eng",
+            "Illustration_48x48@1": illustration_48x48_at_1,
+        },
+        location_kind="quarantine",
+        article_count=105,
+        media_count=115,
+    )
+    title = create_title(
+        name="test_en_all",
+        flavours=["maxi"],
+        title="Test Article",
+        creator="Test Creator",
+        publisher="Test Publisher",
+        description="Test description",
+        language="eng",
+        illustration_48x48_at_1=illustration_48x48_at_1,
+    )
+    title.maturity = "stable"  # override default "unstable"
+    book.title = title
+    dbsession.add(book)
+    dbsession.flush()
+
+    create_collection_title(
+        title=title,
+        media_count_increase_threshold=0.1,
+        article_count_increase_threshold=0.1,
+        media_count_decrease_threshold=0.1,
+        article_count_decrease_threshold=0.1,
+    )
+
+    # create the latest book with media_count of 100 and article count of 105
+    create_book(
+        article_count=105,
+        media_count=100,
+        flavour="maxi",
+        title_id=title.id,
+        location_kind="prod",
+    )
+
+    actions = get_book_promotion_actions(dbsession, book_id=book.id)
+    assert len(actions) == 1
+    assert actions[0].requirement == "information"
+    assert actions[0].kind == "media_count"
+
+
+@patch("cms_backend.db.book_actions.get_zimcheck_errors")
+def test_promotion_article_count_issue(
+    mock_get_zimcheck_errors: MagicMock,
+    dbsession: OrmSession,
+    create_book: Callable[..., Book],
+    create_title: Callable[..., Title],
+    create_collection_title: Callable[..., CollectionTitle],
+    illustration_48x48_at_1: str,
+):
+    """A book with article count issue returns article count action"""
+    mock_get_zimcheck_errors.return_value = []
+    book = create_book(
+        flavour="maxi",
+        zim_metadata={
+            "Name": "test_en_all",
+            "Title": "Test Article",
+            "Creator": "Test Creator",
+            "Publisher": "Test Publisher",
+            "Date": "2025-01-01",
+            "Description": "Test description",
+            "Language": "eng",
+            "Illustration_48x48@1": illustration_48x48_at_1,
+        },
+        location_kind="quarantine",
+        article_count=115,
+        media_count=100,
+    )
+    title = create_title(
+        name="test_en_all",
+        flavours=["maxi"],
+        title="Test Article",
+        creator="Test Creator",
+        publisher="Test Publisher",
+        description="Test description",
+        language="eng",
+        illustration_48x48_at_1=illustration_48x48_at_1,
+    )
+    title.maturity = "stable"  # override default "unstable"
+    book.title = title
+    dbsession.add(book)
+    dbsession.flush()
+
+    create_collection_title(
+        title=title,
+        media_count_increase_threshold=0.1,
+        article_count_increase_threshold=0.1,
+        media_count_decrease_threshold=0.1,
+        article_count_decrease_threshold=0.1,
+    )
+
+    # create the latest book with media_count of 100 and article count of 100
+    create_book(
+        article_count=100,
+        media_count=100,
+        flavour="maxi",
+        title_id=title.id,
+        location_kind="prod",
+    )
+
+    actions = get_book_promotion_actions(dbsession, book_id=book.id)
+    assert len(actions) == 1
+    assert actions[0].requirement == "information"
+    assert actions[0].kind == "article_count"
+
+
+@patch("cms_backend.db.book_actions.get_zimcheck_errors")
 def test_promotion_actions_ready_for_prod(
+    mock_get_zimcheck_errors: MagicMock,
     dbsession: OrmSession,
     create_book: Callable[..., Book],
     create_title: Callable[..., Title],
@@ -672,6 +804,7 @@ def test_promotion_actions_ready_for_prod(
     illustration_48x48_at_1: str,
 ):
     """A book with all prerequisites met returns no actions."""
+    mock_get_zimcheck_errors.return_value = []
     book = create_book(
         flavour="maxi",
         zim_metadata={
@@ -707,7 +840,9 @@ def test_promotion_actions_ready_for_prod(
     assert len(actions) == 0
 
 
+@patch("cms_backend.db.book_actions.get_zimcheck_errors")
 def test_promote_book_with_no_actions_move_directly_to_prod(
+    mock_get_zimcheck_errors: MagicMock,
     dbsession: OrmSession,
     create_book: Callable[..., Book],
     create_title: Callable[..., Title],
@@ -718,6 +853,7 @@ def test_promote_book_with_no_actions_move_directly_to_prod(
     account: Account,
 ):
     """Test applying empty actions on a book with no issues simply moves book to prod"""
+    mock_get_zimcheck_errors.return_value = []
     warehouse = create_warehouse()
 
     book = create_book(

--- a/frontend/src/components/PromoteBookDialog.vue
+++ b/frontend/src/components/PromoteBookDialog.vue
@@ -534,6 +534,9 @@ const submitError = ref<string | null>(null)
 const showConfirmDialog = ref(false)
 
 const hasAnyActionChecked = computed(() => {
+  // Allow promoting when all actions are purely informational
+  if (actions.value.length > 0 && actions.value.every((a) => a.requirement === 'information'))
+    return true
   return actions.value.some(
     (action, index) => action.requirement === 'mandatory' || actionChecked.value[index],
   )
@@ -541,7 +544,12 @@ const hasAnyActionChecked = computed(() => {
 
 const selectedActionsForConfirm = computed(() => {
   return actions.value
-    .filter((action, index) => action.requirement === 'mandatory' || actionChecked.value[index])
+    .filter(
+      (action, index) =>
+        action.requirement === 'mandatory' ||
+        action.requirement === 'information' ||
+        actionChecked.value[index],
+    )
     .map((action) => {
       const index = actions.value.indexOf(action)
       return {
@@ -769,7 +777,12 @@ async function executePromote() {
 
   try {
     const selectedActions = actions.value
-      .filter((action, index) => action.requirement === 'mandatory' || actionChecked.value[index])
+      .filter(
+        (action, index) =>
+          action.requirement === 'mandatory' ||
+          action.requirement === 'information' ||
+          actionChecked.value[index],
+      )
       .map((action) => {
         const originalIndex = actions.value.indexOf(action)
         let data = actionData.value[originalIndex] || action.data


### PR DESCRIPTION
## Changes
- display media/article count issues as informational actions
- extend zimcheck_issue action to return message when no zimcheck URL is found or failed to compute zimcheck summary
- allow user to promote book when there are only informational actions


<img width="1106" height="857" alt="Screenshot_20260730_114239" src="https://github.com/user-attachments/assets/d48767a5-4f92-4889-89b6-16a73c0e4207" />
<img width="886" height="569" alt="Screenshot_20260730_114309" src="https://github.com/user-attachments/assets/2f26ca1f-ce9e-451e-9959-f938a2e7e39a" />

This closes #451 
This fixes #450 
