### PR TITLE
consider book filename when detecting identical target

### DIFF
--- a/backend/src/cms_backend/db/rules.py
+++ b/backend/src/cms_backend/db/rules.py
@@ -20,11 +20,11 @@ def sort_books_by_filename_period(books: list[Book]) -> list[Book]:
     """Sort a list of books by period.
 
     Assumes:
-    - the book's location exists since it contains the filename of the book
+    - the book has a filename
     """
 
     def sort_fn(book: Book) -> tuple[str, int, str]:
-        period, suffix = get_period_and_suffix_from_filename(book.locations[0].filename)
+        period, suffix = get_period_and_suffix_from_filename(book.filename)  # pyright: ignore[reportArgumentType]
         return (period, len(suffix), suffix)
 
     return sorted(

--- a/backend/src/cms_backend/shuttle/move_files.py
+++ b/backend/src/cms_backend/shuttle/move_files.py
@@ -81,7 +81,7 @@ def move_book_files(session: OrmSession, book: Book):
     source_location = current_locations[0]
 
     current_locations_map = {
-        (loc.warehouse_id, loc.path): loc for loc in current_locations
+        (loc.warehouse_id, loc.path, loc.filename): loc for loc in current_locations
     }
 
     for target_location in target_locations:
@@ -89,7 +89,11 @@ def move_book_files(session: OrmSession, book: Book):
             ShuttleContext.local_warehouse_paths
         )
         matching_current = current_locations_map.get(
-            (target_location.warehouse_id, target_location.path)
+            (
+                target_location.warehouse_id,
+                target_location.path,
+                target_location.filename,
+            )
         )
         if matching_current:
             # This file is already here. Remove redundant target and remove the current
@@ -121,7 +125,9 @@ def move_book_files(session: OrmSession, book: Book):
             f"{getnow()}: copied book from {source_location.full_str} to "
             f"{target_location.full_str}"
         )
-        target_location.status = "current"
+        # Defer updating the book locations to "current" as this might have been
+        # a file rename operation and setting this location to "current" will cause
+        # a primary key violation error.
 
         # After making one copy, delete one of the current locations
         # that is not the original if this is not a backup operation.
@@ -150,6 +156,10 @@ def move_book_files(session: OrmSession, book: Book):
         book.events.append(f"{getnow()}: deleted book from {current_location.full_str}")
         book.locations.remove(current_location)
         session.delete(current_location)
+
+    session.flush()
+    for location in book.locations:
+        location.status = "current"
 
     book.needs_file_operation = False
     session.flush()


### PR DESCRIPTION
## Changes
- consider book filename when trying to detect if book current location and target location are identical. This allows a book to be renamed within the same path. As a consequence, defer updating the book status since "status" is part of the composite primary key. Only when we have copied all files (or deleted identical paths) do we set all the locations as current

This fixes #463 